### PR TITLE
[Fix] JWT 토큰 만료 정책 수정

### DIFF
--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -1995,11 +1995,13 @@ components:
         accessTokenExpiresIn:
           type: integer
           format: int64
-          example: 3600
+          description: Access Token 만료 시간(초). MVP 기준 30분
+          example: 1800
         refreshTokenExpiresIn:
           type: integer
           format: int64
-          example: 1209600
+          description: Refresh Token 만료 시간(초). MVP 기준 30일
+          example: 2592000
 
     AuthTokenData:
       allOf:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,5 +42,5 @@ quiket:
   jwt:
     issuer: quiket
     secret: ${QUIKET_JWT_SECRET:local-dev-jwt-secret-for-quiket-f1-authentication}
-    access-token-expires-in-seconds: 3600
-    refresh-token-expires-in-seconds: 1209600
+    access-token-expires-in-seconds: 1800
+    refresh-token-expires-in-seconds: 2592000

--- a/src/test/java/com/f1/quiket/domain/auth/service/AuthTokenServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/auth/service/AuthTokenServiceTest.java
@@ -42,7 +42,7 @@ class AuthTokenServiceTest {
     void setUp() {
         jwtTokenProvider = mock(JwtTokenProvider.class);
         jwtProperties = new JwtProperties();
-        jwtProperties.setRefreshTokenExpiresInSeconds(1209600L);
+        jwtProperties.setRefreshTokenExpiresInSeconds(2592000L);
         refreshTokenGenerator = mock(RefreshTokenGenerator.class);
         tokenHashGenerator = new TokenHashGenerator();
         userRefreshTokenRepository = mock(UserRefreshTokenRepository.class);
@@ -71,7 +71,7 @@ class AuthTokenServiceTest {
         when(userRefreshTokenRepository.findByTokenHashAndDeletedAtIsNull(tokenHashGenerator.hash(refreshTokenValue)))
                 .thenReturn(Optional.of(refreshToken));
         when(jwtTokenProvider.createAccessToken(user)).thenReturn("new-access-token");
-        when(jwtTokenProvider.getAccessTokenExpiresInSeconds()).thenReturn(3600L);
+        when(jwtTokenProvider.getAccessTokenExpiresInSeconds()).thenReturn(1800L);
         when(refreshTokenGenerator.generate()).thenReturn("new-refresh-token");
         when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(identity));
 

--- a/src/test/java/com/f1/quiket/domain/auth/service/LocalAuthServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/auth/service/LocalAuthServiceTest.java
@@ -145,8 +145,8 @@ class LocalAuthServiceTest {
         return AuthTokenResponse.of(
                 "access-token",
                 "refresh-token",
-                3600L,
-                1209600L,
+                1800L,
+                2592000L,
                 AuthUserResponse.of(user, identities)
         );
     }

--- a/src/test/java/com/f1/quiket/global/auth/JwtTokenProviderTest.java
+++ b/src/test/java/com/f1/quiket/global/auth/JwtTokenProviderTest.java
@@ -18,7 +18,7 @@ class JwtTokenProviderTest {
         JwtProperties jwtProperties = new JwtProperties();
         jwtProperties.setIssuer("quiket-test");
         jwtProperties.setSecret("test-jwt-secret-for-quiket-f1-authentication");
-        jwtProperties.setAccessTokenExpiresInSeconds(3600L);
+        jwtProperties.setAccessTokenExpiresInSeconds(1800L);
         jwtTokenProvider = new JwtTokenProvider(jwtProperties);
     }
 

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -34,5 +34,5 @@ quiket:
   jwt:
     issuer: quiket-test
     secret: test-jwt-secret-for-quiket-f1-authentication
-    access-token-expires-in-seconds: 3600
-    refresh-token-expires-in-seconds: 1209600
+    access-token-expires-in-seconds: 1800
+    refresh-token-expires-in-seconds: 2592000


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- JWT Access Token / Refresh Token 만료 정책을 서비스 기준에 맞게 수정했습니다.
- Access Token은 30분, Refresh Token은 30일로 반영했습니다.
- API 명세 YAML과 서버 설정, 테스트 기대값을 함께 갱신했습니다.

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `quiket.jwt.access-token-expires-in-seconds`: `3600` -> `1800`
- `quiket.jwt.refresh-token-expires-in-seconds`: `1209600` -> `2592000`
- OpenAPI `TokenPair` 스키마의 `accessTokenExpiresIn`, `refreshTokenExpiresIn` 예시값 및 설명 갱신
- JWT/토큰 서비스 테스트 기대값 갱신

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test`
2. `ruby -e "require 'yaml'; YAML.load_file('docs/openapi/quiket-mvp-api.yaml'); puts 'YAML OK'"`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #29

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- AT 30분은 `1800초`, RT 30일은 `2592000초` 기준입니다.
- `application-prod.yaml`은 별도 만료시간 override 없이 공통 `application.yaml` 값을 사용합니다.

---

## 🧑‍💻 Assignee

- @imclaremont
