### PR TITLE
[Chore] GitHub Actions 기반 CI/CD 파이프라인 구축 (#5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.gradle
+.idea
+.vscode
+build
+out
+*.iml
+*.log
+README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    # PR 소스 브랜치 범위
+    if: |
+      !github.event.pull_request.draft &&
+      (
+        startsWith(github.head_ref, 'feat/') ||
+        github.head_ref == 'develop' ||
+        github.head_ref == 'main'
+      )
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x ./gradlew
+
+      - name: Build and test with Gradle
+        run: ./gradlew clean build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
         id: image
         run: |
           IMAGE_REPOSITORY=$(echo "ghcr.io/${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          echo "main=${IMAGE_REPOSITORY}:main" >> "$GITHUB_OUTPUT"
           echo "latest=${IMAGE_REPOSITORY}:latest" >> "$GITHUB_OUTPUT"
           echo "sha=${IMAGE_REPOSITORY}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
 
@@ -47,6 +48,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
+            ${{ steps.image.outputs.main }}
             ${{ steps.image.outputs.latest }}
             ${{ steps.image.outputs.sha }}
           cache-from: type=gha

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,104 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: production-deploy
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.image.outputs.latest }}
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Define image tags
+        id: image
+        run: |
+          IMAGE_REPOSITORY=$(echo "ghcr.io/${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          echo "latest=${IMAGE_REPOSITORY}:latest" >> "$GITHUB_OUTPUT"
+          echo "sha=${IMAGE_REPOSITORY}:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ steps.image.outputs.latest }}
+            ${{ steps.image.outputs.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy-to-ec2:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Prepare deploy env
+        run: |
+          mkdir -p .deploy
+          cat <<EOF > .deploy/.env
+          ${{ secrets.PROD_ENV_FILE }}
+          GHCR_IMAGE=${{ needs.build-and-push.outputs.image }}
+          EOF
+
+      - name: Copy deploy files to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: ${{ secrets.EC2_PORT }}
+          source: "docker-compose-prod.yml,.deploy/.env"
+          target: ${{ secrets.EC2_DEPLOY_PATH }}
+
+      - name: Deploy on EC2
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          port: ${{ secrets.EC2_PORT }}
+          script: |
+            set -e
+            DEPLOY_PATH="${{ secrets.EC2_DEPLOY_PATH }}"
+
+            mkdir -p "${DEPLOY_PATH}"
+            cd "${DEPLOY_PATH}"
+
+            if [ -f .deploy/.env ]; then
+              mv .deploy/.env .env
+              rmdir .deploy || true
+            fi
+
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USERNAME }}" --password-stdin
+            docker compose -f docker-compose-prod.yml pull
+            docker compose -f docker-compose-prod.yml up -d
+            docker image prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ WORKDIR /app
 
 ENV TZ=Asia/Seoul
 
+LABEL org.opencontainers.image.source="https://github.com/DDD-Community/DDD-13-F1-BE"
+
 COPY --from=builder /app/build/libs/*.jar /app/app.jar
 
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM eclipse-temurin:17-jdk AS builder
+
+WORKDIR /app
+
+COPY gradlew build.gradle settings.gradle ./
+COPY gradle ./gradle
+COPY src ./src
+
+RUN chmod +x ./gradlew
+RUN ./gradlew clean bootJar --no-daemon
+
+FROM eclipse-temurin:17-jre
+
+WORKDIR /app
+
+ENV TZ=Asia/Seoul
+
+COPY --from=builder /app/build/libs/*.jar /app/app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -12,3 +12,23 @@
 - **Build Tool**: Gradle
 - **Infra**: AWS EC2
 - **CI/CD**: GitHub Actions
+
+## 🔄 CI/CD
+
+- `ci.yml`
+  - 대상: `develop`, `main` 대상 PR
+  - 역할: Gradle build, test
+- `deploy.yml`
+  - 대상: `main` push
+  - 역할: Docker build, GHCR push, EC2 배포
+
+## 🔐 GitHub Secrets
+
+- `PROD_ENV_FILE`: 운영 환경변수 `.env` 전체
+- `EC2_HOST`: 운영 EC2 호스트
+- `EC2_USER`: 운영 EC2 유저
+- `EC2_SSH_KEY`: 운영 EC2 SSH private key
+- `EC2_PORT`: 운영 EC2 SSH 포트
+- `EC2_DEPLOY_PATH`: 운영 배포 디렉터리 경로
+- `GHCR_USERNAME`: GHCR pull 계정명
+- `GHCR_TOKEN`: GHCR pull 토큰

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 
 	// Database
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	// CI 테스트 DB
+	testRuntimeOnly 'com.h2database:h2'
 
 	// Dev Tools
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,9 @@
+services:
+  quiket-server:
+    image: ${GHCR_IMAGE}
+    container_name: quiket-server
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env

--- a/src/main/java/com/f1/quiket/config/JpaConfig.java
+++ b/src/main/java/com/f1/quiket/config/JpaConfig.java
@@ -2,6 +2,7 @@ package com.f1.quiket.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.orm.jpa.JpaTransactionManager;
@@ -28,18 +29,22 @@ public class JpaConfig {
      * 엔티티 스캔, JPA 벤더 설정, Hibernate 속성들을 구성합니다.
      */
     @Bean
-    public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource, Environment environment) {
         LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
         em.setDataSource(dataSource);
         em.setPackagesToScan("com.f1.quiket.domain");  // 엔티티 클래스 스캔 패키지
         em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());  // Hibernate를 JPA 구현체로 사용
 
-        // Hibernate 속성 설정
+        // 프로파일별 YAML 값을 그대로 따라가게 해서 test/prod 설정을 분리합니다.
         Properties properties = new Properties();
-        properties.setProperty("hibernate.hbm2ddl.auto", "validate");  // 스키마 자동 생성/검증 모드
-        properties.setProperty("hibernate.show_sql", "false");  // SQL 쿼리 로깅 비활성화
-        properties.setProperty("hibernate.format_sql", "true");  // SQL 포맷팅 활성화
-        properties.setProperty("hibernate.use_sql_comments", "true");  // SQL 주석 추가
+        properties.setProperty("hibernate.hbm2ddl.auto",
+                environment.getProperty("spring.jpa.hibernate.ddl-auto", "none"));
+        properties.setProperty("hibernate.show_sql",
+                environment.getProperty("spring.jpa.show-sql", "false"));
+        properties.setProperty("hibernate.format_sql",
+                environment.getProperty("spring.jpa.properties.hibernate.format_sql", "false"));
+        properties.setProperty("hibernate.use_sql_comments",
+                environment.getProperty("spring.jpa.properties.hibernate.use_sql_comments", "false"));
 
         em.setJpaProperties(properties);
         return em;

--- a/src/test/java/com/f1/quiket/QuiketApplicationTests.java
+++ b/src/test/java/com/f1/quiket/QuiketApplicationTests.java
@@ -2,8 +2,10 @@ package com.f1.quiket;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test") // 테스트 프로파일
 class QuiketApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,23 @@
+spring:
+  datasource:
+    # MySQL 호환 모드
+    url: jdbc:h2:mem:quiket-test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  data:
+    redis:
+      # 컨텍스트 테스트용 Redis 비활성화
+      repositories:
+        enabled: false
+
+  jpa:
+    hibernate:
+      # 테스트용 스키마 자동 생성/정리
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+        use_sql_comments: false


### PR DESCRIPTION
## :jigsaw: Description
<!-- 어떤 작업을 했는지 요약 -->

- PR 기반 CI 워크플로우 추가
- Docker 빌드/운영 배포용 파일 추가
- `main` 배포용 GitHub Actions 워크플로우 추가
- GHCR 및 EC2 배포에 필요한 문서 정리

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `.github/workflows/ci.yml` 추가
  - `develop`, `main` 대상 PR에서 Gradle build/test 실행
  - `feat/*`, `develop`, `main` 브랜치에서 올라온 PR만 실행
- `.github/workflows/deploy.yml` 추가
  - `main` push 시 Docker 이미지 빌드
  - GHCR push
  - EC2 원격 배포 수행
- `Dockerfile`, `.dockerignore` 추가
  - Spring Boot 애플리케이션 Docker 이미지 빌드 환경 구성
- `docker-compose-prod.yml` 추가
  - 운영 서버 배포용 compose 파일 구성
- 테스트 환경 보완
  - `application-test.yaml` 추가
  - H2 기반 테스트 프로파일 분리
  - 외부 DB 없이 CI 테스트 가능하도록 JPA 설정 보완
- `README.md` 문서화
  - CI/CD 흐름 정리
  - GitHub Secrets 목록 정리
- GHCR 메타데이터 보완
  - 이미지 source label 추가
  - `main`, `latest`, `sha` 태그 push 구성

---

## :test_tube: How to Test
<!-- 테스트 방법 -->

1. `./gradlew test` 실행
2. 테스트 프로파일 기반으로 테스트 통과 확인
3. PR 생성 후 `ci.yml` 실행 여부 확인
4. `main` 브랜치 push 후 `deploy.yml` 실행 여부 확인
5. EC2에서 `docker compose -f docker-compose-prod.yml ps`로 컨테이너 기동 확인

---

## :link: Related Issue
<!-- 연결된 이슈 번호 (자동 close 가능) -->

Closes #5  
Related to #5

---

## :warning: Notes
<!-- 리뷰어가 알아야 할 내용 -->

- 현재 배포에 필요한 Secrets 값들은 모두 등록 완료
  - `PROD_ENV_FILE`
  - `EC2_HOST`
  - `EC2_USER`
  - `EC2_SSH_KEY`
  - `EC2_PORT`
  - `EC2_DEPLOY_PATH`
  - `GHCR_USERNAME`
  - `GHCR_TOKEN`
- GHCR 패키지 첫 배포 후 repository 권한 상속 여부 확인 필요
- EC2 서버에 `docker`, `docker compose` 설치 및 권한 설정 필요

---

## :technologist: Assignee

- @imclaremont
