### PR TITLE
[Feat] Auth 도메인 DB 스키마 적용 및 JPA Entity 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	// Database
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-mysql'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	// CI 테스트 DB
 	testRuntimeOnly 'com.h2database:h2'

--- a/src/main/java/com/f1/quiket/domain/auth/entity/UserAuthIdentity.java
+++ b/src/main/java/com/f1/quiket/domain/auth/entity/UserAuthIdentity.java
@@ -1,0 +1,70 @@
+package com.f1.quiket.domain.auth.entity;
+
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 사용자 인증 수단 엔티티
+ */
+@Entity
+@Table(
+        name = "user_auth_identities",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_user_auth_identities_provider_subject",
+                        columnNames = {"provider", "provider_subject"}
+                ),
+                @UniqueConstraint(
+                        name = "uq_user_auth_identities_user_id_provider",
+                        columnNames = {"user_id", "provider"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_user_auth_identities_user_id_created_at", columnList = "user_id, created_at"),
+                @Index(name = "idx_user_auth_identities_provider_created_at", columnList = "provider, created_at")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserAuthIdentity extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_user_auth_identities_user_id")
+    )
+    User user;
+
+    @Column(name = "provider", length = 20, nullable = false)
+    String provider;
+
+    @Column(name = "provider_subject", length = 255, nullable = false)
+    String providerSubject = "";
+
+    @Column(name = "password_hash", length = 255)
+    String passwordHash;
+
+    @Column(name = "is_primary", nullable = false)
+    boolean primary = false;
+
+    @Column(name = "last_login_at")
+    LocalDateTime lastLoginAt;
+}

--- a/src/main/java/com/f1/quiket/domain/auth/entity/UserEmailVerification.java
+++ b/src/main/java/com/f1/quiket/domain/auth/entity/UserEmailVerification.java
@@ -1,0 +1,73 @@
+package com.f1.quiket.domain.auth.entity;
+
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 이메일 인증 요청 이력 엔티티
+ */
+@Entity
+@Table(
+        name = "user_email_verifications",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_user_email_verifications_verification_token",
+                        columnNames = "verification_token"
+                )
+        },
+        indexes = {
+                @Index(name = "idx_user_email_verifications_user_id_status", columnList = "user_id, status"),
+                @Index(name = "idx_user_email_verifications_email_status", columnList = "email, status"),
+                @Index(name = "idx_user_email_verifications_expires_at", columnList = "expires_at")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserEmailVerification extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_user_email_verifications_user_id")
+    )
+    User user;
+
+    @Column(name = "email", length = 255, nullable = false)
+    String email;
+
+    @Column(name = "verification_token", length = 255, nullable = false)
+    String verificationToken;
+
+    @Column(name = "verification_code", length = 20)
+    String verificationCode;
+
+    @Column(name = "status", length = 20, nullable = false)
+    String status = "pending";
+
+    @Column(name = "requested_at", nullable = false)
+    LocalDateTime requestedAt = LocalDateTime.now();
+
+    @Column(name = "verified_at")
+    LocalDateTime verifiedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    LocalDateTime expiresAt;
+}

--- a/src/main/java/com/f1/quiket/domain/auth/entity/UserPasswordResetToken.java
+++ b/src/main/java/com/f1/quiket/domain/auth/entity/UserPasswordResetToken.java
@@ -1,0 +1,69 @@
+package com.f1.quiket.domain.auth.entity;
+
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 비밀번호 재설정 토큰 엔티티
+ */
+@Entity
+@Table(
+        name = "user_password_reset_tokens",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_user_password_reset_tokens_reset_token",
+                        columnNames = "reset_token"
+                )
+        },
+        indexes = {
+                @Index(name = "idx_user_password_reset_tokens_user_id_status", columnList = "user_id, status"),
+                @Index(name = "idx_user_password_reset_tokens_expires_at", columnList = "expires_at")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserPasswordResetToken extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_user_password_reset_tokens_user_id")
+    )
+    User user;
+
+    @Column(name = "reset_token", length = 255, nullable = false)
+    String resetToken;
+
+    @Column(name = "status", length = 20, nullable = false)
+    String status = "pending";
+
+    @Column(name = "requested_ip", length = 45)
+    String requestedIp;
+
+    @Column(name = "requested_at", nullable = false)
+    LocalDateTime requestedAt = LocalDateTime.now();
+
+    @Column(name = "used_at")
+    LocalDateTime usedAt;
+
+    @Column(name = "expires_at", nullable = false)
+    LocalDateTime expiresAt;
+}

--- a/src/main/java/com/f1/quiket/domain/auth/entity/UserRefreshToken.java
+++ b/src/main/java/com/f1/quiket/domain/auth/entity/UserRefreshToken.java
@@ -1,0 +1,79 @@
+package com.f1.quiket.domain.auth.entity;
+
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 사용자 리프레시 토큰 엔티티
+ */
+@Entity
+@Table(
+        name = "user_refresh_tokens",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_user_refresh_tokens_token_hash",
+                        columnNames = "token_hash"
+                )
+        },
+        indexes = {
+                @Index(name = "idx_user_refresh_tokens_user_id_expires_at", columnList = "user_id, expires_at"),
+                @Index(name = "idx_user_refresh_tokens_user_id_revoked_at", columnList = "user_id, revoked_at"),
+                @Index(name = "idx_user_refresh_tokens_expires_at", columnList = "expires_at")
+        }
+)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserRefreshToken extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "user_id",
+            nullable = false,
+            foreignKey = @ForeignKey(name = "fk_user_refresh_tokens_user_id")
+    )
+    User user;
+
+    @Column(name = "token_hash", length = 255, nullable = false)
+    String tokenHash;
+
+    @Column(name = "device_id", length = 128)
+    String deviceId;
+
+    @Column(name = "device_name", length = 100)
+    String deviceName;
+
+    @Column(name = "user_agent", length = 500)
+    String userAgent;
+
+    @Column(name = "ip_address", length = 45)
+    String ipAddress;
+
+    @Column(name = "issued_at", nullable = false)
+    LocalDateTime issuedAt = LocalDateTime.now();
+
+    @Column(name = "expires_at", nullable = false)
+    LocalDateTime expiresAt;
+
+    @Column(name = "revoked_at")
+    LocalDateTime revokedAt;
+
+    @Column(name = "last_used_at", nullable = false)
+    LocalDateTime lastUsedAt = LocalDateTime.now();
+}

--- a/src/main/java/com/f1/quiket/domain/user/entity/User.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/User.java
@@ -1,50 +1,56 @@
 package com.f1.quiket.domain.user.entity;
 
+import com.f1.quiket.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.FieldDefaults;
-import java.time.LocalDateTime;
 
 /**
  * 사용자 도메인 엔티티
  */
 @Entity
-@Table(name = "users")
+@Table(
+        name = "users",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_users_public_id", columnNames = "public_id"),
+                @UniqueConstraint(name = "uq_users_email", columnNames = "email")
+        },
+        indexes = {
+                @Index(name = "idx_users_status_created_at", columnList = "status, created_at"),
+                @Index(name = "idx_users_deleted_at_created_at", columnList = "deleted_at, created_at")
+        }
+)
 @Getter
 @Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @FieldDefaults(level = AccessLevel.PRIVATE)
-public class User {
+public class User extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id;
-
-    @Column(name = "public_id", length = 36, nullable = false, unique = true)
+    @Column(name = "public_id", length = 36, nullable = false)
     String publicId;
 
-    @Column(length = 255, nullable = false, unique = true)
+    @Column(name = "email", length = 255, nullable = false)
     String email;
 
     @Column(length = 36, nullable = false)
     String nickname;
 
     @Column(length = 20, nullable = false)
-    String status;
+    String status = "active";
 
     @Column(name = "is_email_verified", nullable = false)
-    boolean emailVerified;
+    boolean emailVerified = false;
 
     @Column(name = "failed_login_count", nullable = false)
-    Integer failedLoginCount;
+    Integer failedLoginCount = 0;
 
     @Column(name = "last_failed_login_at")
     LocalDateTime lastFailedLoginAt;
@@ -59,14 +65,11 @@ public class User {
     String lastLoginIp;
 
     @Column(name = "dotori_balance", nullable = false)
-    Integer dotoriBalance;
+    Integer dotoriBalance = 0;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
-    LocalDateTime createdAt;
+    @Column(name = "xp_total", nullable = false)
+    Integer xpTotal = 0;
 
-    @Column(name = "updated_at", nullable = false)
-    LocalDateTime updatedAt;
-
-    @Column(name = "deleted_at")
-    LocalDateTime deletedAt;
+    @Column(name = "current_level", nullable = false)
+    Integer currentLevel = 1;
 }

--- a/src/main/java/com/f1/quiket/global/entity/BaseEntity.java
+++ b/src/main/java/com/f1/quiket/global/entity/BaseEntity.java
@@ -1,0 +1,51 @@
+package com.f1.quiket.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 공통 엔티티 기본 컬럼
+ */
+@Getter
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    LocalDateTime deletedAt;
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void restore() {
+        this.deletedAt = null;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,6 +13,12 @@ spring:
       hibernate:
         format_sql: false     # SQL 로그 포맷팅 여부
 
+  # DB Migration
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: false
+
   # 파일 업로드
   servlet:
     multipart:

--- a/src/main/resources/db/migration/V1__init_auth_schema.sql
+++ b/src/main/resources/db/migration/V1__init_auth_schema.sql
@@ -1,0 +1,139 @@
+-- 사용자 기본 정보
+CREATE TABLE users (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK: 내부 사용자 식별자',
+    public_id CHAR(36) NOT NULL COMMENT '외부 노출용 UUID v7',
+    email VARCHAR(255) NOT NULL COMMENT '사용자 이메일',
+    nickname VARCHAR(36) NOT NULL COMMENT '사용자 닉네임',
+    status VARCHAR(20) NOT NULL DEFAULT 'active' COMMENT '계정 상태',
+    is_email_verified TINYINT(1) NOT NULL DEFAULT 0 COMMENT '이메일 인증 여부',
+    failed_login_count INT NOT NULL DEFAULT 0 COMMENT '로그인 실패 횟수',
+    last_failed_login_at DATETIME(3) NULL COMMENT '마지막 로그인 실패 시각',
+    locked_at DATETIME(3) NULL COMMENT '계정 잠금 시각',
+    last_login_at DATETIME(3) NULL COMMENT '마지막 로그인 시각',
+    last_login_ip VARCHAR(45) NULL COMMENT '마지막 로그인 IP',
+    dotori_balance INT NOT NULL DEFAULT 0 COMMENT '도토리 잔고',
+    xp_total INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '누적 XP 총량',
+    current_level TINYINT UNSIGNED NOT NULL DEFAULT 1 COMMENT '현재 레벨',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at DATETIME(3) NULL COMMENT '삭제 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_users_public_id (public_id),
+    UNIQUE KEY uq_users_email (email),
+    KEY idx_users_status_created_at (status, created_at),
+    KEY idx_users_deleted_at_created_at (deleted_at, created_at),
+
+    CONSTRAINT chk_users_status CHECK (status IN ('active', 'locked', 'inactive')),
+    CONSTRAINT chk_users_is_email_verified CHECK (is_email_verified IN (0, 1)),
+    CONSTRAINT chk_users_failed_login_count CHECK (failed_login_count >= 0),
+    CONSTRAINT chk_users_dotori_balance CHECK (dotori_balance >= 0),
+    CONSTRAINT chk_users_xp_total CHECK (xp_total >= 0),
+    CONSTRAINT chk_users_current_level CHECK (current_level BETWEEN 1 AND 10)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 기본 정보';
+
+-- 사용자 인증 수단
+CREATE TABLE user_auth_identities (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT '로그인 수단 레코드 식별 PK',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    provider VARCHAR(20) NOT NULL COMMENT '로그인 수단 구분값',
+    provider_subject VARCHAR(255) NOT NULL DEFAULT '' COMMENT '소셜 로그인 고유 식별값, local은 빈 문자열',
+    password_hash VARCHAR(255) NULL COMMENT '자체 로그인 비밀번호 해시값',
+    is_primary TINYINT(1) NOT NULL DEFAULT 0 COMMENT '대표 로그인 수단 여부',
+    last_login_at DATETIME(3) NULL COMMENT '해당 인증 수단 마지막 로그인 시각',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at DATETIME(3) NULL COMMENT '삭제 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_user_auth_identities_provider_subject (provider, provider_subject),
+    UNIQUE KEY uq_user_auth_identities_user_id_provider (user_id, provider),
+    KEY idx_user_auth_identities_user_id_created_at (user_id, created_at),
+    KEY idx_user_auth_identities_provider_created_at (provider, created_at),
+
+    CONSTRAINT fk_user_auth_identities_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT chk_user_auth_identities_provider
+        CHECK (provider IN ('local', 'kakao', 'apple')),
+    CONSTRAINT chk_user_auth_identities_is_primary
+        CHECK (is_primary IN (0, 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 인증 수단';
+
+-- 이메일 인증 요청 및 처리 이력
+CREATE TABLE user_email_verifications (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT '이메일 인증 요청 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    email VARCHAR(255) NOT NULL COMMENT '인증 대상 이메일',
+    verification_token VARCHAR(255) NOT NULL COMMENT '이메일 인증 토큰',
+    verification_code VARCHAR(20) NULL COMMENT '사용자 입력용 인증 코드',
+    status VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT '인증 상태',
+    requested_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '인증 요청 시각',
+    verified_at DATETIME(3) NULL COMMENT '인증 완료 시각',
+    expires_at DATETIME(3) NOT NULL COMMENT '만료 시각',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at DATETIME(3) NULL COMMENT '삭제 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_user_email_verifications_verification_token (verification_token),
+    KEY idx_user_email_verifications_user_id_status (user_id, status),
+    KEY idx_user_email_verifications_email_status (email, status),
+    KEY idx_user_email_verifications_expires_at (expires_at),
+
+    CONSTRAINT fk_user_email_verifications_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT chk_user_email_verifications_status
+        CHECK (status IN ('pending', 'verified', 'expired', 'cancelled'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='이메일 인증 요청 및 처리 이력';
+
+-- 비밀번호 재설정 토큰 관리
+CREATE TABLE user_password_reset_tokens (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT '비밀번호 재설정 토큰 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    reset_token VARCHAR(255) NOT NULL COMMENT '재설정 토큰',
+    status VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT '토큰 상태',
+    requested_ip VARCHAR(45) NULL COMMENT '요청 IP',
+    requested_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '요청 시각',
+    used_at DATETIME(3) NULL COMMENT '사용 완료 시각',
+    expires_at DATETIME(3) NOT NULL COMMENT '만료 시각',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at DATETIME(3) NULL COMMENT '삭제 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_user_password_reset_tokens_reset_token (reset_token),
+    KEY idx_user_password_reset_tokens_user_id_status (user_id, status),
+    KEY idx_user_password_reset_tokens_expires_at (expires_at),
+
+    CONSTRAINT fk_user_password_reset_tokens_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT chk_user_password_reset_tokens_status
+        CHECK (status IN ('pending', 'used', 'expired', 'cancelled'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='비밀번호 재설정 토큰 관리';
+
+-- 사용자 리프레시 토큰 관리
+CREATE TABLE user_refresh_tokens (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT '리프레시 토큰 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    token_hash VARCHAR(255) NOT NULL COMMENT '리프레시 토큰 해시값',
+    device_id VARCHAR(128) NULL COMMENT '디바이스 식별자',
+    device_name VARCHAR(100) NULL COMMENT '디바이스 이름',
+    user_agent VARCHAR(500) NULL COMMENT '사용자 에이전트',
+    ip_address VARCHAR(45) NULL COMMENT 'IP 주소',
+    issued_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '발급 시각',
+    expires_at DATETIME(3) NOT NULL COMMENT '만료 시각',
+    revoked_at DATETIME(3) NULL COMMENT '폐기 시각',
+    last_used_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '마지막 사용 시각',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at DATETIME(3) NULL COMMENT '삭제 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_user_refresh_tokens_token_hash (token_hash),
+    KEY idx_user_refresh_tokens_user_id_expires_at (user_id, expires_at),
+    KEY idx_user_refresh_tokens_user_id_revoked_at (user_id, revoked_at),
+    KEY idx_user_refresh_tokens_expires_at (expires_at),
+
+    CONSTRAINT fk_user_refresh_tokens_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 리프레시 토큰 관리';

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -22,6 +22,9 @@ spring:
         format_sql: false
         use_sql_comments: false
 
+  flyway:
+    enabled: false
+
 aws:
   ses:
     region: ${AWS_REGION:ap-northeast-2}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- Auth 도메인 구현을 위한 DB 스키마 마이그레이션과 JPA Entity를 추가했습니다.
- `users`, `user_auth_identities`, `user_refresh_tokens`, `user_email_verifications`, `user_password_reset_tokens` 테이블을 Flyway migration으로 정의했습니다.
- 공통 컬럼 관리를 위한 `BaseEntity`를 추가하고 기존 `User` 엔티티를 DDL 기준으로 정리했습니다.

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- Flyway 의존성 및 migration 설정 추가
- `V1__init_auth_schema.sql` Auth 스키마 추가
- `BaseEntity` 추가 및 `User` 엔티티 공통 컬럼 적용
- Auth 인증 수단, 이메일 인증, 비밀번호 재설정, 리프레시 토큰 엔티티 추가
- UNIQUE, INDEX, FK 매핑 반영

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew compileJava`
2. `./gradlew test`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #7

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 테스트 프로파일은 기존 `ddl-auto: create-drop` 흐름을 유지하기 위해 Flyway를 비활성화했습니다.
- 운영/로컬 프로파일에서는 `spring.flyway.enabled=true` 기준으로 migration을 적용합니다.
- OAuth provider는 MVP 기준 `local`, `kakao`, 확장 고려 `apple`까지 DDL과 동일하게 반영했습니다.

---

## 🧑‍💻 Assignee

- @imclaremont
