### PR TITLE
[Feat] Amazon SES 기반 메일 발송 기능 구현 및 초기 설정 (#11)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	// Swagger (SpringDoc OpenAPI)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 
+	// AWS SES
+	implementation 'software.amazon.awssdk:sesv2:2.32.19'
+
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
@@ -52,4 +55,7 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	testLogging {
+		events 'started', 'passed', 'skipped', 'failed', 'standard_out', 'standard_error'
+	}
 }

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     // 5xx Server Errors
     INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다."),
     SERVICE_UNAVAILABLE(503, "C009", "일시적으로 서비스를 이용할 수 없습니다."),
+    MAIL_SEND_FAILED(503, "C010", "메일 전송에 실패했습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/f1/quiket/infra/mail/config/AwsSesConfig.java
+++ b/src/main/java/com/f1/quiket/infra/mail/config/AwsSesConfig.java
@@ -1,0 +1,41 @@
+package com.f1.quiket.infra.mail.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+
+/**
+ * SES 클라이언트 설정
+ */
+@Configuration
+@EnableConfigurationProperties(AwsSesProperties.class)
+public class AwsSesConfig {
+
+    private static final String AWS_AUTH_SCHEME_PREFERENCE = "aws.authSchemePreference";
+    private static final String AWS_AUTH_SCHEME_PREFERENCE_ENV = "AWS_AUTH_SCHEME_PREFERENCE";
+    private static final String DEFAULT_AUTH_SCHEME = "sigv4";
+
+    @Bean
+    public SesV2Client sesV2Client(AwsSesProperties awsSesProperties) {
+        // 자격증명 로딩 경로
+        // AWS SDK 기본 Credentials Provider Chain
+        // 리전 설정값 소스: aws.ses.region
+        applyDefaultAuthSchemePreference();
+
+        return SesV2Client.builder()
+                .region(Region.of(awsSesProperties.getRegion()))
+                .build();
+    }
+
+    private void applyDefaultAuthSchemePreference() {
+        // 인증 스킴 기본값
+        // 프로필 파싱 오류 회피
+        boolean hasSystemValue = System.getProperty(AWS_AUTH_SCHEME_PREFERENCE) != null;
+        boolean hasEnvValue = System.getenv(AWS_AUTH_SCHEME_PREFERENCE_ENV) != null;
+        if (!hasSystemValue && !hasEnvValue) {
+            System.setProperty(AWS_AUTH_SCHEME_PREFERENCE, DEFAULT_AUTH_SCHEME);
+        }
+    }
+}

--- a/src/main/java/com/f1/quiket/infra/mail/config/AwsSesProperties.java
+++ b/src/main/java/com/f1/quiket/infra/mail/config/AwsSesProperties.java
@@ -1,0 +1,28 @@
+package com.f1.quiket.infra.mail.config;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * SES 설정값 바인딩
+ */
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "aws.ses")
+public class AwsSesProperties {
+
+    /**
+     * SES 리전
+     */
+    private String region = "ap-northeast-2";
+
+    /**
+     * 기본 발신자 이메일
+     */
+    @NotBlank(message = "aws.ses.from-email 값 필수")
+    private String fromEmail;
+}

--- a/src/main/java/com/f1/quiket/infra/mail/dto/MailContentType.java
+++ b/src/main/java/com/f1/quiket/infra/mail/dto/MailContentType.java
@@ -1,0 +1,6 @@
+package com.f1.quiket.infra.mail.dto;
+
+public enum MailContentType {
+    TEXT,
+    HTML
+}

--- a/src/main/java/com/f1/quiket/infra/mail/dto/MailSendRequest.java
+++ b/src/main/java/com/f1/quiket/infra/mail/dto/MailSendRequest.java
@@ -1,0 +1,38 @@
+package com.f1.quiket.infra.mail.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+
+/**
+ * 메일 발송 요청
+ */
+@Getter
+@Builder
+public class MailSendRequest {
+
+    @Singular("toEmail")
+    private List<String> toEmails;
+    private String subject;
+    private String body;
+    private MailContentType contentType;
+
+    public static MailSendRequest text(String toEmail, String subject, String body) {
+        return MailSendRequest.builder()
+                .toEmail(toEmail)
+                .subject(subject)
+                .body(body)
+                .contentType(MailContentType.TEXT)
+                .build();
+    }
+
+    public static MailSendRequest html(String toEmail, String subject, String body) {
+        return MailSendRequest.builder()
+                .toEmail(toEmail)
+                .subject(subject)
+                .body(body)
+                .contentType(MailContentType.HTML)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/infra/mail/service/SesMailSender.java
+++ b/src/main/java/com/f1/quiket/infra/mail/service/SesMailSender.java
@@ -1,0 +1,134 @@
+package com.f1.quiket.infra.mail.service;
+
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.infra.mail.config.AwsSesProperties;
+import com.f1.quiket.infra.mail.dto.MailContentType;
+import com.f1.quiket.infra.mail.dto.MailSendRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.Body;
+import software.amazon.awssdk.services.sesv2.model.Content;
+import software.amazon.awssdk.services.sesv2.model.Destination;
+import software.amazon.awssdk.services.sesv2.model.EmailContent;
+import software.amazon.awssdk.services.sesv2.model.Message;
+import software.amazon.awssdk.services.sesv2.model.SendEmailRequest;
+import software.amazon.awssdk.services.sesv2.model.SendEmailResponse;
+import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
+
+/**
+ * SES 메일 발송기
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SesMailSender {
+
+    private static final String UTF_8 = "UTF-8";
+
+    private final SesV2Client sesV2Client;
+    private final AwsSesProperties awsSesProperties;
+
+    public String sendTextMail(String toEmail, String subject, String body) {
+        return sendMail(MailSendRequest.text(toEmail, subject, body));
+    }
+
+    public String sendHtmlMail(String toEmail, String subject, String body) {
+        return sendMail(MailSendRequest.html(toEmail, subject, body));
+    }
+
+    public String sendMail(MailSendRequest request) {
+        validateRequest(request);
+
+        SendEmailRequest sendEmailRequest = createSendEmailRequest(request);
+        log.info(
+                "Sending SES mail. region={}, fromEmail={}, toEmails={}, subject={}, contentType={}",
+                awsSesProperties.getRegion(),
+                awsSesProperties.getFromEmail(),
+                request.getToEmails(),
+                request.getSubject(),
+                request.getContentType()
+        );
+
+        try {
+            SendEmailResponse response = sesV2Client.sendEmail(sendEmailRequest);
+            log.info("SES mail sent successfully. messageId={}", response.messageId());
+            return response.messageId();
+        } catch (SesV2Exception e) {
+            String errorCode = e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : "unknown";
+            String errorMessage = e.awsErrorDetails() != null ? e.awsErrorDetails().errorMessage() : e.getMessage();
+            log.error(
+                    "Failed to send SES mail by service exception. region={}, fromEmail={}, toEmails={}, subject={}, statusCode={}, requestId={}, errorCode={}, errorMessage={}",
+                    awsSesProperties.getRegion(),
+                    awsSesProperties.getFromEmail(),
+                    request.getToEmails(),
+                    request.getSubject(),
+                    e.statusCode(),
+                    e.requestId(),
+                    errorCode,
+                    errorMessage,
+                    e
+            );
+            throw new CustomException(ErrorCode.MAIL_SEND_FAILED, e);
+        } catch (SdkClientException e) {
+            log.error(
+                    "Failed to send SES mail by client exception. region={}, fromEmail={}, toEmails={}, subject={}, message={}",
+                    awsSesProperties.getRegion(),
+                    awsSesProperties.getFromEmail(),
+                    request.getToEmails(),
+                    request.getSubject(),
+                    e.getMessage(),
+                    e
+            );
+            throw new CustomException(ErrorCode.MAIL_SEND_FAILED, e);
+        }
+    }
+
+    private SendEmailRequest createSendEmailRequest(MailSendRequest request) {
+        Content subject = Content.builder()
+                .data(request.getSubject())
+                .charset(UTF_8)
+                .build();
+
+        Content bodyContent = Content.builder()
+                .data(request.getBody())
+                .charset(UTF_8)
+                .build();
+
+        Body body = request.getContentType() == MailContentType.HTML
+                ? Body.builder().html(bodyContent).build()
+                : Body.builder().text(bodyContent).build();
+
+        Message message = Message.builder()
+                .subject(subject)
+                .body(body)
+                .build();
+
+        return SendEmailRequest.builder()
+                .fromEmailAddress(awsSesProperties.getFromEmail())
+                .destination(Destination.builder().toAddresses(request.getToEmails()).build())
+                .content(EmailContent.builder().simple(message).build())
+                .build();
+    }
+
+    private void validateRequest(MailSendRequest request) {
+        if (request == null || CollectionUtils.isEmpty(request.getToEmails())
+                || !StringUtils.hasText(request.getSubject())
+                || !StringUtils.hasText(request.getBody())
+                || request.getContentType() == null) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "Invalid mail request.");
+        }
+
+        List<String> toEmails = request.getToEmails();
+        boolean hasInvalidEmail = toEmails.stream().anyMatch(email -> !StringUtils.hasText(email));
+        if (hasInvalidEmail) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "Invalid recipient email.");
+        }
+    }
+}

--- a/src/main/java/com/f1/quiket/infra/mail/template/MailTemplateFactory.java
+++ b/src/main/java/com/f1/quiket/infra/mail/template/MailTemplateFactory.java
@@ -1,0 +1,49 @@
+package com.f1.quiket.infra.mail.template;
+
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.infra.mail.dto.MailSendRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+
+@Component
+@RequiredArgsConstructor
+public class MailTemplateFactory {
+
+    private static final String VERIFICATION_TEMPLATE_PATH = "classpath:mail-template/verification-code.html";
+    private static final String VERIFICATION_CODE_PLACEHOLDER = "{{verificationCode}}";
+
+    private final ResourceLoader resourceLoader;
+
+    public MailSendRequest createSignUpVerificationMail(String toEmail, String verificationCode) {
+        String subject = "[Quiket] 회원가입 이메일 인증";
+        String body = createVerificationCodeBody(verificationCode);
+        return MailSendRequest.html(toEmail, subject, body);
+    }
+
+    public MailSendRequest createPasswordResetMail(String toEmail, String verificationCode) {
+        String subject = "[Quiket] 비밀번호 재설정 이메일 인증";
+        String body = createVerificationCodeBody(verificationCode);
+        return MailSendRequest.html(toEmail, subject, body);
+    }
+
+    private String createVerificationCodeBody(String verificationCode) {
+        return loadTemplate(VERIFICATION_TEMPLATE_PATH)
+                .replace(VERIFICATION_CODE_PLACEHOLDER, verificationCode);
+    }
+
+    private String loadTemplate(String templatePath) {
+        Resource resource = resourceLoader.getResource(templatePath);
+        try (InputStream inputStream = resource.getInputStream()) {
+            return StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "메일 템플릿 로딩 실패", e);
+        }
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -46,3 +46,10 @@ springdoc:
     enabled: true   # Swagger JSON 엔드포인트 활성화
   swagger-ui:
     enabled: true   # Swagger UI 활성화
+aws:
+  ses:
+    # SES 리전 설정값
+    # 기본값 사용, 필요 시 환경변수 override
+    region: ${AWS_REGION:ap-northeast-2}
+    # SES 발신자 이메일 설정값
+    from-email: ${AWS_SES_FROM_EMAIL:ja2hoon97@gmail.com}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -37,8 +37,8 @@ file:
 # 로깅
 logging:
   level:
-    root: WARN
-    com.f1.quiket: INFO
+    root: DEBUG
+    com.f1.quiket: DEBUG
 
 # Swagger (SpringDoc OpenAPI)
 springdoc:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -46,3 +46,10 @@ springdoc:
     enabled: false  # Swagger JSON 엔드포인트 비활성화
   swagger-ui:
     enabled: false  # Swagger UI 비활성화
+aws:
+  ses:
+    # SES 리전 설정값
+    # 기본값 사용, 필요 시 환경변수로 override
+    region: ${AWS_REGION:ap-northeast-2}
+    # SES 발신자 이메일 설정값
+    from-email: ${AWS_SES_FROM_EMAIL:ja2hoon97@gmail.com}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -37,7 +37,7 @@ file:
 # 로깅
 logging:
   level:
-    root: WARN
+    root: INFO
     com.f1.quiket: INFO
 
 # Swagger (SpringDoc OpenAPI)

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -34,10 +34,4 @@
             <appender-ref ref="ROLLING_FILE"/>
         </root>
     </springProfile>
-
-    <springProfile name="!local & !prod">
-        <root level="INFO">
-            <appender-ref ref="CONSOLE"/>
-        </root>
-    </springProfile>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_DIR" value="/var/log/quicket"/>
+    <property name="LOG_FILE" value="application.log"/>
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ROLLING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/${LOG_FILE}</file>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/%d{yyyy-MM}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>90</maxHistory>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
+        </rollingPolicy>
+    </appender>
+
+    <springProfile name="local">
+        <root level="DEBUG">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <root level="INFO">
+            <appender-ref ref="ROLLING_FILE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!local & !prod">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/src/main/resources/mail-template/verification-code.html
+++ b/src/main/resources/mail-template/verification-code.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+    <h2>이메일 인증번호 안내</h2>
+    <p>아래 인증번호를 입력해 인증을 완료해주세요.</p>
+    <p>회원가입 또는 비밀번호 초기화에 사용됩니다.</p>
+    <p><strong>{{verificationCode}}</strong></p>
+</body>
+</html>

--- a/src/test/java/com/f1/quiket/infra/mail/service/SesMailSenderRealIntegrationTest.java
+++ b/src/test/java/com/f1/quiket/infra/mail/service/SesMailSenderRealIntegrationTest.java
@@ -1,0 +1,125 @@
+package com.f1.quiket.infra.mail.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.f1.quiket.infra.mail.config.AwsSesProperties;
+import com.f1.quiket.infra.mail.dto.MailSendRequest;
+import com.f1.quiket.infra.mail.template.MailTemplateFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.util.StringUtils;
+
+/**
+ * SES 실발송 수동 통합 테스트
+ *
+ * 실행 방법
+ * 0. AWS 자격증명 설정
+ * export AWS_ACCESS_KEY_ID=<AWS access key id>
+ * export AWS_SECRET_ACCESS_KEY=<AWS secret access key>
+ * export AWS_REGION=ap-northeast-2
+ * 또는 ~/.aws/credentials, ~/.aws/config에 프로파일 구성
+ *
+ * 1. 환경변수 설정
+ * export SES_REAL_MAIL_TEST_ENABLED=true
+ * export AWS_SES_TEST_FROM_EMAIL=<SES 검증된 발신 이메일>
+ * export AWS_SES_TEST_TO_EMAIL=<수신 이메일>
+ *
+ * 2. 단일 테스트 실행
+ * ./gradlew test --tests "com.f1.quiket.infra.mail.service.SesMailSenderRealIntegrationTest"
+ *
+ * 참고
+ * - SES_REAL_MAIL_TEST_ENABLED=true가 아니면 테스트는 skip 처리
+ * - 발신자/수신자 환경변수가 없으면 테스트는 skip 처리
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Tag("manual")
+@Slf4j
+class SesMailSenderRealIntegrationTest {
+
+    private static final String ENABLED_ENV = "SES_REAL_MAIL_TEST_ENABLED";
+    private static final String FROM_EMAIL_ENV = "AWS_SES_TEST_FROM_EMAIL";
+    private static final String TO_EMAIL_ENV = "AWS_SES_TEST_TO_EMAIL";
+
+    @Autowired
+    private AwsSesProperties awsSesProperties;
+
+    @Autowired
+    private SesMailSender sesMailSender;
+
+    @Autowired
+    private MailTemplateFactory mailTemplateFactory;
+
+    @DynamicPropertySource
+    static void overrideFromEmail(DynamicPropertyRegistry registry) {
+        String fromEmail = System.getenv(FROM_EMAIL_ENV);
+        if (StringUtils.hasText(fromEmail)) {
+            registry.add("aws.ses.from-email", () -> fromEmail);
+        }
+    }
+
+    @Test
+    void sendMail_realSes() {
+        progress("start");
+        String enabled = System.getenv(ENABLED_ENV);
+        if (!"true".equalsIgnoreCase(enabled)) {
+            progress("skipped: set " + ENABLED_ENV + "=true to run real SES test");
+        }
+        assumeTrue(
+                "true".equalsIgnoreCase(enabled),
+                () -> "[SES REAL TEST] skipped: set " + ENABLED_ENV + "=true to run real SES test"
+        );
+        progress("enabled env verified: " + ENABLED_ENV + "=" + enabled);
+
+        String fromEmail = System.getenv(FROM_EMAIL_ENV);
+        String toEmail = System.getenv(TO_EMAIL_ENV);
+        if (!StringUtils.hasText(fromEmail)) {
+            progress("skipped: missing env " + FROM_EMAIL_ENV);
+        }
+        assumeTrue(StringUtils.hasText(fromEmail), () -> "[SES REAL TEST] skipped: missing env " + FROM_EMAIL_ENV);
+        if (!StringUtils.hasText(toEmail)) {
+            progress("skipped: missing env " + TO_EMAIL_ENV);
+        }
+        assumeTrue(StringUtils.hasText(toEmail), () -> "[SES REAL TEST] skipped: missing env " + TO_EMAIL_ENV);
+
+        progress("env loaded. fromEmail=" + maskEmail(fromEmail) + ", toEmail=" + maskEmail(toEmail));
+        assertTrue(fromEmail.equals(awsSesProperties.getFromEmail()), "from-email should be loaded from env override");
+        progress(
+                "aws.ses resolved. region=" + awsSesProperties.getRegion()
+                        + ", fromEmail=" + maskEmail(awsSesProperties.getFromEmail())
+        );
+
+        progress("attempting send template mail");
+        MailSendRequest mailRequest = mailTemplateFactory.createSignUpVerificationMail(toEmail, "123456");
+        String messageId = sesMailSender.sendMail(mailRequest);
+
+        assertTrue(StringUtils.hasText(messageId), "messageId should not be blank");
+        progress("success. messageId=" + messageId);
+    }
+
+    private static String maskEmail(String email) {
+        if (!StringUtils.hasText(email) || !email.contains("@")) {
+            return "(blank)";
+        }
+        String[] parts = email.split("@", 2);
+        String localPart = parts[0];
+        String domainPart = parts[1];
+        String maskedLocalPart = localPart.length() <= 2
+                ? "*".repeat(localPart.length())
+                : localPart.substring(0, 2) + "*".repeat(localPart.length() - 2);
+        return maskedLocalPart + "@" + domainPart;
+    }
+
+    private void progress(String message) {
+        String fullMessage = "[SES REAL TEST] " + message;
+        log.info(fullMessage);
+        System.out.println(fullMessage);
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -21,3 +21,8 @@ spring:
       hibernate:
         format_sql: false
         use_sql_comments: false
+
+aws:
+  ses:
+    region: ${AWS_REGION:ap-northeast-2}
+    from-email: ${AWS_SES_FROM_EMAIL:ja2hoon97@gmail.com}


### PR DESCRIPTION
## 📝 Description
- Amazon SES 기반 메일 발송 기능 구현
- 회원가입/비밀번호 초기화 공통 인증번호 템플릿 적용
- 실발송 수동 통합 테스트 및 운영 로그 정책 분리 설정 추가

---

## ✨ Changes
- SES 메일 발송 인프라
  - `build.gradle`에 AWS SES v2 의존성 추가
  - SES 설정 클래스 추가 (`AwsSesConfig`, `AwsSesProperties`)
  -  메일 발송 실패 `ErrorCode` 추가 (`MAIL_SEND_FAILED`)
  - 환경별 SES 설정 추가 (`application-local/prod/test.yaml`)
  - 공통 인증번호 템플릿 및 팩토리 추가 (`mail-template/verification-code.html`, `MailTemplateFactory`)
- SES 실발송 통합 테스트
  - `SesMailSenderRealIntegrationTest` 추가
  - 템플릿 기반 메일 발송 검증 로직 추가
  - 환경변수 기반 실행/skip 처리 추가
  - 테스트 실행 방법 및 AWS credentials 설정 주석 추가
- 로컬/운영 로그 정책 분리
  - `logback-spring.xml` 추가
  - 운영 로그 경로 `/var/log/quicket/application.log` 적용
  - 보관 기간 90일, 일 단위 롤링 및 월별 폴더(`yyyy-MM`) 저장 패턴 추가

---

## 🧪 How to Test

1. AWS 자격증명 설정
  `export AWS_ACCESS_KEY_ID=...`
  `export AWS_SECRET_ACCESS_KEY=...`
  `export AWS_REGION=ap-northeast-2`
  또는 `~/.aws/credentials`, `~/.aws/config` 설정

2. 메일 테스트 환경변수 설정
  `export SES_REAL_MAIL_TEST_ENABLED=true`
  `export AWS_SES_TEST_FROM_EMAIL=<SES 검증된 발신 이메일>`
  `export AWS_SES_TEST_TO_EMAIL=<수신 이메일>`

3. 메일 실발송 테스트 실행
  `./gradlew test --tests "com.f1.quiket.infra.mail.service.SesMailSenderRealIntegrationTest"`

4. 로그 정책 확인
  `./gradlew bootRun --args='--spring.profiles.active=local'`
  `./gradlew bootRun --args='--spring.profiles.active=prod'`

---

## 🔗 Related Issue
Closes #11

---

## 📌 Notes
- 도메인 서비스 레이어에서 `MailTemplateFactory`로 요청 생성 후 `SesMailSender.sendMail(...)` 호출
- 회원가입: `createSignUpVerificationMail(email, code)` 사용
- 비밀번호 초기화: `createPasswordResetMail(email, code)` 사용
- SES Sandbox 상태에서는 검증된 수신자만 발송 가능
- 운영 배포 전 `/var/log/quicket` 경로 쓰기 권한 필요

---

## 🙋‍♂️ Assignee
- @ja2hoon