### PR TITLE
[Docs] MVP API 명세서 작성

### DIFF
--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -1,0 +1,4278 @@
+openapi: 3.0.3
+info:
+  title: Quiket MVP API
+  version: 1.0.0
+  description: |
+    Quiket MVP API 명세
+
+    기준 문서:
+    - 기존 Quiket Auth API 명세
+    - Quiket 기능명세 목록 v1.0
+    - Quiket 기능명세 상세 v1.0
+    - Quiket 서비스 DDL
+
+    MVP 범위:
+    - 자체 회원가입, 이메일 인증, 자체 로그인
+    - JWT Access Token / Refresh Token 재발급, 로그아웃
+    - 비밀번호 재설정
+    - Kakao OAuth 로그인 및 기존 계정 연동
+    - 홈 메인 데이터, 최근활동
+    - 과목 추가/조회/수정/삭제, 시험 D-Day 설정
+    - 챕터명 수정
+    - PDF/이미지/텍스트 강의 업로드
+    - 파트 자동/직접 분류, 파트 조회/편집/추가
+    - 퀴즈 생성, 생성 상태 조회, 퀴즈 세트 조회
+    - 퀴즈 결과 제출, 결과/해설 조회, 다시 풀기
+    - 도토리/XP/캐릭터 성장 조회
+    - 마이페이지 계정/알림/피드백
+
+    MVP 제외:
+    - 퀴즈기록 별도 메뉴
+    - 오답노트 별도 메뉴
+    - PPTX/DOCX 업로드
+    - 텍스트 검수 화면
+    - 파트 병합/분리/순서변경/삭제
+    - 플래시카드, 쪽지시험
+    - 아이템 스토어
+    - 요점정리
+
+    공통 응답 형식:
+    - 성공/실패 응답은 모두 ApiResponse 형태를 사용합니다.
+    - success 필드는 성공/실패 여부만 표현합니다.
+    - 외부 노출 식별자는 UUID v7 문자열(public_id)을 사용합니다.
+
+    [Redis 사용 정책]
+    - 이메일 인증 코드, 비밀번호 재설정 코드, Kakao signupToken, Kakao linkToken은 Redis TTL 기반 임시 데이터로 관리합니다.
+    - Refresh Token은 DB에 해시값으로 영속 저장합니다.
+    - Redis 임시 데이터는 만료 후 재사용하지 않습니다.
+servers:
+  - url: http://43.201.222.243:8080/api/v1
+    description: Quiket 운영/개발 서버
+  - url: http://localhost:8080/api/v1
+    description: Local server
+
+tags:
+  - name: Auth
+    description: 회원가입, 로그인, 토큰, 로그아웃
+  - name: Email Verification
+    description: 이메일 인증
+  - name: Password Reset
+    description: 비밀번호 재설정
+  - name: OAuth
+    description: 소셜 로그인 및 계정 연동
+  - name: Me
+    description: 내 인증 정보 조회
+  - name: Home
+    description: 홈 메인, 최근활동
+  - name: Subjects
+    description: 과목 추가, 조회, 수정, 삭제
+  - name: Certificates
+    description: 자격증 사전 목록
+  - name: Chapters
+    description: 챕터 조회 및 수정
+  - name: Lecture Uploads
+    description: PDF, 이미지, 텍스트 강의 업로드
+  - name: Parts
+    description: 파트 조회, 편집, 추가
+  - name: Quiz Generation
+    description: 퀴즈 생성 및 생성 상태 조회
+  - name: Quiz Play
+    description: 퀴즈 세트 조회 및 풀이 시작
+  - name: Results
+    description: 결과 제출, 결과 조회, 해설 조회
+  - name: History
+    description: MVP 최근활동 기반 퀴즈 기록 조회
+  - name: Gamification
+    description: 도토리, XP, 큐링 성장
+  - name: My Page
+    description: 계정 설정, 알림 설정, 피드백
+
+paths:
+  /auth/signup:
+    post:
+      tags:
+        - Auth
+      summary: 자체 회원가입
+      description: |
+        이메일, 비밀번호, 닉네임으로 자체 계정을 생성합니다.
+        회원가입 성공 시 이메일 인증 요청이 함께 생성됩니다.
+        이메일 인증 완료 전까지 로그인할 수 없습니다.
+      operationId: signup
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SignupRequest'
+            examples:
+              default:
+                value:
+                  email: user@example.com
+                  password: Password123!
+                  passwordConfirm: Password123!
+                  nickname: 도토리장인
+      responses:
+        '201':
+          description: 회원가입 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SignupResponse'
+              examples:
+                default:
+                  value:
+                    success: true
+                    code: AUTH_SIGNUP_SUCCESS
+                    message: 회원가입이 완료되었습니다. 이메일 인증을 진행해주세요.
+                    data:
+                      userId: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+                      email: user@example.com
+                      nickname: 도토리장인
+                      emailVerificationRequired: true
+                      emailVerificationSent: true
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '409':
+          description: 이메일 중복
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                duplicatedEmail:
+                  value:
+                    success: false
+                    code: AUTH_EMAIL_ALREADY_EXISTS
+                    message: 이미 사용 중인 이메일입니다.
+                    data: null
+
+  /auth/emails/availability:
+    get:
+      tags:
+        - Auth
+      summary: 이메일 중복 확인
+      description: 회원가입에 사용할 이메일의 사용 가능 여부를 조회합니다.
+      operationId: checkEmailAvailability
+      parameters:
+        - name: email
+          in: query
+          required: true
+          description: 중복 확인 대상 이메일
+          schema:
+            type: string
+            format: email
+            example: user@example.com
+      responses:
+        '200':
+          description: 이메일 사용 가능 여부 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailAvailabilityResponse'
+              examples:
+                available:
+                  value:
+                    success: true
+                    code: AUTH_EMAIL_AVAILABLE
+                    message: 사용 가능한 이메일입니다.
+                    data:
+                      email: user@example.com
+                      available: true
+                unavailable:
+                  value:
+                    success: true
+                    code: AUTH_EMAIL_UNAVAILABLE
+                    message: 이미 사용 중인 이메일입니다.
+                    data:
+                      email: user@example.com
+                      available: false
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /auth/email-verifications:
+    post:
+      tags:
+        - Email Verification
+      summary: 이메일 인증 메일 재발송
+      description: |
+        회원가입 후 이메일 인증 메일을 재발송합니다.
+        인증 방식은 코드 입력 방식을 기본으로 하되, 링크 방식 확장을 고려합니다.
+        인증 코드는 Redis에 TTL 30분으로 저장합니다.
+      operationId: resendEmailVerification
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailVerificationRequest'
+            examples:
+              default:
+                value:
+                  email: user@example.com
+      responses:
+        '200':
+          description: 이메일 인증 메일 발송 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailVerificationSentResponse'
+              examples:
+                default:
+                  value:
+                    success: true
+                    code: AUTH_EMAIL_VERIFICATION_SENT
+                    message: 이메일 인증 메일이 발송되었습니다.
+                    data:
+                      email: user@example.com
+                      expiresInSeconds: 1800
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          description: 가입되지 않은 이메일
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/email-verifications/confirm:
+    post:
+      tags:
+        - Email Verification
+      summary: 이메일 인증 확인
+      description: 이메일로 발송된 인증 코드를 검증하고 계정을 활성화합니다. verificationCode 검증은 Redis에 저장된 인증 코드를 기준으로 수행합니다.
+      operationId: confirmEmailVerification
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmailVerificationConfirmRequest'
+            examples:
+              code:
+                value:
+                  email: user@example.com
+                  verificationCode: '123456'
+              token:
+                value:
+                  email: user@example.com
+                  verificationToken: eyJraWQiOiJlbWFpbC12ZXJpZmljYXRpb24ifQ
+      responses:
+        '200':
+          description: 이메일 인증 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmailVerificationConfirmResponse'
+        '400':
+          description: 인증 코드/토큰 오류 또는 만료
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/login:
+    post:
+      tags:
+        - Auth
+      summary: 자체 로그인
+      description: |
+        이메일과 비밀번호로 로그인합니다.
+        이메일 인증이 완료되지 않은 계정은 로그인할 수 없습니다.
+        로그인 5회 실패 시 계정이 잠금 처리됩니다.
+      operationId: login
+      parameters:
+        - $ref: '#/components/parameters/XDeviceId'
+        - $ref: '#/components/parameters/XDeviceName'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LoginRequest'
+            examples:
+              default:
+                value:
+                  email: user@example.com
+                  password: Password123!
+      responses:
+        '200':
+          description: 로그인 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTokenResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          description: 로그인 실패
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: 이메일 미인증 또는 계정 잠금
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/token/refresh:
+    post:
+      tags:
+        - Auth
+      summary: 토큰 재발급
+      description: Refresh Token을 검증하여 새로운 Access Token과 Refresh Token을 발급합니다.
+      operationId: refreshToken
+      parameters:
+        - $ref: '#/components/parameters/XDeviceId'
+        - $ref: '#/components/parameters/XDeviceName'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshTokenRequest'
+      responses:
+        '200':
+          description: 토큰 재발급 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTokenResponse'
+        '401':
+          description: Refresh Token 무효
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/logout:
+    post:
+      tags:
+        - Auth
+      summary: 로그아웃
+      description: 현재 사용 중인 Refresh Token을 폐기합니다.
+      operationId: logout
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LogoutRequest'
+      responses:
+        '200':
+          description: 로그아웃 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptySuccessResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /auth/password-reset/requests:
+    post:
+      tags:
+        - Password Reset
+      summary: 비밀번호 재설정 요청
+      description: |
+        등록된 이메일로 비밀번호 재설정 링크 또는 인증 코드를 발송합니다.
+        재설정 링크 유효시간은 30분입니다.
+        재설정 코드 또는 재설정 토큰은 Redis에 TTL 30분으로 저장합니다.
+      operationId: requestPasswordReset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetRequest'
+      responses:
+        '200':
+          description: 비밀번호 재설정 요청 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PasswordResetRequestedResponse'
+        '404':
+          description: 가입되지 않은 이메일
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 소셜 전용 계정
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/password-reset/confirm:
+    post:
+      tags:
+        - Password Reset
+      summary: 비밀번호 재설정 완료
+      description: 재설정 토큰 또는 인증 코드를 검증하고 새 비밀번호로 변경합니다. verificationCode 또는 resetToken은 Redis TTL 기반 임시 값으로 검증합니다.
+      operationId: confirmPasswordReset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordResetConfirmRequest'
+      responses:
+        '200':
+          description: 비밀번호 재설정 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptySuccessResponse'
+        '400':
+          description: 토큰/코드 오류 또는 비밀번호 정책 위반
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/oauth/kakao/login:
+    post:
+      tags:
+        - OAuth
+      summary: Kakao OAuth 로그인
+      description: |
+        Android 앱에서 Kakao Android SDK 로그인으로 획득한 kakaoAccessToken을 서버로 전달합니다.
+        계정 연동 또는 닉네임 설정이 필요한 경우 linkToken/signupToken을 Redis에 TTL 10분으로 저장합니다.
+
+        서버 처리 흐름:
+        1. kakaoAccessToken으로 Kakao 사용자 정보 조회
+        2. Kakao 회원번호를 provider_subject로 사용
+        3. 기존 kakao 인증 수단 존재 시 로그인 처리
+        4. 없으면 email 기준 기존 사용자 확인
+        5. 기존 사용자 없으면 신규 사용자와 kakao 인증 수단 생성
+        6. 기존 사용자 존재하지만 kakao 인증 수단이 없으면 계정 연동 필요 응답 반환
+        7. 로그인 성공 시 Quiket Access Token / Refresh Token 발급
+
+        서버는 Kakao 사용자 정보 조회 시 다음 요청을 수행합니다.
+        GET https://kapi.kakao.com/v2/user/me
+        Authorization: Bearer {kakaoAccessToken}
+      operationId: kakaoLogin
+      parameters:
+        - $ref: '#/components/parameters/XDeviceId'
+        - $ref: '#/components/parameters/XDeviceName'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KakaoLoginRequest'
+            examples:
+              default:
+                value:
+                  kakaoAccessToken: kakao_access_token_from_android_sdk
+                  agreedToTerms: true
+      responses:
+        '200':
+          description: Kakao 로그인 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTokenResponse'
+        '201':
+          description: Kakao 신규 가입 후 로그인 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTokenResponse'
+        '202':
+          description: 최초 로그인 후 닉네임 설정 필요
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KakaoNicknameRequiredResponse'
+        '409':
+          description: 기존 이메일 계정과 연동 필요
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KakaoAccountLinkRequiredResponse'
+        '401':
+          description: Kakao Access Token 무효
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/oauth/kakao/link:
+    post:
+      tags:
+        - OAuth
+      summary: Kakao 기존 계정 연동
+      description: |
+        동일 이메일로 기존 Local 계정이 있는 경우, 사용자의 동의를 받은 뒤 Kakao 인증 수단을 기존 사용자에 연결합니다.
+        로그인 화면에서 진행되는 연동이므로 기존 Local 계정 비밀번호를 함께 검증합니다.
+        linkToken은 Redis에 저장된 Kakao 연동 임시 토큰을 검증합니다.
+      operationId: linkKakaoAccount
+      parameters:
+        - $ref: '#/components/parameters/XDeviceId'
+        - $ref: '#/components/parameters/XDeviceName'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KakaoAccountLinkRequest'
+      responses:
+        '200':
+          description: Kakao 계정 연동 후 로그인 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTokenResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          description: 비밀번호 오류 또는 연동 토큰 무효
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/oauth/kakao/nickname:
+    post:
+      tags:
+        - OAuth
+      summary: Kakao 최초 로그인 닉네임 설정
+      description: Kakao 최초 로그인 시 닉네임 설정이 필요한 경우 닉네임을 저장하고 Quiket 토큰을 발급합니다. signupToken은 Redis에 저장된 Kakao 가입 임시 토큰을 검증합니다.
+      operationId: completeKakaoNickname
+      parameters:
+        - $ref: '#/components/parameters/XDeviceId'
+        - $ref: '#/components/parameters/XDeviceName'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/KakaoNicknameRequest'
+      responses:
+        '200':
+          description: 닉네임 설정 및 로그인 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTokenResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          description: signupToken 무효
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /auth/me:
+    get:
+      tags:
+        - Me
+      summary: 내 인증 정보 조회
+      description: |
+        Access Token을 검증하고 현재 로그인 사용자의 기본 정보를 조회합니다.
+        앱 시작 시 토큰 유효성 확인에도 사용할 수 있습니다.
+      operationId: getMe
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 내 정보 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /home:
+    get:
+      tags:
+        - Home
+      summary: 홈 메인 데이터 조회
+      description: |
+        홈 메인 화면에 필요한 사용자 요약, 캐릭터 바, D-Day, 과목 목록, 최근활동을 한 번에 조회합니다.
+        기록/오답 별도 메뉴는 MVP에서 제외되며 최근활동은 홈에서만 노출합니다.
+      operationId: getHome
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 홈 데이터 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HomeResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /home/recent-activities:
+    get:
+      tags:
+        - Home
+        - History
+      summary: 홈 최근활동 목록 조회
+      description: 퀴즈 생성 중, 미시작, 진행 중, 완료 상태의 최근활동을 최신순으로 조회합니다.
+      operationId: getRecentActivities
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Size'
+      responses:
+        '200':
+          description: 최근활동 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecentActivityListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /subjects:
+    get:
+      tags:
+        - Subjects
+      summary: 내 과목 목록 조회
+      operationId: getSubjects
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/Size'
+      responses:
+        '200':
+          description: 과목 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    post:
+      tags:
+        - Subjects
+      summary: 과목 추가
+      description: |
+        과목명, 학습 목적, 목적별 상세 메타데이터를 저장합니다.
+        선택한 목적/시험 유형/분야 정보는 이후 AI 퀴즈 생성 프롬프트에 반영됩니다.
+      operationId: createSubject
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubjectCreateRequest'
+            examples:
+              examUniversity:
+                value:
+                  name: 데이터베이스
+                  purpose: exam
+                  examDetail:
+                    examType: university
+                    univMajorField: engineering
+                    univMajorName: 컴퓨터공학
+                    univCourseType: major
+              review:
+                value:
+                  name: 운영체제 복습
+                  purpose: review
+                  reviewDetail:
+                    field: IT
+                    studyLevel: beginner
+      responses:
+        '201':
+          description: 과목 생성 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /subjects/{subjectId}:
+    get:
+      tags:
+        - Subjects
+      summary: 과목 상세 조회
+      description: 과목 기본 정보, 목적별 상세 정보, 시험 일정, 챕터/파트 요약을 조회합니다.
+      operationId: getSubject
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SubjectId'
+      responses:
+        '200':
+          description: 과목 상세 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectDetailResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+        - Subjects
+      summary: 과목 삭제
+      description: 과목과 하위 챕터, 파트, 퀴즈 기록을 삭제 처리합니다.
+      operationId: deleteSubject
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SubjectId'
+      responses:
+        '200':
+          description: 과목 삭제 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptySuccessResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /subjects/{subjectId}/name:
+    patch:
+      tags:
+        - Subjects
+      summary: 과목명 수정
+      operationId: updateSubjectName
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SubjectId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubjectNameUpdateRequest'
+      responses:
+        '200':
+          description: 과목명 수정 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /subjects/{subjectId}/details:
+    put:
+      tags:
+        - Subjects
+      summary: 과목 유형 및 상세 메타데이터 수정
+      description: 과목 학습 목적과 상세 정보를 수정합니다. 변경값은 이후 퀴즈 생성 프롬프트부터 반영되며 기존 퀴즈에는 소급 적용하지 않습니다.
+      operationId: updateSubjectDetails
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SubjectId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubjectDetailUpdateRequest'
+      responses:
+        '200':
+          description: 과목 상세 수정 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectDetailResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /subjects/{subjectId}/exam-schedule:
+    put:
+      tags:
+        - Subjects
+      summary: 시험 일정 등록/수정
+      description: MVP에서는 과목당 시험 일정 1개만 지원하며, 기존 일정이 있으면 덮어씁니다.
+      operationId: upsertSubjectExamSchedule
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SubjectId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubjectExamScheduleUpsertRequest'
+      responses:
+        '200':
+          description: 시험 일정 저장 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubjectExamScheduleResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+        - Subjects
+      summary: 시험 일정 삭제
+      operationId: deleteSubjectExamSchedule
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SubjectId'
+      responses:
+        '200':
+          description: 시험 일정 삭제 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptySuccessResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /certificates:
+    get:
+      tags:
+        - Certificates
+      summary: 자격증 목록 조회
+      description: 과목 추가 시 자격증 시험 유형에서 사용할 사전 정의 자격증 목록을 조회합니다.
+      operationId: getCertificates
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: featured
+          in: query
+          required: false
+          description: 자주 찾는 자격증만 조회할지 여부
+          schema:
+            type: boolean
+            example: true
+        - name: keyword
+          in: query
+          required: false
+          description: 자격증명 검색어
+          schema:
+            type: string
+            example: 정보처리
+      responses:
+        '200':
+          description: 자격증 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateListResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /chapters/{chapterId}/name:
+    patch:
+      tags:
+        - Chapters
+      summary: 챕터명 수정
+      operationId: updateChapterName
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ChapterId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChapterNameUpdateRequest'
+      responses:
+        '200':
+          description: 챕터명 수정 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChapterResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /lecture-uploads:
+    post:
+      tags:
+        - Lecture Uploads
+      summary: 강의 업로드 및 파트 분류 요청
+      description: |
+        PDF, 이미지, 텍스트 직접 입력을 하나의 업로드 API로 처리합니다.
+        사용자가 선택한 파트 분류 방식에 따라 자동 분류 또는 직접 입력 파트명 기반 분류를 수행합니다.
+        원본 학습 파일은 서버 영구 저장 대상이 아니며, MVP에서는 추출된 텍스트와 파트 본문 저장을 기준으로 합니다.
+      operationId: createLectureUpload
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/LectureTextUploadRequest'
+            examples:
+              textAuto:
+                value:
+                  subjectId: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+                  chapterName: 1장 데이터 모델링
+                  uploadType: text
+                  partSplitMethod: auto
+                  text: 데이터 모델링은 현실 세계의 데이터를 추상화하여 구조화하는 과정입니다...
+              textManual:
+                value:
+                  subjectId: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+                  chapterName: 1장 데이터 모델링
+                  uploadType: text
+                  partSplitMethod: manual
+                  text: 데이터 모델링은 현실 세계의 데이터를 추상화하여 구조화하는 과정입니다...
+                  partSplitPlans:
+                    - partNumber: 1
+                      intendedName: 데이터 모델링 개념
+                    - partNumber: 2
+                      intendedName: 데이터 모델링 특징
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/LectureFileUploadRequest'
+      responses:
+        '202':
+          description: 업로드 및 파트 분류 작업 접수 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LectureUploadAcceptedResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '413':
+          description: 파일 크기 초과
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /lecture-uploads/{lectureUploadId}/status:
+    get:
+      tags:
+        - Lecture Uploads
+      summary: 강의 업로드 처리 상태 조회
+      operationId: getLectureUploadStatus
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/LectureUploadId'
+      responses:
+        '200':
+          description: 업로드 처리 상태 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LectureUploadStatusResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /chapters/{chapterId}/parts:
+    post:
+      tags:
+        - Parts
+        - Lecture Uploads
+      summary: 기존 챕터에 파트 추가
+      description: 기존 챕터 마지막 순서에 새 파트를 추가합니다. PDF/이미지/텍스트 업로드 플로우와 동일한 방식으로 처리합니다.
+      operationId: addPartToChapter
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/ChapterId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PartTextAddRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PartFileAddRequest'
+      responses:
+        '202':
+          description: 파트 추가 작업 접수 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LectureUploadAcceptedResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /parts/{partId}:
+    get:
+      tags:
+        - Parts
+      summary: 파트 상세 조회
+      operationId: getPart
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/PartId'
+      responses:
+        '200':
+          description: 파트 상세 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PartResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    patch:
+      tags:
+        - Parts
+      summary: 파트명 및 본문 수정
+      operationId: updatePart
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/PartId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PartUpdateRequest'
+      responses:
+        '200':
+          description: 파트 수정 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PartResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /subjects/{subjectId}/quiz-scope:
+    get:
+      tags:
+        - Quiz Generation
+        - Subjects
+      summary: 퀴즈 출제 범위 선택용 챕터/파트 조회
+      operationId: getQuizScope
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/SubjectId'
+      responses:
+        '200':
+          description: 출제 범위 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizScopeResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /quiz-sessions:
+    post:
+      tags:
+        - Quiz Generation
+      summary: 퀴즈 생성 요청
+      description: |
+        선택한 과목, 출제 범위, 퀴즈 형식, 문제 수, 풀이 방식, 타이머, 난이도를 기반으로 퀴즈 생성 작업을 접수합니다.
+        서버는 jobId를 즉시 반환하고 백그라운드에서 퀴즈를 생성합니다.
+        MVP 정책상 사용자당 생성 작업 1건만 순차 처리합니다.
+      operationId: createQuizSession
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuizCreateRequest'
+      responses:
+        '202':
+          description: 퀴즈 생성 작업 접수 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizGenerationAcceptedResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: 이미 생성 중인 퀴즈가 있음
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /quiz-sessions/{quizSessionId}/generation-status:
+    get:
+      tags:
+        - Quiz Generation
+      summary: 퀴즈 생성 상태 조회
+      operationId: getQuizGenerationStatus
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/QuizSessionId'
+      responses:
+        '200':
+          description: 퀴즈 생성 상태 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizGenerationStatusResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /quiz-sessions/{quizSessionId}:
+    get:
+      tags:
+        - Quiz Play
+      summary: 퀴즈 세트 조회
+      description: 완료된 퀴즈 세트의 문제, 선택지, 정답, 해설을 조회합니다. 앱은 풀이 중 이 데이터를 로컬에 저장하고 서버 호출 없이 진행합니다.
+      operationId: getQuizSession
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/QuizSessionId'
+      responses:
+        '200':
+          description: 퀴즈 세트 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizSessionResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: 아직 생성 완료 전인 퀴즈
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /quiz-sessions/{quizSessionId}/play-sessions:
+    post:
+      tags:
+        - Quiz Play
+      summary: 퀴즈 풀이 세션 시작
+      description: |
+        클라이언트가 발급한 clientSessionId를 서버에 등록합니다.
+        풀이 중 답안 저장은 로컬에서 처리하며, 결과 화면 진입 시 결과 제출 API를 호출합니다.
+      operationId: startQuizPlaySession
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/QuizSessionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuizPlayStartRequest'
+      responses:
+        '201':
+          description: 풀이 세션 시작 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizPlaySessionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /quiz-results:
+    post:
+      tags:
+        - Results
+        - History
+        - Gamification
+      summary: 퀴즈 결과 제출
+      description: |
+        결과 화면 진입 시 클라이언트가 로컬에 저장한 답안 배열을 서버에 1회 제출합니다.
+        서버는 저장된 정답으로 재채점하고, 도토리/XP를 적립하며, 풀이 기록을 같은 트랜잭션으로 저장합니다.
+        clientSessionId 기준으로 중복 제출을 차단하며, 동일 요청 재전송 시 동일 결과를 반환하고 보상은 추가 지급하지 않습니다.
+      operationId: submitQuizResult
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuizResultSubmitRequest'
+      responses:
+        '201':
+          description: 결과 제출 및 저장 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizResultResponse'
+        '200':
+          description: 중복 제출에 대한 기존 결과 반환
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizResultResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /quiz-results/{playSessionId}:
+    get:
+      tags:
+        - Results
+        - History
+      summary: 퀴즈 결과 상세 조회
+      description: 과거에 저장된 퀴즈 결과를 조회합니다. 홈 최근활동의 완료 카드에서 진입합니다.
+      operationId: getQuizResult
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/PlaySessionId'
+      responses:
+        '200':
+          description: 결과 상세 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizResultResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /quiz-results/{playSessionId}/review:
+    get:
+      tags:
+        - Results
+      summary: 문제별 해설 조회
+      description: 결과 화면의 해설보기에서 사용할 문항별 정답/오답/해설 데이터를 조회합니다.
+      operationId: getQuizResultReview
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/PlaySessionId'
+        - name: filter
+          in: query
+          required: false
+          description: 전체 또는 틀린 문제만 필터링
+          schema:
+            type: string
+            enum:
+              - all
+              - wrong
+            default: all
+      responses:
+        '200':
+          description: 해설 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizReviewResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /quiz-results/{playSessionId}/retry-all:
+    post:
+      tags:
+        - History
+        - Quiz Play
+      summary: 전체 다시풀기 시작
+      description: 같은 퀴즈 세트를 새 풀이 세션으로 다시 풉니다. 도토리는 지급하지 않고 XP만 복습 기준으로 지급합니다.
+      operationId: retryAllQuestions
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/PlaySessionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuizRetryRequest'
+      responses:
+        '201':
+          description: 전체 다시풀기 세션 생성 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizPlaySessionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /quiz-results/{playSessionId}/retry-wrong:
+    post:
+      tags:
+        - History
+        - Quiz Play
+      summary: 틀린 문제만 다시풀기 시작
+      description: 부모 풀이 세션의 오답 문항으로 새 자식 퀴즈 세트를 생성하고 풀이 세션을 시작합니다.
+      operationId: retryWrongQuestions
+      security:
+        - bearerAuth: []
+      parameters:
+        - $ref: '#/components/parameters/PlaySessionId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuizRetryRequest'
+      responses:
+        '201':
+          description: 오답 복습 세션 생성 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QuizPlaySessionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: 오답 문항이 없어 다시풀기 불가
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /gamification/me:
+    get:
+      tags:
+        - Gamification
+      summary: 내 도토리/XP/큐링 성장 정보 조회
+      operationId: getMyGamification
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 게임화 정보 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GamificationResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /my/profile:
+    get:
+      tags:
+        - My Page
+      summary: 마이페이지 계정 정보 조회
+      operationId: getMyProfile
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 계정 정보 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MyProfileResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /my/profile/nickname:
+    patch:
+      tags:
+        - My Page
+      summary: 닉네임 변경
+      operationId: updateMyNickname
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NicknameUpdateRequest'
+      responses:
+        '200':
+          description: 닉네임 변경 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MyProfileResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /my/password:
+    patch:
+      tags:
+        - My Page
+      summary: 비밀번호 변경
+      description: 소셜 전용 계정은 비밀번호 변경을 지원하지 않습니다.
+      operationId: updateMyPassword
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PasswordChangeRequest'
+      responses:
+        '200':
+          description: 비밀번호 변경 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptySuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '409':
+          description: 소셜 전용 계정 또는 이전 비밀번호와 동일
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /my/account/deletion:
+    post:
+      tags:
+        - My Page
+      summary: 회원 탈퇴 요청
+      description: MVP 정책상 탈퇴 시 사용자 학습 기록, 도토리, XP를 삭제 처리합니다. 세부 보존/유예 정책은 개인정보 처리방침 확정 후 조정합니다.
+      operationId: deleteMyAccount
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountDeleteRequest'
+      responses:
+        '200':
+          description: 회원 탈퇴 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptySuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /my/notifications:
+    get:
+      tags:
+        - My Page
+      summary: 알림 설정 조회
+      operationId: getNotificationSettings
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: 알림 설정 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationSettingsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+    put:
+      tags:
+        - My Page
+      summary: 알림 설정 수정
+      operationId: updateNotificationSettings
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NotificationSettingsUpdateRequest'
+      responses:
+        '200':
+          description: 알림 설정 수정 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotificationSettingsResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /my/fcm-token:
+    put:
+      tags:
+        - My Page
+      summary: FCM 토큰 등록/갱신
+      operationId: updateFcmToken
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FcmTokenUpdateRequest'
+      responses:
+        '200':
+          description: FCM 토큰 갱신 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmptySuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /feedbacks:
+    post:
+      tags:
+        - My Page
+      summary: 피드백/문의 제출
+      operationId: createFeedback
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FeedbackCreateRequest'
+      responses:
+        '201':
+          description: 피드백 제출 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FeedbackResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  parameters:
+    XDeviceId:
+      name: X-Device-Id
+      in: header
+      required: false
+      description: 클라이언트 디바이스 식별자
+      schema:
+        type: string
+        maxLength: 128
+        example: android-device-uuid
+    XDeviceName:
+      name: X-Device-Name
+      in: header
+      required: false
+      description: 사용자에게 표시할 디바이스 이름
+      schema:
+        type: string
+        maxLength: 100
+        example: Galaxy S24
+    Page:
+      name: page
+      in: query
+      required: false
+      description: 0부터 시작하는 페이지 번호
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+    Size:
+      name: size
+      in: query
+      required: false
+      description: 페이지 크기
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 10
+    SubjectId:
+      name: subjectId
+      in: path
+      required: true
+      description: 과목 publicId
+      schema:
+        type: string
+        format: uuid
+        example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+    ChapterId:
+      name: chapterId
+      in: path
+      required: true
+      description: 챕터 publicId
+      schema:
+        type: string
+        format: uuid
+        example: 018f8c2e-6a10-7ca2-8a4b-52f3b4b7a100
+    PartId:
+      name: partId
+      in: path
+      required: true
+      description: 파트 publicId
+      schema:
+        type: string
+        format: uuid
+        example: 018f8c2e-7001-7d4e-9404-4440c3f4ad21
+    LectureUploadId:
+      name: lectureUploadId
+      in: path
+      required: true
+      description: 강의 업로드 publicId
+      schema:
+        type: string
+        format: uuid
+        example: 018f8c2e-7123-7af4-9b72-b1d93c401f41
+    QuizSessionId:
+      name: quizSessionId
+      in: path
+      required: true
+      description: 퀴즈 세션 publicId
+      schema:
+        type: string
+        format: uuid
+        example: 018f8c2e-8123-72ab-96a1-f7c49c1d1111
+    PlaySessionId:
+      name: playSessionId
+      in: path
+      required: true
+      description: 풀이 세션 ID. 서버 publicId 또는 클라이언트 발급 clientSessionId
+      schema:
+        type: string
+        example: android-play-session-uuid
+
+  responses:
+    BadRequest:
+      description: 잘못된 요청
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Unauthorized:
+      description: 인증 실패
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    Forbidden:
+      description: 접근 권한 없음
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: 리소스 없음
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+  schemas:
+    SignupRequest:
+      type: object
+      required:
+        - email
+        - password
+        - passwordConfirm
+        - nickname
+      properties:
+        email:
+          type: string
+          format: email
+          maxLength: 255
+          example: user@example.com
+        password:
+          type: string
+          minLength: 8
+          maxLength: 64
+          pattern: '^(?=.*[A-Za-z])(?=.*\d).{8,64}$'
+          example: Password123!
+        passwordConfirm:
+          type: string
+          minLength: 8
+          maxLength: 64
+          example: Password123!
+        nickname:
+          type: string
+          minLength: 2
+          maxLength: 12
+          pattern: '^[가-힣A-Za-z]{2,12}$'
+          example: 도토리장인
+
+    LoginRequest:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          format: email
+          maxLength: 255
+          example: user@example.com
+        password:
+          type: string
+          minLength: 8
+          maxLength: 64
+          example: Password123!
+
+    RefreshTokenRequest:
+      type: object
+      required:
+        - refreshToken
+      properties:
+        refreshToken:
+          type: string
+          example: eyJhbGciOiJIUzI1NiJ9.refresh.payload
+
+    LogoutRequest:
+      type: object
+      properties:
+        refreshToken:
+          type: string
+          example: eyJhbGciOiJIUzI1NiJ9.refresh.payload
+
+    EmailVerificationRequest:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
+          example: user@example.com
+
+    EmailVerificationConfirmRequest:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        verificationCode:
+          type: string
+          minLength: 4
+          maxLength: 20
+          example: '123456'
+        verificationToken:
+          type: string
+          maxLength: 255
+          example: eyJraWQiOiJlbWFpbC12ZXJpZmljYXRpb24ifQ
+      oneOf:
+        - required:
+            - verificationCode
+        - required:
+            - verificationToken
+
+    PasswordResetRequest:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
+          example: user@example.com
+
+    PasswordResetConfirmRequest:
+      type: object
+      required:
+        - email
+        - newPassword
+        - newPasswordConfirm
+      properties:
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        resetToken:
+          type: string
+          maxLength: 255
+          example: eyJraWQiOiJwYXNzd29yZC1yZXNldCJ9
+        verificationCode:
+          type: string
+          maxLength: 20
+          example: '123456'
+        newPassword:
+          type: string
+          minLength: 8
+          maxLength: 64
+          pattern: '^(?=.*[A-Za-z])(?=.*\d).{8,64}$'
+          example: NewPassword123!
+        newPasswordConfirm:
+          type: string
+          minLength: 8
+          maxLength: 64
+          example: NewPassword123!
+      oneOf:
+        - required:
+            - resetToken
+        - required:
+            - verificationCode
+
+    KakaoLoginRequest:
+      type: object
+      required:
+        - kakaoAccessToken
+      properties:
+        kakaoAccessToken:
+          type: string
+          description: Android Kakao SDK에서 획득한 Kakao Access Token
+          example: kakao_access_token_from_android_sdk
+        agreedToTerms:
+          type: boolean
+          default: true
+          example: true
+
+    KakaoAccountLinkRequest:
+      type: object
+      required:
+        - linkToken
+        - email
+        - password
+        - agreedToLink
+      properties:
+        linkToken:
+          type: string
+          example: eyJraWQiOiJrYWthby1saW5rIn0
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        password:
+          type: string
+          example: Password123!
+        agreedToLink:
+          type: boolean
+          example: true
+
+    KakaoNicknameRequest:
+      type: object
+      required:
+        - signupToken
+        - nickname
+      properties:
+        signupToken:
+          type: string
+          example: eyJraWQiOiJrYWthby1zaWdudXAifQ
+        nickname:
+          type: string
+          minLength: 2
+          maxLength: 12
+          pattern: '^[가-힣A-Za-z]{2,12}$'
+          example: 도토리장인
+
+    AuthUser:
+      type: object
+      required:
+        - id
+        - email
+        - nickname
+        - dotoriBalance
+        - emailVerified
+        - status
+        - providers
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        nickname:
+          type: string
+          example: 도토리장인
+        dotoriBalance:
+          type: integer
+          minimum: 0
+          example: 0
+        emailVerified:
+          type: boolean
+          example: true
+        status:
+          $ref: '#/components/schemas/UserStatus'
+        providers:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuthProvider'
+          example:
+            - local
+            - kakao
+
+    TokenPair:
+      type: object
+      required:
+        - accessToken
+        - refreshToken
+        - tokenType
+        - accessTokenExpiresIn
+        - refreshTokenExpiresIn
+      properties:
+        accessToken:
+          type: string
+          example: eyJhbGciOiJIUzI1NiJ9.access.payload
+        refreshToken:
+          type: string
+          example: eyJhbGciOiJIUzI1NiJ9.refresh.payload
+        tokenType:
+          type: string
+          example: Bearer
+        accessTokenExpiresIn:
+          type: integer
+          format: int64
+          example: 3600
+        refreshTokenExpiresIn:
+          type: integer
+          format: int64
+          example: 1209600
+
+    AuthTokenData:
+      allOf:
+        - $ref: '#/components/schemas/TokenPair'
+        - type: object
+          required:
+            - user
+          properties:
+            user:
+              $ref: '#/components/schemas/AuthUser'
+
+    SignupData:
+      type: object
+      required:
+        - userId
+        - email
+        - nickname
+        - emailVerificationRequired
+        - emailVerificationSent
+      properties:
+        userId:
+          type: string
+          format: uuid
+          example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        nickname:
+          type: string
+          example: 도토리장인
+        emailVerificationRequired:
+          type: boolean
+          example: true
+        emailVerificationSent:
+          type: boolean
+          example: true
+
+    EmailAvailabilityData:
+      type: object
+      required:
+        - email
+        - available
+      properties:
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        available:
+          type: boolean
+          example: true
+
+    EmailVerificationSentData:
+      type: object
+      required:
+        - email
+        - expiresInSeconds
+      properties:
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        expiresInSeconds:
+          type: integer
+          format: int64
+          example: 1800
+
+    EmailVerificationConfirmData:
+      type: object
+      required:
+        - email
+        - verified
+      properties:
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        verified:
+          type: boolean
+          example: true
+
+    PasswordResetRequestedData:
+      type: object
+      required:
+        - email
+        - expiresInSeconds
+      properties:
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        expiresInSeconds:
+          type: integer
+          format: int64
+          example: 1800
+
+    KakaoAccountLinkRequiredData:
+      type: object
+      required:
+        - email
+        - provider
+        - linkToken
+        - expiresInSeconds
+      properties:
+        email:
+          type: string
+          format: email
+          example: user@example.com
+        provider:
+          $ref: '#/components/schemas/AuthProvider'
+        linkToken:
+          type: string
+          example: eyJraWQiOiJrYWthby1saW5rIn0
+        expiresInSeconds:
+          type: integer
+          format: int64
+          example: 600
+
+    KakaoNicknameRequiredData:
+      type: object
+      required:
+        - signupToken
+        - provider
+      properties:
+        signupToken:
+          type: string
+          example: eyJraWQiOiJrYWthby1zaWdudXAifQ
+        provider:
+          $ref: '#/components/schemas/AuthProvider'
+        suggestedNickname:
+          type: string
+          nullable: true
+          example: 카카오사용자
+
+    FieldError:
+      type: object
+      properties:
+        field:
+          type: string
+          example: email
+        reason:
+          type: string
+          example: 올바른 이메일 형식이 아닙니다.
+
+    ErrorData:
+      type: object
+      additionalProperties: true
+      properties:
+        fieldErrors:
+          type: array
+          items:
+            $ref: '#/components/schemas/FieldError'
+
+    UserStatus:
+      type: string
+      enum:
+        - active
+        - locked
+        - inactive
+      example: active
+
+    AuthProvider:
+      type: string
+      enum:
+        - local
+        - kakao
+        - apple
+      example: kakao
+
+    SignupResponse:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        code:
+          type: string
+          example: AUTH_SIGNUP_SUCCESS
+        message:
+          type: string
+          example: 회원가입이 완료되었습니다. 이메일 인증을 진행해주세요.
+        data:
+          $ref: '#/components/schemas/SignupData'
+
+    EmailAvailabilityResponse:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        code:
+          type: string
+          example: AUTH_EMAIL_AVAILABLE
+        message:
+          type: string
+          example: 사용 가능한 이메일입니다.
+        data:
+          $ref: '#/components/schemas/EmailAvailabilityData'
+
+    EmailVerificationSentResponse:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        code:
+          type: string
+          example: AUTH_EMAIL_VERIFICATION_SENT
+        message:
+          type: string
+          example: 이메일 인증 메일이 발송되었습니다.
+        data:
+          $ref: '#/components/schemas/EmailVerificationSentData'
+
+    EmailVerificationConfirmResponse:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        code:
+          type: string
+          example: AUTH_EMAIL_VERIFIED
+        message:
+          type: string
+          example: 이메일 인증이 완료되었습니다.
+        data:
+          $ref: '#/components/schemas/EmailVerificationConfirmData'
+
+    PasswordResetRequestedResponse:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        code:
+          type: string
+          example: AUTH_PASSWORD_RESET_REQUESTED
+        message:
+          type: string
+          example: 비밀번호 재설정 안내가 발송되었습니다.
+        data:
+          $ref: '#/components/schemas/PasswordResetRequestedData'
+
+    AuthTokenResponse:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        code:
+          type: string
+          example: AUTH_LOGIN_SUCCESS
+        message:
+          type: string
+          example: 로그인이 완료되었습니다.
+        data:
+          $ref: '#/components/schemas/AuthTokenData'
+
+    UserResponse:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        code:
+          type: string
+          example: AUTH_ME_SUCCESS
+        message:
+          type: string
+          example: 내 정보 조회가 완료되었습니다.
+        data:
+          $ref: '#/components/schemas/AuthUser'
+
+    KakaoAccountLinkRequiredResponse:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: false
+        code:
+          type: string
+          example: AUTH_OAUTH_ACCOUNT_LINK_REQUIRED
+        message:
+          type: string
+          example: 동일 이메일로 가입된 계정이 있습니다. 계정 연동이 필요합니다.
+        data:
+          $ref: '#/components/schemas/KakaoAccountLinkRequiredData'
+
+    KakaoNicknameRequiredResponse:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        code:
+          type: string
+          example: AUTH_NICKNAME_REQUIRED
+        message:
+          type: string
+          example: 닉네임 설정이 필요합니다.
+        data:
+          $ref: '#/components/schemas/KakaoNicknameRequiredData'
+
+    EmptySuccessResponse:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        code:
+          type: string
+          example: COMMON_SUCCESS
+        message:
+          type: string
+          example: 요청이 성공했습니다.
+        data:
+          type: object
+          nullable: true
+          additionalProperties: true
+          example: null
+
+    ErrorResponse:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: false
+        code:
+          type: string
+          example: COMMON_VALIDATION_ERROR
+        message:
+          type: string
+          example: 요청 값이 올바르지 않습니다.
+        data:
+          type: object
+          nullable: true
+          additionalProperties: true
+          example: null
+
+    RedisTemporaryTokenPolicy:
+      type: object
+      description: |
+        Redis 기반 임시 토큰/코드 저장 정책입니다.
+        실제 API 응답에 직접 포함되는 스키마는 아니며, 서버 내부 구현 정책 문서화 용도입니다.
+      properties:
+        emailVerificationCode:
+          type: string
+          description: 이메일 인증 코드 Redis Key
+          example: auth:email-verification:code:{email}
+        passwordResetCode:
+          type: string
+          description: 비밀번호 재설정 코드 Redis Key
+          example: auth:password-reset:code:{email}
+        kakaoSignupToken:
+          type: string
+          description: Kakao 최초 가입 임시 토큰 Redis Key
+          example: auth:kakao:signup:{signupToken}
+        kakaoLinkToken:
+          type: string
+          description: Kakao 계정 연동 임시 토큰 Redis Key
+          example: auth:kakao:link:{linkToken}
+        ttlSeconds:
+          type: integer
+          description: 기본 TTL
+          example: 600
+
+    HomeResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/HomeData'
+
+    HomeData:
+      type: object
+      required:
+        - user
+        - hero
+        - dDayCards
+        - subjects
+        - recentActivities
+      properties:
+        user:
+          $ref: '#/components/schemas/HomeUserSummary'
+        hero:
+          $ref: '#/components/schemas/HomeHero'
+        dDayCards:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubjectExamSchedule'
+        subjects:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubjectSummary'
+        recentActivities:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecentActivity'
+
+    HomeUserSummary:
+      type: object
+      required:
+        - nickname
+        - dotoriBalance
+        - xpTotal
+        - currentLevel
+      properties:
+        nickname:
+          type: string
+          example: 도토리장인
+        dotoriBalance:
+          type: integer
+          minimum: 0
+          example: 12
+        xpTotal:
+          type: integer
+          minimum: 0
+          example: 360
+        currentLevel:
+          type: integer
+          minimum: 1
+          maximum: 10
+          example: 3
+        levelName:
+          type: string
+          example: 펜굴리는 다람쥐
+
+    HomeHero:
+      type: object
+      properties:
+        hasActiveQuiz:
+          type: boolean
+          example: true
+        activeQuiz:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/RecentActivity'
+
+    RecentActivityListResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/RecentActivityPage'
+
+    RecentActivityPage:
+      allOf:
+        - $ref: '#/components/schemas/PageMeta'
+        - type: object
+          properties:
+            content:
+              type: array
+              items:
+                $ref: '#/components/schemas/RecentActivity'
+
+    RecentActivity:
+      type: object
+      required:
+        - activityId
+        - activityType
+        - title
+        - subjectId
+        - subjectName
+        - createdAt
+      properties:
+        activityId:
+          type: string
+          example: 018f8c2e-8123-72ab-96a1-f7c49c1d1111
+        activityType:
+          $ref: '#/components/schemas/RecentActivityType'
+        quizSessionId:
+          type: string
+          format: uuid
+          nullable: true
+          example: 018f8c2e-8123-72ab-96a1-f7c49c1d1111
+        playSessionId:
+          type: string
+          nullable: true
+          example: android-play-session-uuid
+        resultId:
+          type: string
+          format: uuid
+          nullable: true
+          example: 018f8c2e-9999-7b11-b2d1-774f4c1c2222
+        title:
+          type: string
+          example: 데이터베이스 객관식 10문제
+        subjectId:
+          type: string
+          format: uuid
+          example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+        subjectName:
+          type: string
+          example: 데이터베이스
+        status:
+          type: string
+          nullable: true
+          example: completed
+        progressPct:
+          type: integer
+          minimum: 0
+          maximum: 100
+          nullable: true
+          example: 80
+        scoreText:
+          type: string
+          nullable: true
+          example: 8/10
+        createdAt:
+          type: string
+          format: date-time
+          example: '2026-05-19T07:30:00+09:00'
+
+    RecentActivityType:
+      type: string
+      enum:
+        - quiz_generating
+        - quiz_ready
+        - quiz_in_progress
+        - quiz_completed
+        - lecture_uploaded
+      example: quiz_completed
+
+    SubjectListResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/SubjectPage'
+
+    SubjectPage:
+      allOf:
+        - $ref: '#/components/schemas/PageMeta'
+        - type: object
+          properties:
+            content:
+              type: array
+              items:
+                $ref: '#/components/schemas/SubjectSummary'
+
+    SubjectResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/Subject'
+
+    SubjectDetailResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/SubjectDetail'
+
+    SubjectSummary:
+      type: object
+      required:
+        - id
+        - name
+        - purpose
+        - chapterCount
+        - partCount
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+        name:
+          type: string
+          minLength: 1
+          maxLength: 30
+          example: 데이터베이스
+        purpose:
+          $ref: '#/components/schemas/SubjectPurpose'
+        chapterCount:
+          type: integer
+          minimum: 0
+          example: 3
+        partCount:
+          type: integer
+          minimum: 0
+          example: 12
+        lastActivityAt:
+          type: string
+          format: date-time
+          nullable: true
+          example: '2026-05-19T07:30:00+09:00'
+        examSchedule:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/SubjectExamSchedule'
+
+    Subject:
+      type: object
+      required:
+        - id
+        - name
+        - purpose
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+        name:
+          type: string
+          minLength: 1
+          maxLength: 30
+          example: 데이터베이스
+        purpose:
+          $ref: '#/components/schemas/SubjectPurpose'
+        detail:
+          $ref: '#/components/schemas/SubjectPurposeDetail'
+        createdAt:
+          type: string
+          format: date-time
+          example: '2026-05-19T07:30:00+09:00'
+
+    SubjectDetail:
+      allOf:
+        - $ref: '#/components/schemas/Subject'
+        - type: object
+          properties:
+            examSchedule:
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/SubjectExamSchedule'
+            chapters:
+              type: array
+              items:
+                $ref: '#/components/schemas/ChapterWithParts'
+
+    SubjectCreateRequest:
+      type: object
+      required:
+        - name
+        - purpose
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 30
+          example: 데이터베이스
+        purpose:
+          $ref: '#/components/schemas/SubjectPurpose'
+        examDetail:
+          $ref: '#/components/schemas/SubjectExamDetailRequest'
+        reviewDetail:
+          $ref: '#/components/schemas/SubjectReviewDetailRequest'
+        otherDetail:
+          $ref: '#/components/schemas/SubjectOtherDetailRequest'
+
+    SubjectDetailUpdateRequest:
+      allOf:
+        - $ref: '#/components/schemas/SubjectCreateRequest'
+
+    SubjectNameUpdateRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 30
+          example: 데이터베이스 심화
+
+    SubjectPurpose:
+      type: string
+      enum:
+        - exam
+        - review
+        - other
+      example: exam
+
+    SubjectPurposeDetail:
+      type: object
+      nullable: true
+      description: purpose 값에 따라 examDetail/reviewDetail/otherDetail 중 하나가 내려옵니다.
+      properties:
+        examDetail:
+          $ref: '#/components/schemas/SubjectExamDetail'
+        reviewDetail:
+          $ref: '#/components/schemas/SubjectReviewDetail'
+        otherDetail:
+          $ref: '#/components/schemas/SubjectOtherDetail'
+
+    SubjectExamDetailRequest:
+      type: object
+      required:
+        - examType
+      properties:
+        examType:
+          $ref: '#/components/schemas/ExamType'
+        univMajorField:
+          type: string
+          nullable: true
+          example: engineering
+        univMajorName:
+          type: string
+          nullable: true
+          maxLength: 30
+          example: 컴퓨터공학
+        univCourseType:
+          type: string
+          nullable: true
+          enum:
+            - major
+            - liberal_arts
+          example: major
+        mhGrade:
+          type: string
+          nullable: true
+          example: 고2
+        mhSubjectType:
+          type: string
+          nullable: true
+          maxLength: 30
+          example: 수학
+        certificateId:
+          type: string
+          nullable: true
+          example: '42'
+        certificateName:
+          type: string
+          nullable: true
+          maxLength: 100
+          example: SQLD
+        civilRank:
+          type: string
+          nullable: true
+          example: 9급
+        civilSeries:
+          type: string
+          nullable: true
+          example: 일반행정
+        langType:
+          type: string
+          nullable: true
+          enum:
+            - english
+            - japanese
+            - chinese
+          example: english
+        langExamName:
+          type: string
+          nullable: true
+          maxLength: 30
+          example: TOEIC
+        otherExamName:
+          type: string
+          nullable: true
+          maxLength: 30
+          example: 사내 승진시험
+
+    SubjectExamDetail:
+      allOf:
+        - $ref: '#/components/schemas/SubjectExamDetailRequest'
+
+    ExamType:
+      type: string
+      enum:
+        - university
+        - middle_high
+        - certificate
+        - civil_service
+        - language
+        - other_exam
+      example: university
+
+    SubjectReviewDetailRequest:
+      type: object
+      required:
+        - field
+        - studyLevel
+      properties:
+        field:
+          type: string
+          maxLength: 30
+          example: IT
+        studyLevel:
+          type: string
+          enum:
+            - beginner
+            - casual
+            - regular
+            - expert
+          example: beginner
+
+    SubjectReviewDetail:
+      allOf:
+        - $ref: '#/components/schemas/SubjectReviewDetailRequest'
+
+    SubjectOtherDetailRequest:
+      type: object
+      required:
+        - usagePurpose
+      properties:
+        usagePurpose:
+          type: string
+          enum:
+            - work
+            - personal
+            - hobby
+            - memory
+            - other
+          example: work
+        description:
+          type: string
+          nullable: true
+          minLength: 1
+          maxLength: 100
+          example: 업무 지식 정리용
+
+    SubjectOtherDetail:
+      allOf:
+        - $ref: '#/components/schemas/SubjectOtherDetailRequest'
+
+    SubjectExamScheduleUpsertRequest:
+      type: object
+      required:
+        - examDate
+      properties:
+        examName:
+          type: string
+          nullable: true
+          maxLength: 100
+          example: 중간고사
+        examDate:
+          type: string
+          format: date
+          example: '2026-06-30'
+
+    SubjectExamScheduleResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/SubjectExamSchedule'
+
+    SubjectExamSchedule:
+      type: object
+      required:
+        - id
+        - subjectId
+        - examName
+        - examDate
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 018f8c2e-1234-7abc-91c1-000000000001
+        subjectId:
+          type: string
+          format: uuid
+          example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+        examName:
+          type: string
+          example: 중간고사
+        examDate:
+          type: string
+          format: date
+          example: '2026-06-30'
+        dDay:
+          type: integer
+          nullable: true
+          description: 오늘 기준 남은 일수. 시험일이 지난 경우 null
+          example: 3
+
+    CertificateListResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              type: array
+              items:
+                $ref: '#/components/schemas/Certificate'
+
+    Certificate:
+      type: object
+      required:
+        - id
+        - name
+        - featured
+        - displayOrder
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: 정보처리기사
+        featured:
+          type: boolean
+          example: true
+        displayOrder:
+          type: integer
+          example: 10
+
+    ChapterNameUpdateRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 30
+          example: 1장 데이터 모델링
+
+    ChapterResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/Chapter'
+
+    Chapter:
+      type: object
+      required:
+        - id
+        - subjectId
+        - name
+        - displayOrder
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 018f8c2e-6a10-7ca2-8a4b-52f3b4b7a100
+        subjectId:
+          type: string
+          format: uuid
+          example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+        name:
+          type: string
+          example: 1장 데이터 모델링
+        displayOrder:
+          type: integer
+          example: 1
+
+    ChapterWithParts:
+      allOf:
+        - $ref: '#/components/schemas/Chapter'
+        - type: object
+          properties:
+            parts:
+              type: array
+              items:
+                $ref: '#/components/schemas/PartSummary'
+
+    LectureTextUploadRequest:
+      type: object
+      required:
+        - subjectId
+        - chapterName
+        - uploadType
+        - partSplitMethod
+        - text
+      properties:
+        subjectId:
+          type: string
+          format: uuid
+          example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+        chapterName:
+          type: string
+          minLength: 1
+          maxLength: 30
+          example: 1장 데이터 모델링
+        uploadType:
+          type: string
+          enum:
+            - text
+          example: text
+        partSplitMethod:
+          $ref: '#/components/schemas/PartSplitMethod'
+        text:
+          type: string
+          minLength: 100
+          maxLength: 30000
+          example: 데이터 모델링은 현실 세계의 데이터를 추상화하여 구조화하는 과정입니다...
+        partSplitPlans:
+          type: array
+          nullable: true
+          items:
+            $ref: '#/components/schemas/PartSplitPlanRequest'
+
+    LectureFileUploadRequest:
+      type: object
+      required:
+        - subjectId
+        - chapterName
+        - uploadType
+        - partSplitMethod
+        - files
+      properties:
+        subjectId:
+          type: string
+          format: uuid
+        chapterName:
+          type: string
+          minLength: 1
+          maxLength: 30
+        uploadType:
+          type: string
+          enum:
+            - pdf
+            - image
+          example: pdf
+        partSplitMethod:
+          $ref: '#/components/schemas/PartSplitMethod'
+        files:
+          type: array
+          description: PDF는 1개, 이미지는 여러 장 선택 가능. 총 파일 크기 정책은 MVP 기준 50MB 이하입니다.
+          items:
+            type: string
+            format: binary
+        partSplitPlansJson:
+          type: string
+          nullable: true
+          description: multipart 요청에서 직접 분류 파트 계획을 JSON 문자열로 전달합니다.
+          example: '[{"partNumber":1,"intendedName":"데이터 모델링 개념"}]'
+
+    PartTextAddRequest:
+      type: object
+      required:
+        - partName
+        - uploadType
+        - text
+      properties:
+        partName:
+          type: string
+          minLength: 1
+          maxLength: 100
+          example: 데이터 모델링 특징
+        uploadType:
+          type: string
+          enum:
+            - text
+          example: text
+        text:
+          type: string
+          minLength: 100
+          maxLength: 30000
+          example: 데이터 모델링의 주요 특징은 추상화, 단순화, 명확화입니다...
+
+    PartFileAddRequest:
+      type: object
+      required:
+        - partName
+        - uploadType
+        - files
+      properties:
+        partName:
+          type: string
+          minLength: 1
+          maxLength: 100
+          example: 데이터 모델링 특징
+        uploadType:
+          type: string
+          enum:
+            - pdf
+            - image
+          example: pdf
+        files:
+          type: array
+          items:
+            type: string
+            format: binary
+
+    LectureUploadAcceptedResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/LectureUploadAcceptedData'
+
+    LectureUploadAcceptedData:
+      type: object
+      required:
+        - lectureUploadId
+        - subjectId
+        - chapterId
+        - status
+      properties:
+        lectureUploadId:
+          type: string
+          format: uuid
+          example: 018f8c2e-7123-7af4-9b72-b1d93c401f41
+        subjectId:
+          type: string
+          format: uuid
+          example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+        chapterId:
+          type: string
+          format: uuid
+          example: 018f8c2e-6a10-7ca2-8a4b-52f3b4b7a100
+        status:
+          $ref: '#/components/schemas/LectureUploadStatus'
+        estimatedSeconds:
+          type: integer
+          nullable: true
+          example: 30
+
+    LectureUploadStatusResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/LectureUploadStatusData'
+
+    LectureUploadStatusData:
+      allOf:
+        - $ref: '#/components/schemas/LectureUploadAcceptedData'
+        - type: object
+          properties:
+            progressPct:
+              type: integer
+              minimum: 0
+              maximum: 100
+              example: 100
+            parts:
+              type: array
+              items:
+                $ref: '#/components/schemas/PartSummary'
+            failReason:
+              type: string
+              nullable: true
+              example: OCR 처리 실패
+
+    LectureUploadStatus:
+      type: string
+      enum:
+        - pending
+        - processing
+        - completed
+        - failed
+      example: processing
+
+    PartSplitMethod:
+      type: string
+      enum:
+        - auto
+        - manual
+      example: auto
+
+    PartSplitPlanRequest:
+      type: object
+      required:
+        - partNumber
+      properties:
+        partNumber:
+          type: integer
+          minimum: 1
+          example: 1
+        intendedName:
+          type: string
+          nullable: true
+          maxLength: 100
+          example: 데이터 모델링 개념
+
+    PartResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/Part'
+
+    PartSummary:
+      type: object
+      required:
+        - id
+        - chapterId
+        - name
+        - partNumber
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 018f8c2e-7001-7d4e-9404-4440c3f4ad21
+        chapterId:
+          type: string
+          format: uuid
+          example: 018f8c2e-6a10-7ca2-8a4b-52f3b4b7a100
+        name:
+          type: string
+          example: 데이터 모델링 개념
+        partNumber:
+          type: integer
+          minimum: 1
+          example: 1
+        contentPreview:
+          type: string
+          nullable: true
+          example: 데이터 모델링은 현실 세계의 데이터를...
+
+    Part:
+      allOf:
+        - $ref: '#/components/schemas/PartSummary'
+        - type: object
+          required:
+            - content
+          properties:
+            subjectId:
+              type: string
+              format: uuid
+              example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+            lectureUploadId:
+              type: string
+              format: uuid
+              nullable: true
+              example: 018f8c2e-7123-7af4-9b72-b1d93c401f41
+            content:
+              type: string
+              nullable: true
+              maxLength: 30000
+              example: 데이터 모델링은 현실 세계의 데이터를 추상화하여 구조화하는 과정입니다.
+
+    PartUpdateRequest:
+      type: object
+      required:
+        - name
+        - content
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 100
+          example: 데이터 모델링 개념
+        content:
+          type: string
+          maxLength: 30000
+          example: 데이터 모델링은 현실 세계의 데이터를 추상화하여 구조화하는 과정입니다.
+
+    QuizScopeResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/QuizScopeData'
+
+    QuizScopeData:
+      type: object
+      required:
+        - subjectId
+        - subjectName
+        - chapters
+      properties:
+        subjectId:
+          type: string
+          format: uuid
+        subjectName:
+          type: string
+          example: 데이터베이스
+        chapters:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChapterWithParts'
+
+    QuizCreateRequest:
+      type: object
+      required:
+        - subjectId
+        - partIds
+        - quizType
+        - questionCount
+        - playMode
+        - difficulty
+      properties:
+        subjectId:
+          type: string
+          format: uuid
+          example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+        partIds:
+          type: array
+          minItems: 1
+          items:
+            type: string
+            format: uuid
+          example:
+            - 018f8c2e-7001-7d4e-9404-4440c3f4ad21
+            - 018f8c2e-7002-7d4e-9404-4440c3f4ad22
+        quizType:
+          $ref: '#/components/schemas/QuizType'
+        choiceCount:
+          type: integer
+          nullable: true
+          enum:
+            - 4
+            - 5
+          example: 4
+        questionCount:
+          type: integer
+          minimum: 1
+          maximum: 100
+          example: 10
+        playMode:
+          $ref: '#/components/schemas/QuizPlayMode'
+        timerEnabled:
+          type: boolean
+          default: false
+          example: true
+        timerScope:
+          type: string
+          nullable: true
+          enum:
+            - per_question
+            - total
+          example: per_question
+        timerSeconds:
+          type: integer
+          nullable: true
+          minimum: 1
+          example: 60
+        difficulty:
+          $ref: '#/components/schemas/QuizDifficulty'
+
+    QuizGenerationAcceptedResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/QuizGenerationAcceptedData'
+
+    QuizGenerationAcceptedData:
+      type: object
+      required:
+        - quizSessionId
+        - jobId
+        - status
+      properties:
+        quizSessionId:
+          type: string
+          format: uuid
+          example: 018f8c2e-8123-72ab-96a1-f7c49c1d1111
+        jobId:
+          type: string
+          example: quiz-job-018f8c2e
+        status:
+          $ref: '#/components/schemas/QuizGenerationStatus'
+        estimatedSeconds:
+          type: integer
+          nullable: true
+          example: 45
+
+    QuizGenerationStatusResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/QuizGenerationStatusData'
+
+    QuizGenerationStatusData:
+      allOf:
+        - $ref: '#/components/schemas/QuizGenerationAcceptedData'
+        - type: object
+          properties:
+            progressPct:
+              type: integer
+              minimum: 0
+              maximum: 100
+              example: 100
+            generatedCount:
+              type: integer
+              nullable: true
+              example: 8
+            failReason:
+              type: string
+              nullable: true
+              example: 텍스트 길이 부족
+
+    QuizSessionResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/QuizSession'
+
+    QuizSession:
+      type: object
+      required:
+        - id
+        - subjectId
+        - quizType
+        - questionCount
+        - playMode
+        - difficulty
+        - status
+        - questions
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 018f8c2e-8123-72ab-96a1-f7c49c1d1111
+        subjectId:
+          type: string
+          format: uuid
+        subjectName:
+          type: string
+          example: 데이터베이스
+        quizType:
+          $ref: '#/components/schemas/QuizType'
+        choiceCount:
+          type: integer
+          nullable: true
+          example: 4
+        questionCount:
+          type: integer
+          example: 10
+        playMode:
+          $ref: '#/components/schemas/QuizPlayMode'
+        timerEnabled:
+          type: boolean
+          example: true
+        timerScope:
+          type: string
+          nullable: true
+          example: per_question
+        timerSeconds:
+          type: integer
+          nullable: true
+          example: 60
+        difficulty:
+          $ref: '#/components/schemas/QuizDifficulty'
+        status:
+          $ref: '#/components/schemas/QuizGenerationStatus'
+        questions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Question'
+
+    Question:
+      type: object
+      required:
+        - id
+        - questionType
+        - difficulty
+        - body
+        - displayOrder
+        - answer
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: 018f8c2e-9001-7bc4-8211-777777777001
+        subjectId:
+          type: string
+          format: uuid
+        chapterId:
+          type: string
+          format: uuid
+        partId:
+          type: string
+          format: uuid
+        partName:
+          type: string
+          example: 데이터 모델링 개념
+        questionType:
+          $ref: '#/components/schemas/QuizType'
+        difficulty:
+          $ref: '#/components/schemas/QuizDifficulty'
+        summary:
+          type: string
+          nullable: true
+          minLength: 8
+          maxLength: 20
+          example: 모델링의 특징
+        body:
+          type: string
+          example: 다음 중 데이터 모델링의 특징으로 올바른 것은?
+        correctExplanation:
+          type: string
+          nullable: true
+          example: 데이터 모델링은 복잡한 현실 데이터를 추상화하고 단순화합니다.
+        incorrectExplanation:
+          type: string
+          nullable: true
+          example: 선택지는 데이터 모델링의 핵심 특징과 맞지 않습니다.
+        displayOrder:
+          type: integer
+          minimum: 1
+          example: 1
+        options:
+          type: array
+          items:
+            $ref: '#/components/schemas/QuestionOption'
+        answer:
+          $ref: '#/components/schemas/QuestionAnswer'
+
+    QuestionOption:
+      type: object
+      required:
+        - id
+        - optionNumber
+        - content
+      properties:
+        id:
+          type: string
+          example: '1'
+        optionNumber:
+          type: integer
+          minimum: 1
+          maximum: 5
+          example: 1
+        content:
+          type: string
+          example: 추상화
+
+    QuestionAnswer:
+      type: object
+      required:
+        - answerValue
+      properties:
+        answerValue:
+          type: string
+          example: '1'
+
+    QuizPlayStartRequest:
+      type: object
+      required:
+        - clientSessionId
+        - playType
+      properties:
+        clientSessionId:
+          type: string
+          maxLength: 36
+          example: android-play-session-uuid
+        playType:
+          $ref: '#/components/schemas/QuizPlayType'
+        parentPlaySessionId:
+          type: string
+          nullable: true
+          example: parent-play-session-uuid
+        questionShuffled:
+          type: boolean
+          default: false
+          example: false
+        optionShuffled:
+          type: boolean
+          default: true
+          example: true
+        shuffleSeed:
+          type: string
+          nullable: true
+          example: seed-1234
+
+    QuizPlaySessionResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/QuizPlaySession'
+
+    QuizPlaySession:
+      type: object
+      required:
+        - playSessionId
+        - clientSessionId
+        - quizSessionId
+        - playType
+        - status
+      properties:
+        playSessionId:
+          type: string
+          example: android-play-session-uuid
+        clientSessionId:
+          type: string
+          example: android-play-session-uuid
+        quizSessionId:
+          type: string
+          format: uuid
+        playType:
+          $ref: '#/components/schemas/QuizPlayType'
+        status:
+          type: string
+          enum:
+            - in_progress
+            - submitted
+            - abandoned
+          example: in_progress
+        quizSession:
+          $ref: '#/components/schemas/QuizSession'
+
+    QuizResultSubmitRequest:
+      type: object
+      required:
+        - clientSessionId
+        - quizSessionId
+        - playType
+        - elapsedMs
+        - answers
+      properties:
+        clientSessionId:
+          type: string
+          maxLength: 36
+          example: android-play-session-uuid
+        quizSessionId:
+          type: string
+          format: uuid
+          example: 018f8c2e-8123-72ab-96a1-f7c49c1d1111
+        playType:
+          $ref: '#/components/schemas/QuizPlayType'
+        parentPlaySessionId:
+          type: string
+          nullable: true
+          example: parent-play-session-uuid
+        elapsedMs:
+          type: integer
+          minimum: 0
+          example: 430000
+        questionShuffled:
+          type: boolean
+          example: false
+        optionShuffled:
+          type: boolean
+          example: true
+        shuffleSeed:
+          type: string
+          nullable: true
+          example: seed-1234
+        answers:
+          type: array
+          minItems: 1
+          items:
+            $ref: '#/components/schemas/QuizAnswerSubmitItem'
+
+    QuizAnswerSubmitItem:
+      type: object
+      required:
+        - questionId
+        - skipped
+      properties:
+        questionId:
+          type: string
+          format: uuid
+          example: 018f8c2e-9001-7bc4-8211-777777777001
+        selectedOptionId:
+          type: string
+          nullable: true
+          example: '2'
+        selectedValue:
+          type: string
+          nullable: true
+          example: O
+        correctClient:
+          type: boolean
+          nullable: true
+          example: true
+        skipped:
+          type: boolean
+          example: false
+        answerElapsedMs:
+          type: integer
+          nullable: true
+          minimum: 0
+          example: 15000
+        marked:
+          type: boolean
+          default: false
+          example: false
+
+    QuizResultResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/QuizResult'
+
+    QuizResult:
+      type: object
+      required:
+        - playSessionId
+        - quizSessionId
+        - subjectId
+        - totalCount
+        - correctCount
+        - wrongCount
+        - skipCount
+        - accuracyPct
+        - elapsedMs
+        - rewards
+        - reviewItems
+      properties:
+        playSessionId:
+          type: string
+          example: android-play-session-uuid
+        quizSessionId:
+          type: string
+          format: uuid
+        subjectId:
+          type: string
+          format: uuid
+        subjectName:
+          type: string
+          example: 데이터베이스
+        totalCount:
+          type: integer
+          example: 10
+        correctCount:
+          type: integer
+          example: 8
+        wrongCount:
+          type: integer
+          example: 2
+        skipCount:
+          type: integer
+          example: 0
+        accuracyPct:
+          type: integer
+          minimum: 0
+          maximum: 100
+          example: 80
+        elapsedMs:
+          type: integer
+          example: 430000
+        scoreMatched:
+          type: boolean
+          example: true
+        abuseFlagged:
+          type: boolean
+          example: false
+        rewards:
+          $ref: '#/components/schemas/RewardSummary'
+        reviewItems:
+          type: array
+          items:
+            $ref: '#/components/schemas/QuizReviewItem'
+        retryAvailable:
+          $ref: '#/components/schemas/RetryAvailable'
+        createdAt:
+          type: string
+          format: date-time
+          example: '2026-05-19T07:30:00+09:00'
+
+    QuizReviewResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              type: object
+              required:
+                - playSessionId
+                - items
+              properties:
+                playSessionId:
+                  type: string
+                  example: android-play-session-uuid
+                items:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/QuizReviewItem'
+
+    QuizReviewItem:
+      type: object
+      required:
+        - questionId
+        - displayOrder
+        - body
+        - correctServer
+      properties:
+        questionId:
+          type: string
+          format: uuid
+        displayOrder:
+          type: integer
+          example: 1
+        summary:
+          type: string
+          nullable: true
+          example: 모델링의 특징
+        body:
+          type: string
+          example: 다음 중 데이터 모델링의 특징으로 올바른 것은?
+        options:
+          type: array
+          items:
+            $ref: '#/components/schemas/QuestionOption'
+        selectedOptionId:
+          type: string
+          nullable: true
+          example: '2'
+        selectedValue:
+          type: string
+          nullable: true
+          example: O
+        answerValue:
+          type: string
+          example: '1'
+        correctServer:
+          type: boolean
+          example: false
+        skipped:
+          type: boolean
+          example: false
+        correctExplanation:
+          type: string
+          nullable: true
+          example: 데이터 모델링은 복잡한 현실 데이터를 추상화합니다.
+        incorrectExplanation:
+          type: string
+          nullable: true
+          example: 선택한 답은 데이터 모델링의 핵심 특징과 맞지 않습니다.
+        sourcePart:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/PartSummary'
+
+    QuizRetryRequest:
+      type: object
+      required:
+        - clientSessionId
+      properties:
+        clientSessionId:
+          type: string
+          maxLength: 36
+          example: android-retry-session-uuid
+        questionShuffled:
+          type: boolean
+          example: false
+        optionShuffled:
+          type: boolean
+          example: true
+        shuffleSeed:
+          type: string
+          nullable: true
+          example: seed-5678
+
+    RewardSummary:
+      type: object
+      required:
+        - dotoriEarned
+        - xpEarned
+        - leveledUp
+      properties:
+        dotoriEarned:
+          type: integer
+          minimum: 0
+          example: 8
+        xpEarned:
+          type: integer
+          minimum: 0
+          example: 32
+        leveledUp:
+          type: boolean
+          example: true
+        newLevel:
+          type: integer
+          nullable: true
+          minimum: 1
+          maximum: 10
+          example: 3
+        currentDotoriBalance:
+          type: integer
+          minimum: 0
+          example: 20
+        currentXpTotal:
+          type: integer
+          minimum: 0
+          example: 360
+
+    RetryAvailable:
+      type: object
+      properties:
+        retryAll:
+          type: boolean
+          example: true
+        retryWrong:
+          type: boolean
+          example: true
+        wrongCount:
+          type: integer
+          example: 2
+
+    GamificationResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/GamificationData'
+
+    GamificationData:
+      type: object
+      required:
+        - dotoriBalance
+        - xpTotal
+        - currentLevel
+        - maxLevel
+      properties:
+        dotoriBalance:
+          type: integer
+          minimum: 0
+          example: 20
+        xpTotal:
+          type: integer
+          minimum: 0
+          example: 360
+        currentLevel:
+          type: integer
+          minimum: 1
+          maximum: 10
+          example: 3
+        currentLevelName:
+          type: string
+          example: 펜굴리는 다람쥐
+        maxLevel:
+          type: integer
+          example: 10
+        nextLevel:
+          type: integer
+          nullable: true
+          example: 4
+        nextLevelName:
+          type: string
+          nullable: true
+          example: 노력형 다람쥐
+        currentLevelMinXp:
+          type: integer
+          example: 350
+        nextLevelRequiredXp:
+          type: integer
+          nullable: true
+          example: 850
+        levelProgressPct:
+          type: integer
+          minimum: 0
+          maximum: 100
+          example: 25
+
+    MyProfileResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/MyProfile'
+
+    MyProfile:
+      allOf:
+        - $ref: '#/components/schemas/AuthUser'
+        - type: object
+          properties:
+            xpTotal:
+              type: integer
+              example: 360
+            currentLevel:
+              type: integer
+              example: 3
+            createdAt:
+              type: string
+              format: date-time
+              example: '2026-05-19T07:30:00+09:00'
+
+    NicknameUpdateRequest:
+      type: object
+      required:
+        - nickname
+      properties:
+        nickname:
+          type: string
+          minLength: 2
+          maxLength: 16
+          pattern: '^[가-힣A-Za-z0-9]{2,16}$'
+          example: 도토리장인
+
+    PasswordChangeRequest:
+      type: object
+      required:
+        - currentPassword
+        - newPassword
+        - newPasswordConfirm
+      properties:
+        currentPassword:
+          type: string
+          example: Password123!
+        newPassword:
+          type: string
+          minLength: 8
+          maxLength: 64
+          pattern: '^(?=.*[A-Za-z])(?=.*\d).{8,64}$'
+          example: NewPassword123!
+        newPasswordConfirm:
+          type: string
+          minLength: 8
+          maxLength: 64
+          example: NewPassword123!
+
+    AccountDeleteRequest:
+      type: object
+      required:
+        - agreedToDelete
+      properties:
+        password:
+          type: string
+          nullable: true
+          description: Local 계정인 경우 확인용 비밀번호
+          example: Password123!
+        agreedToDelete:
+          type: boolean
+          example: true
+
+    NotificationSettingsResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/NotificationSettings'
+
+    NotificationSettings:
+      type: object
+      required:
+        - activityEnabled
+        - updateEnabled
+        - reviewEnabled
+      properties:
+        fcmTokenRegistered:
+          type: boolean
+          example: true
+        activityEnabled:
+          type: boolean
+          example: true
+        updateEnabled:
+          type: boolean
+          example: true
+        reviewEnabled:
+          type: boolean
+          example: true
+
+    NotificationSettingsUpdateRequest:
+      type: object
+      required:
+        - activityEnabled
+        - updateEnabled
+        - reviewEnabled
+      properties:
+        activityEnabled:
+          type: boolean
+          example: true
+        updateEnabled:
+          type: boolean
+          example: true
+        reviewEnabled:
+          type: boolean
+          example: true
+
+    FcmTokenUpdateRequest:
+      type: object
+      required:
+        - fcmToken
+      properties:
+        fcmToken:
+          type: string
+          maxLength: 255
+          example: fcm-token-from-android
+
+    FeedbackCreateRequest:
+      type: object
+      required:
+        - category
+        - body
+      properties:
+        category:
+          type: string
+          enum:
+            - feature
+            - bug
+            - inquiry
+            - other
+          example: feature
+        body:
+          type: string
+          minLength: 1
+          maxLength: 1000
+          example: 퀴즈 결과 화면에서 복습 알림을 받을 수 있으면 좋겠어요.
+        replyEmail:
+          type: string
+          format: email
+          nullable: true
+          example: user@example.com
+        appVersion:
+          type: string
+          nullable: true
+          example: 1.0.0
+        osVersion:
+          type: string
+          nullable: true
+          example: Android 15
+        deviceModel:
+          type: string
+          nullable: true
+          example: Galaxy S24
+
+    FeedbackResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiSuccessBase'
+        - type: object
+          properties:
+            data:
+              $ref: '#/components/schemas/Feedback'
+
+    Feedback:
+      allOf:
+        - $ref: '#/components/schemas/FeedbackCreateRequest'
+        - type: object
+          required:
+            - id
+            - createdAt
+          properties:
+            id:
+              type: string
+              example: '1'
+            createdAt:
+              type: string
+              format: date-time
+              example: '2026-05-19T07:30:00+09:00'
+
+    QuizType:
+      type: string
+      enum:
+        - multiple_choice
+        - ox
+      example: multiple_choice
+
+    QuizPlayMode:
+      type: string
+      enum:
+        - one_by_one
+        - all_at_once
+      example: one_by_one
+
+    QuizDifficulty:
+      type: string
+      enum:
+        - easy
+        - medium
+        - hard
+      example: medium
+
+    QuizGenerationStatus:
+      type: string
+      enum:
+        - pending
+        - in_progress
+        - completed
+        - failed
+      example: completed
+
+    QuizPlayType:
+      type: string
+      enum:
+        - first
+        - retry_all
+        - retry_wrong
+      example: first
+
+    ApiSuccessBase:
+      type: object
+      required:
+        - success
+        - code
+        - message
+        - data
+      properties:
+        success:
+          type: boolean
+          example: true
+        code:
+          type: string
+          example: COMMON_SUCCESS
+        message:
+          type: string
+          example: 요청이 성공했습니다.
+        data:
+          nullable: true
+
+    PageMeta:
+      type: object
+      required:
+        - content
+        - page
+        - size
+        - totalElements
+        - totalPages
+        - hasNext
+      properties:
+        page:
+          type: integer
+          example: 0
+        size:
+          type: integer
+          example: 10
+        totalElements:
+          type: integer
+          format: int64
+          example: 42
+        totalPages:
+          type: integer
+          example: 5
+        hasNext:
+          type: boolean
+          example: true


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- Swagger Editor에서 확인 가능한 Quiket MVP API 명세서를 추가했습니다.
- 기존 Auth API 명세를 유지하면서 MVP 범위의 홈, 과목, 강의 업로드, 파트, 퀴즈, 결과, 게임화, 마이페이지 API를 확장했습니다.

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `docs/openapi/quiket-mvp-api.yaml` 추가
- 공통 응답 형식과 JWT Bearer 인증 스키마 문서화
- MVP 범위 API path, request, response schema 작성
- `DELETE` requestBody 경고 방지를 위해 회원 탈퇴 요청을 `POST /my/account/deletion`으로 명세

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. Swagger Editor에 `docs/openapi/quiket-mvp-api.yaml` 전체 붙여넣기
2. OpenAPI 문서 렌더링 확인
3. YAML/OpenAPI validation 통과 확인

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #18

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 전체/v2 API 명세는 DDL 전체 확정 이후 별도 작업으로 진행합니다.
- 이메일 인증/비밀번호 재설정 TTL 등 정책값은 구현 단계에서 최종 확정 필요합니다.

---

## 🧑‍💻 Assignee

- @imclaremont
