### PR TITLE
[Feat] 일반 회원가입 및 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.security:spring-security-crypto'
 	
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'

--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -1755,13 +1755,13 @@ components:
         password:
           type: string
           minLength: 8
-          maxLength: 64
-          pattern: '^(?=.*[A-Za-z])(?=.*\d).{8,64}$'
+          maxLength: 32
+          pattern: '^(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9~!@#$%^&*()_+=\[\]{}.,?-]{8,32}$'
           example: Password123!
         passwordConfirm:
           type: string
           minLength: 8
-          maxLength: 64
+          maxLength: 32
           example: Password123!
         nickname:
           type: string
@@ -1784,7 +1784,7 @@ components:
         password:
           type: string
           minLength: 8
-          maxLength: 64
+          maxLength: 32
           example: Password123!
 
     RefreshTokenRequest:
@@ -1869,13 +1869,13 @@ components:
         newPassword:
           type: string
           minLength: 8
-          maxLength: 64
-          pattern: '^(?=.*[A-Za-z])(?=.*\d).{8,64}$'
+          maxLength: 32
+          pattern: '^(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9~!@#$%^&*()_+=\[\]{}.,?-]{8,32}$'
           example: NewPassword123!
         newPasswordConfirm:
           type: string
           minLength: 8
-          maxLength: 64
+          maxLength: 32
           example: NewPassword123!
       oneOf:
         - required:
@@ -4052,13 +4052,13 @@ components:
         newPassword:
           type: string
           minLength: 8
-          maxLength: 64
-          pattern: '^(?=.*[A-Za-z])(?=.*\d).{8,64}$'
+          maxLength: 32
+          pattern: '^(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9~!@#$%^&*()_+=\[\]{}.,?-]{8,32}$'
           example: NewPassword123!
         newPasswordConfirm:
           type: string
           minLength: 8
-          maxLength: 64
+          maxLength: 32
           example: NewPassword123!
 
     AccountDeleteRequest:

--- a/src/main/java/com/f1/quiket/config/PasswordConfig.java
+++ b/src/main/java/com/f1/quiket/config/PasswordConfig.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * 비밀번호 암호화 설정
+ */
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/f1/quiket/domain/auth/controller/AuthController.java
@@ -1,0 +1,69 @@
+package com.f1.quiket.domain.auth.controller;
+
+import com.f1.quiket.domain.auth.dto.EmailAvailabilityResponse;
+import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmRequest;
+import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmResponse;
+import com.f1.quiket.domain.auth.dto.EmailVerificationRequest;
+import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.auth.dto.SignupRequest;
+import com.f1.quiket.domain.auth.dto.SignupResponse;
+import com.f1.quiket.domain.auth.service.LocalAuthService;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final LocalAuthService localAuthService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
+        SignupResponse response = localAuthService.signup(request);
+        return ResponseEntity.status(SuccessCode.AUTH_SIGNUP_SUCCESS.getStatus())
+                .body(ApiResponse.success(SuccessCode.AUTH_SIGNUP_SUCCESS, response));
+    }
+
+    @GetMapping("/emails/availability")
+    public ResponseEntity<ApiResponse<EmailAvailabilityResponse>> checkEmailAvailability(
+            @Email(message = "올바른 이메일 형식이 아닙니다")
+            @NotBlank(message = "이메일은 필수입니다")
+            @RequestParam String email
+    ) {
+        EmailAvailabilityResponse response = localAuthService.checkEmailAvailability(email);
+        SuccessCode successCode = response.isAvailable()
+                ? SuccessCode.AUTH_EMAIL_AVAILABLE
+                : SuccessCode.AUTH_EMAIL_UNAVAILABLE;
+        return ResponseEntity.ok(ApiResponse.success(successCode, response));
+    }
+
+    @PostMapping("/email-verifications")
+    public ResponseEntity<ApiResponse<EmailVerificationSentResponse>> resendEmailVerification(
+            @Valid @RequestBody EmailVerificationRequest request
+    ) {
+        EmailVerificationSentResponse response = localAuthService.resendEmailVerification(request.getEmail());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.AUTH_EMAIL_VERIFICATION_SENT, response));
+    }
+
+    @PostMapping("/email-verifications/confirm")
+    public ResponseEntity<ApiResponse<EmailVerificationConfirmResponse>> confirmEmailVerification(
+            @Valid @RequestBody EmailVerificationConfirmRequest request
+    ) {
+        EmailVerificationConfirmResponse response = localAuthService.confirmEmailVerification(request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.AUTH_EMAIL_VERIFIED, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/f1/quiket/domain/auth/controller/AuthController.java
@@ -5,11 +5,14 @@ import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmRequest;
 import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmResponse;
 import com.f1.quiket.domain.auth.dto.EmailVerificationRequest;
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.auth.dto.LocalLoginResponse;
+import com.f1.quiket.domain.auth.dto.LoginRequest;
 import com.f1.quiket.domain.auth.dto.SignupRequest;
 import com.f1.quiket.domain.auth.dto.SignupResponse;
 import com.f1.quiket.domain.auth.service.LocalAuthService;
 import com.f1.quiket.global.response.ApiResponse;
 import com.f1.quiket.global.response.SuccessCode;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -28,6 +31,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 public class AuthController {
+
+    private static final String X_FORWARDED_FOR = "X-Forwarded-For";
 
     private final LocalAuthService localAuthService;
 
@@ -65,5 +70,22 @@ public class AuthController {
     ) {
         EmailVerificationConfirmResponse response = localAuthService.confirmEmailVerification(request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.AUTH_EMAIL_VERIFIED, response));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LocalLoginResponse>> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletRequest httpServletRequest
+    ) {
+        LocalLoginResponse response = localAuthService.login(request, resolveClientIp(httpServletRequest));
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.AUTH_LOGIN_SUCCESS, response));
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String forwardedFor = request.getHeader(X_FORWARDED_FOR);
+        if (forwardedFor != null && !forwardedFor.isBlank()) {
+            return forwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 }

--- a/src/main/java/com/f1/quiket/domain/auth/dto/AuthUserResponse.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/AuthUserResponse.java
@@ -1,0 +1,34 @@
+package com.f1.quiket.domain.auth.dto;
+
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.user.entity.User;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthUserResponse {
+
+    private final String id;
+    private final String email;
+    private final String nickname;
+    private final Integer dotoriBalance;
+    private final boolean emailVerified;
+    private final String status;
+    private final List<String> providers;
+
+    public static AuthUserResponse of(User user, List<UserAuthIdentity> identities) {
+        return AuthUserResponse.builder()
+                .id(user.getPublicId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .dotoriBalance(user.getDotoriBalance())
+                .emailVerified(user.isEmailVerified())
+                .status(user.getStatus())
+                .providers(identities.stream()
+                        .map(UserAuthIdentity::getProvider)
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/EmailAvailabilityResponse.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/EmailAvailabilityResponse.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmailAvailabilityResponse {
+
+    private final String email;
+    private final boolean available;
+
+    public static EmailAvailabilityResponse of(String email, boolean available) {
+        return EmailAvailabilityResponse.builder()
+                .email(email)
+                .available(available)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/EmailVerificationConfirmRequest.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/EmailVerificationConfirmRequest.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailVerificationConfirmRequest {
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수입니다")
+    private String email;
+
+    private String verificationCode;
+    private String verificationToken;
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/EmailVerificationConfirmResponse.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/EmailVerificationConfirmResponse.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmailVerificationConfirmResponse {
+
+    private final String email;
+    private final boolean verified;
+
+    public static EmailVerificationConfirmResponse verified(String email) {
+        return EmailVerificationConfirmResponse.builder()
+                .email(email)
+                .verified(true)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/EmailVerificationRequest.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/EmailVerificationRequest.java
@@ -1,0 +1,15 @@
+package com.f1.quiket.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailVerificationRequest {
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수입니다")
+    private String email;
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/EmailVerificationSentResponse.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/EmailVerificationSentResponse.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class EmailVerificationSentResponse {
+
+    private final String email;
+    private final long expiresInSeconds;
+
+    public static EmailVerificationSentResponse of(String email, long expiresInSeconds) {
+        return EmailVerificationSentResponse.builder()
+                .email(email)
+                .expiresInSeconds(expiresInSeconds)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/LocalLoginResponse.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/LocalLoginResponse.java
@@ -1,0 +1,20 @@
+package com.f1.quiket.domain.auth.dto;
+
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.user.entity.User;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LocalLoginResponse {
+
+    private final AuthUserResponse user;
+
+    public static LocalLoginResponse of(User user, List<UserAuthIdentity> identities) {
+        return LocalLoginResponse.builder()
+                .user(AuthUserResponse.of(user, identities))
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/LoginRequest.java
@@ -16,6 +16,6 @@ public class LoginRequest {
     private String email;
 
     @NotBlank(message = "비밀번호는 필수입니다")
-    @Size(min = 8, max = 64, message = "비밀번호는 8자 이상 64자 이하여야 합니다")
+    @Size(min = 8, max = 32, message = "비밀번호는 8자 이상 32자 이하여야 합니다")
     private String password;
 }

--- a/src/main/java/com/f1/quiket/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,21 @@
+package com.f1.quiket.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수입니다")
+    @Size(max = 255, message = "이메일은 255자 이하여야 합니다")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 8, max = 64, message = "비밀번호는 8자 이상 64자 이하여야 합니다")
+    private String password;
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/SignupRequest.java
@@ -17,12 +17,14 @@ public class SignupRequest {
     private String email;
 
     @NotBlank(message = "비밀번호는 필수입니다")
-    @Size(min = 8, max = 64, message = "비밀번호는 8자 이상 64자 이하여야 합니다")
-    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,64}$", message = "비밀번호는 영문과 숫자를 포함해야 합니다")
+    @Size(min = 8, max = 32, message = "비밀번호는 8자 이상 32자 이하여야 합니다")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z0-9~!@#$%^&*()_+=\\[\\]{}.,?-]{8,32}$",
+            message = "비밀번호는 영문과 숫자를 포함하고 공백 없이 허용된 문자만 사용할 수 있습니다")
     private String password;
 
     @NotBlank(message = "비밀번호 확인은 필수입니다")
-    @Size(min = 8, max = 64, message = "비밀번호 확인은 8자 이상 64자 이하여야 합니다")
+    @Size(min = 8, max = 32, message = "비밀번호 확인은 8자 이상 32자 이하여야 합니다")
     private String passwordConfirm;
 
     @NotBlank(message = "닉네임은 필수입니다")

--- a/src/main/java/com/f1/quiket/domain/auth/dto/SignupRequest.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/SignupRequest.java
@@ -1,0 +1,32 @@
+package com.f1.quiket.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignupRequest {
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수입니다")
+    @Size(max = 255, message = "이메일은 255자 이하여야 합니다")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    @Size(min = 8, max = 64, message = "비밀번호는 8자 이상 64자 이하여야 합니다")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d).{8,64}$", message = "비밀번호는 영문과 숫자를 포함해야 합니다")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인은 필수입니다")
+    @Size(min = 8, max = 64, message = "비밀번호 확인은 8자 이상 64자 이하여야 합니다")
+    private String passwordConfirm;
+
+    @NotBlank(message = "닉네임은 필수입니다")
+    @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하여야 합니다")
+    @Pattern(regexp = "^[가-힣A-Za-z]{2,12}$", message = "닉네임은 한글 또는 영문만 사용할 수 있습니다")
+    private String nickname;
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/SignupResponse.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/SignupResponse.java
@@ -1,0 +1,26 @@
+package com.f1.quiket.domain.auth.dto;
+
+import com.f1.quiket.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SignupResponse {
+
+    private final String userId;
+    private final String email;
+    private final String nickname;
+    private final boolean emailVerificationRequired;
+    private final boolean emailVerificationSent;
+
+    public static SignupResponse of(User user, boolean emailVerificationSent) {
+        return SignupResponse.builder()
+                .userId(user.getPublicId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .emailVerificationRequired(true)
+                .emailVerificationSent(emailVerificationSent)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/entity/UserAuthIdentity.java
+++ b/src/main/java/com/f1/quiket/domain/auth/entity/UserAuthIdentity.java
@@ -67,4 +67,18 @@ public class UserAuthIdentity extends BaseEntity {
 
     @Column(name = "last_login_at")
     LocalDateTime lastLoginAt;
+
+    public static UserAuthIdentity createLocal(User user, String passwordHash, boolean primary) {
+        UserAuthIdentity identity = new UserAuthIdentity();
+        identity.user = user;
+        identity.provider = "local";
+        identity.providerSubject = "";
+        identity.passwordHash = passwordHash;
+        identity.primary = primary;
+        return identity;
+    }
+
+    public void recordLoginSuccess() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/auth/entity/UserEmailVerification.java
+++ b/src/main/java/com/f1/quiket/domain/auth/entity/UserEmailVerification.java
@@ -70,4 +70,33 @@ public class UserEmailVerification extends BaseEntity {
 
     @Column(name = "expires_at", nullable = false)
     LocalDateTime expiresAt;
+
+    public static UserEmailVerification create(
+            User user,
+            String email,
+            String verificationToken,
+            String verificationCode,
+            LocalDateTime expiresAt
+    ) {
+        UserEmailVerification verification = new UserEmailVerification();
+        verification.user = user;
+        verification.email = email;
+        verification.verificationToken = verificationToken;
+        verification.verificationCode = verificationCode;
+        verification.expiresAt = expiresAt;
+        return verification;
+    }
+
+    public boolean isExpired(LocalDateTime now) {
+        return expiresAt.isBefore(now);
+    }
+
+    public void verify(LocalDateTime now) {
+        this.status = "verified";
+        this.verifiedAt = now;
+    }
+
+    public void expire() {
+        this.status = "expired";
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/auth/repository/UserAuthIdentityRepository.java
+++ b/src/main/java/com/f1/quiket/domain/auth/repository/UserAuthIdentityRepository.java
@@ -1,0 +1,14 @@
+package com.f1.quiket.domain.auth.repository;
+
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.user.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAuthIdentityRepository extends JpaRepository<UserAuthIdentity, Long> {
+
+    Optional<UserAuthIdentity> findByUserAndProviderAndDeletedAtIsNull(User user, String provider);
+
+    List<UserAuthIdentity> findAllByUserAndDeletedAtIsNull(User user);
+}

--- a/src/main/java/com/f1/quiket/domain/auth/repository/UserEmailVerificationRepository.java
+++ b/src/main/java/com/f1/quiket/domain/auth/repository/UserEmailVerificationRepository.java
@@ -1,0 +1,20 @@
+package com.f1.quiket.domain.auth.repository;
+
+import com.f1.quiket.domain.auth.entity.UserEmailVerification;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserEmailVerificationRepository extends JpaRepository<UserEmailVerification, Long> {
+
+    Optional<UserEmailVerification> findTopByEmailAndVerificationCodeAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(
+            String email,
+            String verificationCode,
+            String status
+    );
+
+    Optional<UserEmailVerification> findTopByEmailAndVerificationTokenAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(
+            String email,
+            String verificationToken,
+            String status
+    );
+}

--- a/src/main/java/com/f1/quiket/domain/auth/service/EmailVerificationCodeGenerator.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/EmailVerificationCodeGenerator.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.auth.service;
+
+import java.security.SecureRandom;
+import org.springframework.stereotype.Component;
+
+/**
+ * 이메일 인증 코드 생성기
+ */
+@Component
+public class EmailVerificationCodeGenerator {
+
+    private static final int CODE_BOUND = 1_000_000;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    public String generate() {
+        return "%06d".formatted(SECURE_RANDOM.nextInt(CODE_BOUND));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/service/LocalAuthService.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/LocalAuthService.java
@@ -1,0 +1,147 @@
+package com.f1.quiket.domain.auth.service;
+
+import com.f1.quiket.domain.auth.dto.EmailAvailabilityResponse;
+import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmRequest;
+import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmResponse;
+import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.auth.dto.SignupRequest;
+import com.f1.quiket.domain.auth.dto.SignupResponse;
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.auth.entity.UserEmailVerification;
+import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.auth.repository.UserEmailVerificationRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.global.util.UuidV7Generator;
+import com.f1.quiket.infra.mail.dto.MailSendRequest;
+import com.f1.quiket.infra.mail.service.SesMailSender;
+import com.f1.quiket.infra.mail.template.MailTemplateFactory;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LocalAuthService {
+
+    private static final String PROVIDER_LOCAL = "local";
+    private static final String VERIFICATION_STATUS_PENDING = "pending";
+    private static final long EMAIL_VERIFICATION_TTL_SECONDS = 1800L;
+
+    private final UserRepository userRepository;
+    private final UserAuthIdentityRepository userAuthIdentityRepository;
+    private final UserEmailVerificationRepository userEmailVerificationRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final EmailVerificationCodeGenerator verificationCodeGenerator;
+    private final MailTemplateFactory mailTemplateFactory;
+    private final SesMailSender sesMailSender;
+
+    public SignupResponse signup(SignupRequest request) {
+        validatePasswordConfirm(request.getPassword(), request.getPasswordConfirm());
+        validateEmailNotExists(request.getEmail());
+
+        User user = User.create(UuidV7Generator.generate(), request.getEmail(), request.getNickname());
+        User savedUser = userRepository.save(user);
+
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(
+                savedUser,
+                passwordEncoder.encode(request.getPassword()),
+                true
+        );
+        userAuthIdentityRepository.save(identity);
+
+        sendEmailVerification(savedUser);
+        return SignupResponse.of(savedUser, true);
+    }
+
+    @Transactional(readOnly = true)
+    public EmailAvailabilityResponse checkEmailAvailability(String email) {
+        boolean available = !userRepository.existsByEmail(email);
+        return EmailAvailabilityResponse.of(email, available);
+    }
+
+    public EmailVerificationSentResponse resendEmailVerification(String email) {
+        User user = findUserByEmail(email);
+        sendEmailVerification(user);
+        return EmailVerificationSentResponse.of(email, EMAIL_VERIFICATION_TTL_SECONDS);
+    }
+
+    public EmailVerificationConfirmResponse confirmEmailVerification(EmailVerificationConfirmRequest request) {
+        UserEmailVerification verification = findPendingVerification(request);
+        LocalDateTime now = LocalDateTime.now();
+        if (verification.isExpired(now)) {
+            verification.expire();
+            throw new CustomException(ErrorCode.AUTH_EMAIL_VERIFICATION_EXPIRED);
+        }
+
+        verification.verify(now);
+        verification.getUser().verifyEmail();
+        return EmailVerificationConfirmResponse.verified(verification.getEmail());
+    }
+
+    private void validatePasswordConfirm(String password, String passwordConfirm) {
+        if (!password.equals(passwordConfirm)) {
+            throw new CustomException(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
+        }
+    }
+
+    private void validateEmailNotExists(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException(ErrorCode.AUTH_EMAIL_ALREADY_EXISTS);
+        }
+    }
+
+    private User findUserByEmail(String email) {
+        return userRepository.findByEmailAndDeletedAtIsNull(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    private void sendEmailVerification(User user) {
+        String verificationCode = verificationCodeGenerator.generate();
+        String verificationToken = UUID.randomUUID().toString();
+        LocalDateTime expiresAt = LocalDateTime.now().plusSeconds(EMAIL_VERIFICATION_TTL_SECONDS);
+
+        UserEmailVerification verification = UserEmailVerification.create(
+                user,
+                user.getEmail(),
+                verificationToken,
+                verificationCode,
+                expiresAt
+        );
+        userEmailVerificationRepository.save(verification);
+
+        MailSendRequest mailRequest = mailTemplateFactory.createSignUpVerificationMail(user.getEmail(), verificationCode);
+        sesMailSender.sendMail(mailRequest);
+    }
+
+    private UserEmailVerification findPendingVerification(EmailVerificationConfirmRequest request) {
+        if (StringUtils.hasText(request.getVerificationCode())) {
+            return userEmailVerificationRepository
+                    .findTopByEmailAndVerificationCodeAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(
+                            request.getEmail(),
+                            request.getVerificationCode(),
+                            VERIFICATION_STATUS_PENDING
+                    )
+                    .orElseThrow(() -> new CustomException(ErrorCode.AUTH_INVALID_EMAIL_VERIFICATION));
+        }
+
+        if (StringUtils.hasText(request.getVerificationToken())) {
+            return userEmailVerificationRepository
+                    .findTopByEmailAndVerificationTokenAndStatusAndDeletedAtIsNullOrderByCreatedAtDesc(
+                            request.getEmail(),
+                            request.getVerificationToken(),
+                            VERIFICATION_STATUS_PENDING
+                    )
+                    .orElseThrow(() -> new CustomException(ErrorCode.AUTH_INVALID_EMAIL_VERIFICATION));
+        }
+
+        throw new CustomException(ErrorCode.AUTH_INVALID_EMAIL_VERIFICATION);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/service/LocalAuthService.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/LocalAuthService.java
@@ -4,6 +4,8 @@ import com.f1.quiket.domain.auth.dto.EmailAvailabilityResponse;
 import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmRequest;
 import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmResponse;
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.auth.dto.LocalLoginResponse;
+import com.f1.quiket.domain.auth.dto.LoginRequest;
 import com.f1.quiket.domain.auth.dto.SignupRequest;
 import com.f1.quiket.domain.auth.dto.SignupResponse;
 import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
@@ -34,6 +36,7 @@ public class LocalAuthService {
     private static final String PROVIDER_LOCAL = "local";
     private static final String VERIFICATION_STATUS_PENDING = "pending";
     private static final long EMAIL_VERIFICATION_TTL_SECONDS = 1800L;
+    private static final int MAX_FAILED_LOGIN_COUNT = 5;
 
     private final UserRepository userRepository;
     private final UserAuthIdentityRepository userAuthIdentityRepository;
@@ -86,6 +89,24 @@ public class LocalAuthService {
         return EmailVerificationConfirmResponse.verified(verification.getEmail());
     }
 
+    public LocalLoginResponse login(LoginRequest request, String loginIp) {
+        User user = userRepository.findByEmailAndDeletedAtIsNull(request.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_INVALID_CREDENTIALS));
+
+        validateAccountIsNotLocked(user);
+
+        UserAuthIdentity localIdentity = userAuthIdentityRepository
+                .findByUserAndProviderAndDeletedAtIsNull(user, PROVIDER_LOCAL)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND));
+
+        validatePassword(user, localIdentity, request.getPassword());
+        validateEmailVerified(user);
+
+        user.recordLoginSuccess(loginIp);
+        localIdentity.recordLoginSuccess();
+        return LocalLoginResponse.of(user, userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user));
+    }
+
     private void validatePasswordConfirm(String password, String passwordConfirm) {
         if (!password.equals(passwordConfirm)) {
             throw new CustomException(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
@@ -101,6 +122,29 @@ public class LocalAuthService {
     private User findUserByEmail(String email) {
         return userRepository.findByEmailAndDeletedAtIsNull(email)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    private void validateAccountIsNotLocked(User user) {
+        if (user.isLocked()) {
+            throw new CustomException(ErrorCode.AUTH_ACCOUNT_LOCKED);
+        }
+    }
+
+    private void validatePassword(User user, UserAuthIdentity localIdentity, String password) {
+        if (!StringUtils.hasText(localIdentity.getPasswordHash())
+                || !passwordEncoder.matches(password, localIdentity.getPasswordHash())) {
+            user.recordLoginFailure(MAX_FAILED_LOGIN_COUNT);
+            if (user.isLocked()) {
+                throw new CustomException(ErrorCode.AUTH_ACCOUNT_LOCKED);
+            }
+            throw new CustomException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        }
+    }
+
+    private void validateEmailVerified(User user) {
+        if (!user.isEmailVerified()) {
+            throw new CustomException(ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
+        }
     }
 
     private void sendEmailVerification(User user) {

--- a/src/main/java/com/f1/quiket/domain/user/entity/User.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/User.java
@@ -72,4 +72,36 @@ public class User extends BaseEntity {
 
     @Column(name = "current_level", nullable = false)
     Integer currentLevel = 1;
+
+    public static User create(String publicId, String email, String nickname) {
+        User user = new User();
+        user.publicId = publicId;
+        user.email = email;
+        user.nickname = nickname;
+        return user;
+    }
+
+    public void verifyEmail() {
+        this.emailVerified = true;
+    }
+
+    public void recordLoginFailure(int maxFailedCount) {
+        this.failedLoginCount++;
+        this.lastFailedLoginAt = LocalDateTime.now();
+        if (this.failedLoginCount >= maxFailedCount) {
+            this.status = "locked";
+            this.lockedAt = LocalDateTime.now();
+        }
+    }
+
+    public void recordLoginSuccess(String loginIp) {
+        this.failedLoginCount = 0;
+        this.lastFailedLoginAt = null;
+        this.lastLoginAt = LocalDateTime.now();
+        this.lastLoginIp = loginIp;
+    }
+
+    public boolean isLocked() {
+        return "locked".equals(this.status);
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/f1/quiket/domain/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.user.repository;
 
 import com.f1.quiket.domain.user.entity.User;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +16,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * 활성화된 사용자 목록 조회.
      */
     List<User> findAllByStatusAndDeletedAtIsNull(String status);
+
+    boolean existsByEmail(String email);
+
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
 }

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -20,6 +20,17 @@ public enum ErrorCode {
     CONFLICT(409, "C007", "이미 존재하는 리소스입니다."),
     UNPROCESSABLE_ENTITY(422, "C008", "처리할 수 없는 엔티티입니다."),
 
+    // Auth Errors
+    AUTH_EMAIL_ALREADY_EXISTS(409, "AUTH_EMAIL_ALREADY_EXISTS", "이미 사용 중인 이메일입니다."),
+    AUTH_PASSWORD_CONFIRM_MISMATCH(400, "AUTH_PASSWORD_CONFIRM_MISMATCH", "비밀번호 확인이 일치하지 않습니다."),
+    AUTH_USER_NOT_FOUND(404, "AUTH_USER_NOT_FOUND", "가입되지 않은 이메일입니다."),
+    AUTH_INVALID_EMAIL_VERIFICATION(400, "AUTH_INVALID_EMAIL_VERIFICATION", "인증 코드 또는 토큰이 올바르지 않습니다."),
+    AUTH_EMAIL_VERIFICATION_EXPIRED(400, "AUTH_EMAIL_VERIFICATION_EXPIRED", "이메일 인증 요청이 만료되었습니다."),
+    AUTH_INVALID_CREDENTIALS(401, "AUTH_INVALID_CREDENTIALS", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    AUTH_EMAIL_NOT_VERIFIED(403, "AUTH_EMAIL_NOT_VERIFIED", "이메일 인증이 필요합니다."),
+    AUTH_ACCOUNT_LOCKED(403, "AUTH_ACCOUNT_LOCKED", "계정이 잠금 처리되었습니다."),
+    AUTH_LOCAL_IDENTITY_NOT_FOUND(409, "AUTH_LOCAL_IDENTITY_NOT_FOUND", "자체 로그인 인증 수단이 없는 계정입니다."),
+
     // 5xx Server Errors
     INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다."),
     SERVICE_UNAVAILABLE(503, "C009", "일시적으로 서비스를 이용할 수 없습니다."),

--- a/src/main/java/com/f1/quiket/global/response/SuccessCode.java
+++ b/src/main/java/com/f1/quiket/global/response/SuccessCode.java
@@ -16,6 +16,14 @@ public enum SuccessCode {
     CREATED(201, "S002", "리소스가 생성되었습니다."),
     ACCEPTED(202, "S003", "요청이 수락되었습니다."),
     NO_CONTENT(204, "S004", "요청이 성공했습니다. 반환 콘텐츠가 없습니다."),
+
+    // Auth Success
+    AUTH_SIGNUP_SUCCESS(201, "AUTH_SIGNUP_SUCCESS", "회원가입이 완료되었습니다. 이메일 인증을 진행해주세요."),
+    AUTH_EMAIL_AVAILABLE(200, "AUTH_EMAIL_AVAILABLE", "사용 가능한 이메일입니다."),
+    AUTH_EMAIL_UNAVAILABLE(200, "AUTH_EMAIL_UNAVAILABLE", "이미 사용 중인 이메일입니다."),
+    AUTH_EMAIL_VERIFICATION_SENT(200, "AUTH_EMAIL_VERIFICATION_SENT", "이메일 인증 메일이 발송되었습니다."),
+    AUTH_EMAIL_VERIFIED(200, "AUTH_EMAIL_VERIFIED", "이메일 인증이 완료되었습니다."),
+    AUTH_LOGIN_SUCCESS(200, "AUTH_LOGIN_SUCCESS", "로그인이 완료되었습니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/f1/quiket/global/util/UuidV7Generator.java
+++ b/src/main/java/com/f1/quiket/global/util/UuidV7Generator.java
@@ -1,0 +1,28 @@
+package com.f1.quiket.global.util;
+
+import java.security.SecureRandom;
+import java.util.UUID;
+
+/**
+ * UUID v7 생성기
+ */
+public final class UuidV7Generator {
+
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private UuidV7Generator() {
+    }
+
+    public static String generate() {
+        long timestampMillis = System.currentTimeMillis();
+        long randomA = SECURE_RANDOM.nextLong() & 0x0FFFL;
+        long randomB = SECURE_RANDOM.nextLong() & 0x3FFF_FFFF_FFFF_FFFFL;
+
+        long mostSignificantBits = (timestampMillis << 16)
+                | 0x7000L
+                | randomA;
+        long leastSignificantBits = 0x8000_0000_0000_0000L | randomB;
+
+        return new UUID(mostSignificantBits, leastSignificantBits).toString();
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/auth/service/LocalAuthServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/auth/service/LocalAuthServiceTest.java
@@ -1,0 +1,129 @@
+package com.f1.quiket.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.auth.dto.LoginRequest;
+import com.f1.quiket.domain.auth.dto.LocalLoginResponse;
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.auth.repository.UserEmailVerificationRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.infra.mail.service.SesMailSender;
+import com.f1.quiket.infra.mail.template.MailTemplateFactory;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class LocalAuthServiceTest {
+
+    private UserRepository userRepository;
+    private UserAuthIdentityRepository userAuthIdentityRepository;
+    private LocalAuthService localAuthService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userAuthIdentityRepository = mock(UserAuthIdentityRepository.class);
+
+        localAuthService = new LocalAuthService(
+                userRepository,
+                userAuthIdentityRepository,
+                mock(UserEmailVerificationRepository.class),
+                new BCryptPasswordEncoder(),
+                mock(EmailVerificationCodeGenerator.class),
+                mock(MailTemplateFactory.class),
+                mock(SesMailSender.class)
+        );
+    }
+
+    @Test
+    void login_succeeds_when_local_user_verified() {
+        User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
+        user.verifyEmail();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(
+                user,
+                new BCryptPasswordEncoder().encode("Password123!"),
+                true
+        );
+        LoginRequest request = loginRequest("user@example.com", "Password123!");
+
+        when(userRepository.findByEmailAndDeletedAtIsNull("user@example.com")).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(identity));
+
+        LocalLoginResponse response = localAuthService.login(request, "127.0.0.1");
+
+        assertThat(response.getUser().getEmail()).isEqualTo("user@example.com");
+        assertThat(user.getFailedLoginCount()).isZero();
+        assertThat(user.getLastLoginIp()).isEqualTo("127.0.0.1");
+        assertThat(user.getLastLoginAt()).isNotNull();
+        assertThat(identity.getLastLoginAt()).isNotNull();
+    }
+
+    @Test
+    void login_locks_account_after_five_failures() {
+        User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
+        user.verifyEmail();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(
+                user,
+                new BCryptPasswordEncoder().encode("Password123!"),
+                true
+        );
+        LoginRequest request = loginRequest("user@example.com", "WrongPassword123!");
+
+        when(userRepository.findByEmailAndDeletedAtIsNull("user@example.com")).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+
+        for (int i = 0; i < 4; i++) {
+            assertThatThrownBy(() -> localAuthService.login(request, "127.0.0.1"))
+                    .isInstanceOf(CustomException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        }
+
+        assertThatThrownBy(() -> localAuthService.login(request, "127.0.0.1"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_ACCOUNT_LOCKED);
+        assertThat(user.isLocked()).isTrue();
+        assertThat(user.getLockedAt()).isNotNull();
+    }
+
+    @Test
+    void login_fails_when_email_not_verified() {
+        User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(
+                user,
+                new BCryptPasswordEncoder().encode("Password123!"),
+                true
+        );
+        LoginRequest request = loginRequest("user@example.com", "Password123!");
+
+        when(userRepository.findByEmailAndDeletedAtIsNull("user@example.com")).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+
+        assertThatThrownBy(() -> localAuthService.login(request, "127.0.0.1"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_EMAIL_NOT_VERIFIED);
+    }
+
+    private LoginRequest loginRequest(String email, String password) {
+        LoginRequest request = new LoginRequest();
+        ReflectionTestUtils.setField(request, "email", email);
+        ReflectionTestUtils.setField(request, "password", password);
+        return request;
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 이메일 기반 일반 회원가입 및 자체 로그인 기능을 구현했습니다.
- 회원가입 시 Local 인증 수단을 생성하고 이메일 인증 요청/검증 흐름을 추가했습니다.
- 로그인 실패 횟수 기반 계정 잠금 정책을 DB 기반으로 적용했습니다.

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- BCrypt 비밀번호 해시 설정 추가
- UUID v7 publicId 생성 유틸 추가
- 회원가입 API 구현
- 이메일 중복 확인 API 구현
- 이메일 인증 메일 재발송 및 인증 확인 API 구현
- 자체 로그인 API 구현
- 로그인 실패 횟수 증가 및 5회 실패 시 계정 잠금 처리
- 로그인 성공 시 실패 횟수 초기화, 마지막 로그인 시각/IP 기록
- Local Auth 서비스 단위 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew compileJava`
2. `./gradlew test`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #8

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- JWT Access/Refresh Token 발급 및 응답 연결은 후속 이슈 #9에서 진행합니다.
- 현재 로그인 API는 Local 인증 검증과 사용자 정보 반환까지 구현했습니다.
- 이메일 인증 코드는 MVP 기준 DB의 `user_email_verifications` 테이블에 저장/검증합니다.
- 메일 발송은 기존 SES 메일 발송기를 사용합니다.

---

## 🧑‍💻 Assignee

- @imclaremont
