### PR TITLE
[Fix] Local Auth 리뷰 피드백 반영

### DIFF
--- a/docs/db/quiket-ddl-mvp.sql
+++ b/docs/db/quiket-ddl-mvp.sql
@@ -41,7 +41,7 @@ CREATE TABLE user_auth_identities (
     id BIGINT NOT NULL AUTO_INCREMENT COMMENT '로그인 수단 레코드 식별 PK',
     user_id BIGINT NOT NULL COMMENT '사용자 ID',
     provider VARCHAR(20) NOT NULL COMMENT '로그인 수단 구분값',
-    provider_subject VARCHAR(255) NOT NULL DEFAULT '' COMMENT '소셜 로그인 고유 식별값, local은 빈 문자열',
+    provider_subject VARCHAR(255) NOT NULL DEFAULT '' COMMENT '로그인 수단별 사용자 고유 식별값, local은 users.public_id',
     password_hash VARCHAR(255) NULL COMMENT '자체 로그인 비밀번호 해시값',
     is_primary TINYINT(1) NOT NULL DEFAULT 0 COMMENT '대표 로그인 수단 여부',
     last_login_at DATETIME(3) NULL COMMENT '해당 인증 수단 마지막 로그인 시각',

--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -197,7 +197,7 @@ paths:
       description: |
         회원가입 후 이메일 인증 메일을 재발송합니다.
         인증 방식은 코드 입력 방식을 기본으로 하되, 링크 방식 확장을 고려합니다.
-        인증 코드는 Redis에 TTL 30분으로 저장합니다.
+        인증 코드는 Redis에 TTL 10분으로 저장합니다.
       operationId: resendEmailVerification
       requestBody:
         required: true
@@ -224,7 +224,7 @@ paths:
                     message: 이메일 인증 메일이 발송되었습니다.
                     data:
                       email: user@example.com
-                      expiresInSeconds: 1800
+                      expiresInSeconds: 600
         '400':
           $ref: '#/components/responses/BadRequest'
         '404':
@@ -378,8 +378,8 @@ paths:
       summary: 비밀번호 재설정 요청
       description: |
         등록된 이메일로 비밀번호 재설정 링크 또는 인증 코드를 발송합니다.
-        재설정 링크 유효시간은 30분입니다.
-        재설정 코드 또는 재설정 토큰은 Redis에 TTL 30분으로 저장합니다.
+        재설정 링크 유효시간은 10분입니다.
+        재설정 코드 또는 재설정 토큰은 Redis에 TTL 10분으로 저장합니다.
       operationId: requestPasswordReset
       requestBody:
         required: true
@@ -2065,7 +2065,7 @@ components:
         expiresInSeconds:
           type: integer
           format: int64
-          example: 1800
+          example: 600
 
     EmailVerificationConfirmData:
       type: object
@@ -2094,7 +2094,7 @@ components:
         expiresInSeconds:
           type: integer
           format: int64
-          example: 1800
+          example: 600
 
     KakaoAccountLinkRequiredData:
       type: object

--- a/src/main/java/com/f1/quiket/config/SchedulingConfig.java
+++ b/src/main/java/com/f1/quiket/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.f1.quiket.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/f1/quiket/domain/auth/entity/UserAuthIdentity.java
+++ b/src/main/java/com/f1/quiket/domain/auth/entity/UserAuthIdentity.java
@@ -72,7 +72,7 @@ public class UserAuthIdentity extends BaseEntity {
         UserAuthIdentity identity = new UserAuthIdentity();
         identity.user = user;
         identity.provider = "local";
-        identity.providerSubject = "";
+        identity.providerSubject = user.getPublicId();
         identity.passwordHash = passwordHash;
         identity.primary = primary;
         return identity;

--- a/src/main/java/com/f1/quiket/domain/auth/event/EmailVerificationMailRequestedEvent.java
+++ b/src/main/java/com/f1/quiket/domain/auth/event/EmailVerificationMailRequestedEvent.java
@@ -1,0 +1,7 @@
+package com.f1.quiket.domain.auth.event;
+
+public record EmailVerificationMailRequestedEvent(
+        String email,
+        String verificationCode
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/auth/repository/UserEmailVerificationRepository.java
+++ b/src/main/java/com/f1/quiket/domain/auth/repository/UserEmailVerificationRepository.java
@@ -1,8 +1,12 @@
 package com.f1.quiket.domain.auth.repository;
 
 import com.f1.quiket.domain.auth.entity.UserEmailVerification;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserEmailVerificationRepository extends JpaRepository<UserEmailVerification, Long> {
 
@@ -16,5 +20,19 @@ public interface UserEmailVerificationRepository extends JpaRepository<UserEmail
             String email,
             String verificationToken,
             String status
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update UserEmailVerification verification
+            set verification.status = :expiredStatus
+            where verification.status = :pendingStatus
+              and verification.expiresAt <= :now
+              and verification.deletedAt is null
+            """)
+    int expirePendingVerifications(
+            @Param("pendingStatus") String pendingStatus,
+            @Param("expiredStatus") String expiredStatus,
+            @Param("now") LocalDateTime now
     );
 }

--- a/src/main/java/com/f1/quiket/domain/auth/service/LocalAuthService.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/LocalAuthService.java
@@ -1,15 +1,16 @@
 package com.f1.quiket.domain.auth.service;
 
+import com.f1.quiket.domain.auth.dto.AuthTokenResponse;
 import com.f1.quiket.domain.auth.dto.EmailAvailabilityResponse;
 import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmRequest;
 import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmResponse;
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
-import com.f1.quiket.domain.auth.dto.AuthTokenResponse;
 import com.f1.quiket.domain.auth.dto.LoginRequest;
 import com.f1.quiket.domain.auth.dto.SignupRequest;
 import com.f1.quiket.domain.auth.dto.SignupResponse;
 import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.entity.UserEmailVerification;
+import com.f1.quiket.domain.auth.event.EmailVerificationMailRequestedEvent;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
 import com.f1.quiket.domain.auth.repository.UserEmailVerificationRepository;
 import com.f1.quiket.domain.user.entity.User;
@@ -17,12 +18,10 @@ import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import com.f1.quiket.global.util.UuidV7Generator;
-import com.f1.quiket.infra.mail.dto.MailSendRequest;
-import com.f1.quiket.infra.mail.service.SesMailSender;
-import com.f1.quiket.infra.mail.template.MailTemplateFactory;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +34,8 @@ public class LocalAuthService {
 
     private static final String PROVIDER_LOCAL = "local";
     private static final String VERIFICATION_STATUS_PENDING = "pending";
-    private static final long EMAIL_VERIFICATION_TTL_SECONDS = 1800L;
+    private static final String VERIFICATION_STATUS_EXPIRED = "expired";
+    private static final long EMAIL_VERIFICATION_TTL_SECONDS = 600L;
     private static final int MAX_FAILED_LOGIN_COUNT = 5;
 
     private final UserRepository userRepository;
@@ -43,9 +43,8 @@ public class LocalAuthService {
     private final UserEmailVerificationRepository userEmailVerificationRepository;
     private final PasswordEncoder passwordEncoder;
     private final EmailVerificationCodeGenerator verificationCodeGenerator;
-    private final MailTemplateFactory mailTemplateFactory;
-    private final SesMailSender sesMailSender;
     private final AuthTokenService authTokenService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public SignupResponse signup(SignupRequest request) {
         validatePasswordConfirm(request.getPassword(), request.getPasswordConfirm());
@@ -108,6 +107,14 @@ public class LocalAuthService {
         return authTokenService.issueTokens(user, context);
     }
 
+    public int expirePendingEmailVerifications() {
+        return userEmailVerificationRepository.expirePendingVerifications(
+                VERIFICATION_STATUS_PENDING,
+                VERIFICATION_STATUS_EXPIRED,
+                LocalDateTime.now()
+        );
+    }
+
     private void validatePasswordConfirm(String password, String passwordConfirm) {
         if (!password.equals(passwordConfirm)) {
             throw new CustomException(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
@@ -162,8 +169,7 @@ public class LocalAuthService {
         );
         userEmailVerificationRepository.save(verification);
 
-        MailSendRequest mailRequest = mailTemplateFactory.createSignUpVerificationMail(user.getEmail(), verificationCode);
-        sesMailSender.sendMail(mailRequest);
+        eventPublisher.publishEvent(new EmailVerificationMailRequestedEvent(user.getEmail(), verificationCode));
     }
 
     private UserEmailVerification findPendingVerification(EmailVerificationConfirmRequest request) {

--- a/src/main/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListener.java
+++ b/src/main/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListener.java
@@ -1,0 +1,27 @@
+package com.f1.quiket.infra.mail.listener;
+
+import com.f1.quiket.domain.auth.event.EmailVerificationMailRequestedEvent;
+import com.f1.quiket.infra.mail.dto.MailSendRequest;
+import com.f1.quiket.infra.mail.service.SesMailSender;
+import com.f1.quiket.infra.mail.template.MailTemplateFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationMailEventListener {
+
+    private final MailTemplateFactory mailTemplateFactory;
+    private final SesMailSender sesMailSender;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void sendEmailVerificationMail(EmailVerificationMailRequestedEvent event) {
+        MailSendRequest mailRequest = mailTemplateFactory.createSignUpVerificationMail(
+                event.email(),
+                event.verificationCode()
+        );
+        sesMailSender.sendMail(mailRequest);
+    }
+}

--- a/src/main/java/com/f1/quiket/support/auth/EmailVerificationCleanupScheduler.java
+++ b/src/main/java/com/f1/quiket/support/auth/EmailVerificationCleanupScheduler.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.support.auth;
+
+import com.f1.quiket.domain.auth.service.LocalAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationCleanupScheduler {
+
+    private final LocalAuthService localAuthService;
+
+    @Scheduled(fixedDelayString = "${quiket.auth.email-verification-cleanup-fixed-delay-ms:600000}")
+    public void expirePendingEmailVerifications() {
+        localAuthService.expirePendingEmailVerifications();
+    }
+}

--- a/src/main/resources/db/migration/V2__fix_local_provider_subject.sql
+++ b/src/main/resources/db/migration/V2__fix_local_provider_subject.sql
@@ -1,0 +1,10 @@
+-- local 인증 수단 provider_subject 보정
+UPDATE user_auth_identities uai
+INNER JOIN users u ON uai.user_id = u.id
+SET uai.provider_subject = u.public_id
+WHERE uai.provider = 'local'
+  AND uai.provider_subject = '';
+
+ALTER TABLE user_auth_identities
+    MODIFY provider_subject VARCHAR(255) NOT NULL DEFAULT ''
+        COMMENT '로그인 수단별 사용자 고유 식별값, local은 users.public_id';

--- a/src/test/java/com/f1/quiket/domain/auth/service/LocalAuthServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/auth/service/LocalAuthServiceTest.java
@@ -3,25 +3,33 @@ package com.f1.quiket.domain.auth.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.f1.quiket.domain.auth.dto.AuthTokenResponse;
 import com.f1.quiket.domain.auth.dto.AuthUserResponse;
+import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
 import com.f1.quiket.domain.auth.dto.LoginRequest;
+import com.f1.quiket.domain.auth.dto.SignupRequest;
+import com.f1.quiket.domain.auth.dto.SignupResponse;
 import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.auth.entity.UserEmailVerification;
+import com.f1.quiket.domain.auth.event.EmailVerificationMailRequestedEvent;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
 import com.f1.quiket.domain.auth.repository.UserEmailVerificationRepository;
 import com.f1.quiket.domain.user.entity.User;
 import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
-import com.f1.quiket.infra.mail.service.SesMailSender;
-import com.f1.quiket.infra.mail.template.MailTemplateFactory;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -29,25 +37,81 @@ class LocalAuthServiceTest {
 
     private UserRepository userRepository;
     private UserAuthIdentityRepository userAuthIdentityRepository;
+    private UserEmailVerificationRepository userEmailVerificationRepository;
+    private EmailVerificationCodeGenerator verificationCodeGenerator;
     private AuthTokenService authTokenService;
+    private ApplicationEventPublisher eventPublisher;
     private LocalAuthService localAuthService;
 
     @BeforeEach
     void setUp() {
         userRepository = mock(UserRepository.class);
         userAuthIdentityRepository = mock(UserAuthIdentityRepository.class);
+        userEmailVerificationRepository = mock(UserEmailVerificationRepository.class);
+        verificationCodeGenerator = mock(EmailVerificationCodeGenerator.class);
         authTokenService = mock(AuthTokenService.class);
+        eventPublisher = mock(ApplicationEventPublisher.class);
 
         localAuthService = new LocalAuthService(
                 userRepository,
                 userAuthIdentityRepository,
-                mock(UserEmailVerificationRepository.class),
+                userEmailVerificationRepository,
                 new BCryptPasswordEncoder(),
-                mock(EmailVerificationCodeGenerator.class),
-                mock(MailTemplateFactory.class),
-                mock(SesMailSender.class),
-                authTokenService
+                verificationCodeGenerator,
+                authTokenService,
+                eventPublisher
         );
+    }
+
+    @Test
+    void signup_uses_user_public_id_as_local_provider_subject() {
+        SignupRequest request = signupRequest("new@example.com", "Password123!", "도토리");
+        when(userRepository.existsByEmail("new@example.com")).thenReturn(false);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(userAuthIdentityRepository.save(any(UserAuthIdentity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(verificationCodeGenerator.generate()).thenReturn("123456");
+        when(userEmailVerificationRepository.save(any(UserEmailVerification.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        SignupResponse response = localAuthService.signup(request);
+
+        ArgumentCaptor<UserAuthIdentity> identityCaptor = ArgumentCaptor.forClass(UserAuthIdentity.class);
+        verify(userAuthIdentityRepository).save(identityCaptor.capture());
+        assertThat(identityCaptor.getValue().getProviderSubject()).isEqualTo(response.getUserId());
+
+        ArgumentCaptor<EmailVerificationMailRequestedEvent> eventCaptor =
+                ArgumentCaptor.forClass(EmailVerificationMailRequestedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().email()).isEqualTo("new@example.com");
+        assertThat(eventCaptor.getValue().verificationCode()).isEqualTo("123456");
+    }
+
+    @Test
+    void resendEmailVerification_returns_ten_minute_ttl() {
+        User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
+        when(userRepository.findByEmailAndDeletedAtIsNull("user@example.com")).thenReturn(Optional.of(user));
+        when(verificationCodeGenerator.generate()).thenReturn("123456");
+        when(userEmailVerificationRepository.save(any(UserEmailVerification.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        EmailVerificationSentResponse response = localAuthService.resendEmailVerification("user@example.com");
+
+        assertThat(response.getExpiresInSeconds()).isEqualTo(600L);
+        verify(eventPublisher).publishEvent(any(EmailVerificationMailRequestedEvent.class));
+    }
+
+    @Test
+    void expirePendingEmailVerifications_updates_expired_pending_rows() {
+        when(userEmailVerificationRepository.expirePendingVerifications(
+                eq("pending"),
+                eq("expired"),
+                any(LocalDateTime.class)
+        )).thenReturn(3);
+
+        int expiredCount = localAuthService.expirePendingEmailVerifications();
+
+        assertThat(expiredCount).isEqualTo(3);
     }
 
     @Test
@@ -132,6 +196,15 @@ class LocalAuthServiceTest {
         LoginRequest request = new LoginRequest();
         ReflectionTestUtils.setField(request, "email", email);
         ReflectionTestUtils.setField(request, "password", password);
+        return request;
+    }
+
+    private SignupRequest signupRequest(String email, String password, String nickname) {
+        SignupRequest request = new SignupRequest();
+        ReflectionTestUtils.setField(request, "email", email);
+        ReflectionTestUtils.setField(request, "password", password);
+        ReflectionTestUtils.setField(request, "passwordConfirm", password);
+        ReflectionTestUtils.setField(request, "nickname", nickname);
         return request;
     }
 


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- PR #23 리뷰에서 확인된 Local Auth 후속 수정 사항을 반영했습니다.
- local 인증 수단의 `provider_subject` 중복 가능성을 제거했습니다.
- 기능명세 상세 기준에 맞춰 인증코드 TTL을 10분으로 정리했습니다.
- 이메일 인증 메일 발송을 트랜잭션 commit 이후 이벤트로 분리했습니다.

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- local `provider_subject`를 빈 문자열 대신 `user.publicId`로 저장
- 기존 local 빈 `provider_subject` 보정용 `V2` Flyway 마이그레이션 추가
- MVP DDL 문서의 `provider_subject` 설명 갱신
- 이메일 인증 TTL `1800초` -> `600초` 변경
- OpenAPI 인증코드/비밀번호 재설정 TTL 설명과 예시를 10분 기준으로 갱신
- 만료된 pending 이메일 인증 요청 bulk update Repository 및 Scheduler 추가
- `EmailVerificationMailRequestedEvent`와 AFTER_COMMIT listener 추가
- Local Auth 단위 테스트 보강

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test`
2. `ruby -e "require 'yaml'; YAML.load_file('docs/openapi/quiket-mvp-api.yaml'); puts 'YAML OK'"`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #27
Related to #23

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 기존 `V1` 마이그레이션은 이미 적용된 DB의 Flyway checksum 변경을 피하기 위해 수정하지 않고, 보정 작업은 `V2`로 추가했습니다.
- 기능명세 상세 기준 인증코드 유효시간은 10분입니다.
- SES 실발송은 트랜잭션 commit 이후 처리됩니다.

---

## 🧑‍💻 Assignee

- @imclaremont
