### PR TITLE
[Feat] Kakao OAuth 로그인 및 계정 연동 기능 구현

### DIFF
--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -1894,7 +1894,7 @@ components:
           example: kakao_access_token_from_android_sdk
         agreedToTerms:
           type: boolean
-          default: true
+          description: 신규 Kakao 가입 생성 시 true 명시 필요
           example: true
 
     KakaoAccountLinkRequest:

--- a/src/main/java/com/f1/quiket/config/SecurityConfig.java
+++ b/src/main/java/com/f1/quiket/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                                 "/api/v1/auth/email-verifications/**",
                                 "/api/v1/auth/login",
                                 "/api/v1/auth/token/refresh",
+                                "/api/v1/auth/oauth/kakao/**",
                                 "/api-docs/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",

--- a/src/main/java/com/f1/quiket/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/f1/quiket/domain/auth/controller/AuthController.java
@@ -159,7 +159,7 @@ public class AuthController {
                 request,
                 createTokenRequestContext(deviceId, deviceName, userAgent, httpServletRequest)
         );
-        return ResponseEntity.ok(ApiResponse.success(SuccessCode.AUTH_OAUTH_SIGNUP_SUCCESS, response));
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.AUTH_OAUTH_NICKNAME_COMPLETED, response));
     }
 
     @PostMapping("/token/refresh")

--- a/src/main/java/com/f1/quiket/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/f1/quiket/domain/auth/controller/AuthController.java
@@ -7,6 +7,11 @@ import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmRequest;
 import com.f1.quiket.domain.auth.dto.EmailVerificationConfirmResponse;
 import com.f1.quiket.domain.auth.dto.EmailVerificationRequest;
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.auth.dto.KakaoAccountLinkRequest;
+import com.f1.quiket.domain.auth.dto.KakaoAccountLinkRequiredResponse;
+import com.f1.quiket.domain.auth.dto.KakaoLoginRequest;
+import com.f1.quiket.domain.auth.dto.KakaoNicknameRequest;
+import com.f1.quiket.domain.auth.dto.KakaoNicknameRequiredResponse;
 import com.f1.quiket.domain.auth.dto.LoginRequest;
 import com.f1.quiket.domain.auth.dto.LogoutRequest;
 import com.f1.quiket.domain.auth.dto.RefreshTokenRequest;
@@ -14,9 +19,12 @@ import com.f1.quiket.domain.auth.dto.SignupRequest;
 import com.f1.quiket.domain.auth.dto.SignupResponse;
 import com.f1.quiket.domain.auth.service.AuthTokenRequestContext;
 import com.f1.quiket.domain.auth.service.AuthTokenService;
+import com.f1.quiket.domain.auth.service.KakaoOAuthLoginResult;
+import com.f1.quiket.domain.auth.service.KakaoOAuthService;
 import com.f1.quiket.domain.auth.service.LocalAuthService;
 import com.f1.quiket.global.auth.UserPrincipal;
 import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.ErrorCode;
 import com.f1.quiket.global.response.SuccessCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -47,6 +55,7 @@ public class AuthController {
 
     private final LocalAuthService localAuthService;
     private final AuthTokenService authTokenService;
+    private final KakaoOAuthService kakaoOAuthService;
 
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse<SignupResponse>> signup(@Valid @RequestBody SignupRequest request) {
@@ -99,6 +108,60 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.AUTH_LOGIN_SUCCESS, response));
     }
 
+    @PostMapping("/oauth/kakao/login")
+    public ResponseEntity<ApiResponse<?>> kakaoLogin(
+            @Valid @RequestBody KakaoLoginRequest request,
+            @RequestHeader(value = X_DEVICE_ID, required = false) String deviceId,
+            @RequestHeader(value = X_DEVICE_NAME, required = false) String deviceName,
+            @RequestHeader(value = USER_AGENT, required = false) String userAgent,
+            HttpServletRequest httpServletRequest
+    ) {
+        KakaoOAuthLoginResult result = kakaoOAuthService.login(
+                request,
+                createTokenRequestContext(deviceId, deviceName, userAgent, httpServletRequest)
+        );
+        return switch (result.getStatus()) {
+            case EXISTING_LOGIN -> ResponseEntity.ok(
+                    ApiResponse.success(SuccessCode.AUTH_OAUTH_LOGIN_SUCCESS, result.getTokenResponse())
+            );
+            case SIGNUP_LOGIN -> ResponseEntity.status(SuccessCode.AUTH_OAUTH_SIGNUP_SUCCESS.getStatus())
+                    .body(ApiResponse.success(SuccessCode.AUTH_OAUTH_SIGNUP_SUCCESS, result.getTokenResponse()));
+            case ACCOUNT_LINK_REQUIRED -> accountLinkRequiredResponse(result.getAccountLinkRequiredResponse());
+            case NICKNAME_REQUIRED -> ResponseEntity.status(SuccessCode.AUTH_NICKNAME_REQUIRED.getStatus())
+                    .body(ApiResponse.success(SuccessCode.AUTH_NICKNAME_REQUIRED, result.getNicknameRequiredResponse()));
+        };
+    }
+
+    @PostMapping("/oauth/kakao/link")
+    public ResponseEntity<ApiResponse<AuthTokenResponse>> linkKakaoAccount(
+            @Valid @RequestBody KakaoAccountLinkRequest request,
+            @RequestHeader(value = X_DEVICE_ID, required = false) String deviceId,
+            @RequestHeader(value = X_DEVICE_NAME, required = false) String deviceName,
+            @RequestHeader(value = USER_AGENT, required = false) String userAgent,
+            HttpServletRequest httpServletRequest
+    ) {
+        AuthTokenResponse response = kakaoOAuthService.link(
+                request,
+                createTokenRequestContext(deviceId, deviceName, userAgent, httpServletRequest)
+        );
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.AUTH_OAUTH_LINK_SUCCESS, response));
+    }
+
+    @PostMapping("/oauth/kakao/nickname")
+    public ResponseEntity<ApiResponse<AuthTokenResponse>> completeKakaoNickname(
+            @Valid @RequestBody KakaoNicknameRequest request,
+            @RequestHeader(value = X_DEVICE_ID, required = false) String deviceId,
+            @RequestHeader(value = X_DEVICE_NAME, required = false) String deviceName,
+            @RequestHeader(value = USER_AGENT, required = false) String userAgent,
+            HttpServletRequest httpServletRequest
+    ) {
+        AuthTokenResponse response = kakaoOAuthService.completeNickname(
+                request,
+                createTokenRequestContext(deviceId, deviceName, userAgent, httpServletRequest)
+        );
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.AUTH_OAUTH_SIGNUP_SUCCESS, response));
+    }
+
     @PostMapping("/token/refresh")
     public ResponseEntity<ApiResponse<AuthTokenResponse>> refreshToken(
             @Valid @RequestBody RefreshTokenRequest request,
@@ -149,5 +212,15 @@ public class AuthController {
             return forwardedFor.split(",")[0].trim();
         }
         return request.getRemoteAddr();
+    }
+
+    private ResponseEntity<ApiResponse<?>> accountLinkRequiredResponse(KakaoAccountLinkRequiredResponse response) {
+        return ResponseEntity.status(ErrorCode.AUTH_OAUTH_ACCOUNT_LINK_REQUIRED.getStatus())
+                .body(ApiResponse.<KakaoAccountLinkRequiredResponse>builder()
+                        .success(false)
+                        .code(ErrorCode.AUTH_OAUTH_ACCOUNT_LINK_REQUIRED.getCode())
+                        .message(ErrorCode.AUTH_OAUTH_ACCOUNT_LINK_REQUIRED.getMessage())
+                        .data(response)
+                        .build());
     }
 }

--- a/src/main/java/com/f1/quiket/domain/auth/dto/KakaoAccountLinkRequest.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/KakaoAccountLinkRequest.java
@@ -1,0 +1,25 @@
+package com.f1.quiket.domain.auth.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoAccountLinkRequest {
+
+    @NotBlank(message = "계정 연동 토큰은 필수입니다")
+    private String linkToken;
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수입니다")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다")
+    private String password;
+
+    @AssertTrue(message = "계정 연동 동의는 필수입니다")
+    private boolean agreedToLink;
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/KakaoAccountLinkRequiredResponse.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/KakaoAccountLinkRequiredResponse.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class KakaoAccountLinkRequiredResponse {
+
+    private final String email;
+    private final String provider;
+    private final String linkToken;
+    private final long expiresInSeconds;
+
+    public static KakaoAccountLinkRequiredResponse of(String email, String linkToken, long expiresInSeconds) {
+        return KakaoAccountLinkRequiredResponse.builder()
+                .email(email)
+                .provider("kakao")
+                .linkToken(linkToken)
+                .expiresInSeconds(expiresInSeconds)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/KakaoLoginRequest.java
@@ -11,5 +11,5 @@ public class KakaoLoginRequest {
     @NotBlank(message = "Kakao Access Token은 필수입니다")
     private String kakaoAccessToken;
 
-    private boolean agreedToTerms = true;
+    private Boolean agreedToTerms;
 }

--- a/src/main/java/com/f1/quiket/domain/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/KakaoLoginRequest.java
@@ -1,0 +1,15 @@
+package com.f1.quiket.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoLoginRequest {
+
+    @NotBlank(message = "Kakao Access Token은 필수입니다")
+    private String kakaoAccessToken;
+
+    private boolean agreedToTerms = true;
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/KakaoNicknameRequest.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/KakaoNicknameRequest.java
@@ -1,0 +1,20 @@
+package com.f1.quiket.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoNicknameRequest {
+
+    @NotBlank(message = "Kakao 회원가입 토큰은 필수입니다")
+    private String signupToken;
+
+    @NotBlank(message = "닉네임은 필수입니다")
+    @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하여야 합니다")
+    @Pattern(regexp = "^[가-힣A-Za-z]{2,12}$", message = "닉네임은 한글 또는 영문만 사용할 수 있습니다")
+    private String nickname;
+}

--- a/src/main/java/com/f1/quiket/domain/auth/dto/KakaoNicknameRequiredResponse.java
+++ b/src/main/java/com/f1/quiket/domain/auth/dto/KakaoNicknameRequiredResponse.java
@@ -1,0 +1,21 @@
+package com.f1.quiket.domain.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class KakaoNicknameRequiredResponse {
+
+    private final String signupToken;
+    private final String provider;
+    private final String suggestedNickname;
+
+    public static KakaoNicknameRequiredResponse of(String signupToken, String suggestedNickname) {
+        return KakaoNicknameRequiredResponse.builder()
+                .signupToken(signupToken)
+                .provider("kakao")
+                .suggestedNickname(suggestedNickname)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/entity/UserAuthIdentity.java
+++ b/src/main/java/com/f1/quiket/domain/auth/entity/UserAuthIdentity.java
@@ -78,6 +78,15 @@ public class UserAuthIdentity extends BaseEntity {
         return identity;
     }
 
+    public static UserAuthIdentity createOAuth(User user, String provider, String providerSubject, boolean primary) {
+        UserAuthIdentity identity = new UserAuthIdentity();
+        identity.user = user;
+        identity.provider = provider;
+        identity.providerSubject = providerSubject;
+        identity.primary = primary;
+        return identity;
+    }
+
     public void recordLoginSuccess() {
         this.lastLoginAt = LocalDateTime.now();
     }

--- a/src/main/java/com/f1/quiket/domain/auth/repository/UserAuthIdentityRepository.java
+++ b/src/main/java/com/f1/quiket/domain/auth/repository/UserAuthIdentityRepository.java
@@ -10,5 +10,7 @@ public interface UserAuthIdentityRepository extends JpaRepository<UserAuthIdenti
 
     Optional<UserAuthIdentity> findByUserAndProviderAndDeletedAtIsNull(User user, String provider);
 
+    Optional<UserAuthIdentity> findByProviderAndProviderSubjectAndDeletedAtIsNull(String provider, String providerSubject);
+
     List<UserAuthIdentity> findAllByUserAndDeletedAtIsNull(User user);
 }

--- a/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthLinkTokenPayload.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthLinkTokenPayload.java
@@ -1,0 +1,7 @@
+package com.f1.quiket.domain.auth.service;
+
+public record KakaoOAuthLinkTokenPayload(
+        String providerSubject,
+        String email
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthLoginResult.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthLoginResult.java
@@ -1,0 +1,54 @@
+package com.f1.quiket.domain.auth.service;
+
+import com.f1.quiket.domain.auth.dto.AuthTokenResponse;
+import com.f1.quiket.domain.auth.dto.KakaoAccountLinkRequiredResponse;
+import com.f1.quiket.domain.auth.dto.KakaoNicknameRequiredResponse;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class KakaoOAuthLoginResult {
+
+    private final KakaoOAuthLoginStatus status;
+    private final AuthTokenResponse tokenResponse;
+    private final KakaoAccountLinkRequiredResponse accountLinkRequiredResponse;
+    private final KakaoNicknameRequiredResponse nicknameRequiredResponse;
+
+    public static KakaoOAuthLoginResult existingLogin(AuthTokenResponse tokenResponse) {
+        return new KakaoOAuthLoginResult(
+                KakaoOAuthLoginStatus.EXISTING_LOGIN,
+                tokenResponse,
+                null,
+                null
+        );
+    }
+
+    public static KakaoOAuthLoginResult signupLogin(AuthTokenResponse tokenResponse) {
+        return new KakaoOAuthLoginResult(
+                KakaoOAuthLoginStatus.SIGNUP_LOGIN,
+                tokenResponse,
+                null,
+                null
+        );
+    }
+
+    public static KakaoOAuthLoginResult accountLinkRequired(KakaoAccountLinkRequiredResponse response) {
+        return new KakaoOAuthLoginResult(
+                KakaoOAuthLoginStatus.ACCOUNT_LINK_REQUIRED,
+                null,
+                response,
+                null
+        );
+    }
+
+    public static KakaoOAuthLoginResult nicknameRequired(KakaoNicknameRequiredResponse response) {
+        return new KakaoOAuthLoginResult(
+                KakaoOAuthLoginStatus.NICKNAME_REQUIRED,
+                null,
+                null,
+                response
+        );
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthLoginStatus.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthLoginStatus.java
@@ -1,0 +1,8 @@
+package com.f1.quiket.domain.auth.service;
+
+public enum KakaoOAuthLoginStatus {
+    EXISTING_LOGIN,
+    SIGNUP_LOGIN,
+    ACCOUNT_LINK_REQUIRED,
+    NICKNAME_REQUIRED
+}

--- a/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthService.java
@@ -53,7 +53,7 @@ public class KakaoOAuthService {
         }
 
         validateUsableKakaoEmail(kakaoUserInfo);
-        return loginWithNewKakaoIdentity(kakaoUserInfo, request.isAgreedToTerms(), context);
+        return loginWithNewKakaoIdentity(kakaoUserInfo, request.getAgreedToTerms(), context);
     }
 
     public AuthTokenResponse link(KakaoAccountLinkRequest request, AuthTokenRequestContext context) {
@@ -145,7 +145,7 @@ public class KakaoOAuthService {
 
     private KakaoOAuthLoginResult loginWithNewKakaoIdentity(
             KakaoUserInfo kakaoUserInfo,
-            boolean agreedToTerms,
+            Boolean agreedToTerms,
             AuthTokenRequestContext context
     ) {
         User existingUser = userRepository.findByEmailAndDeletedAtIsNull(kakaoUserInfo.email())
@@ -212,8 +212,8 @@ public class KakaoOAuthService {
         }
     }
 
-    private void validateTermsAgreed(boolean agreedToTerms) {
-        if (!agreedToTerms) {
+    private void validateTermsAgreed(Boolean agreedToTerms) {
+        if (!Boolean.TRUE.equals(agreedToTerms)) {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
     }

--- a/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthService.java
@@ -1,0 +1,257 @@
+package com.f1.quiket.domain.auth.service;
+
+import com.f1.quiket.domain.auth.dto.AuthTokenResponse;
+import com.f1.quiket.domain.auth.dto.KakaoAccountLinkRequest;
+import com.f1.quiket.domain.auth.dto.KakaoAccountLinkRequiredResponse;
+import com.f1.quiket.domain.auth.dto.KakaoLoginRequest;
+import com.f1.quiket.domain.auth.dto.KakaoNicknameRequest;
+import com.f1.quiket.domain.auth.dto.KakaoNicknameRequiredResponse;
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.global.util.UuidV7Generator;
+import com.f1.quiket.infra.kakao.client.KakaoApiClient;
+import com.f1.quiket.infra.kakao.dto.KakaoUserInfo;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class KakaoOAuthService {
+
+    private static final String PROVIDER_KAKAO = "kakao";
+    private static final String PROVIDER_LOCAL = "local";
+    private static final long KAKAO_TEMP_TOKEN_TTL_SECONDS = 600L;
+    private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[가-힣A-Za-z]{2,12}$");
+
+    private final KakaoApiClient kakaoApiClient;
+    private final UserRepository userRepository;
+    private final UserAuthIdentityRepository userAuthIdentityRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthTokenService authTokenService;
+    private final KakaoOAuthTemporaryTokenStore temporaryTokenStore;
+
+    public KakaoOAuthLoginResult login(KakaoLoginRequest request, AuthTokenRequestContext context) {
+        KakaoUserInfo kakaoUserInfo = kakaoApiClient.getUserInfo(request.getKakaoAccessToken());
+        UserAuthIdentity kakaoIdentity = userAuthIdentityRepository
+                .findByProviderAndProviderSubjectAndDeletedAtIsNull(
+                        PROVIDER_KAKAO,
+                        kakaoUserInfo.providerSubject()
+                )
+                .orElse(null);
+
+        if (kakaoIdentity != null) {
+            return loginWithExistingKakaoIdentity(kakaoIdentity, context);
+        }
+
+        validateUsableKakaoEmail(kakaoUserInfo);
+        return loginWithNewKakaoIdentity(kakaoUserInfo, request.isAgreedToTerms(), context);
+    }
+
+    public AuthTokenResponse link(KakaoAccountLinkRequest request, AuthTokenRequestContext context) {
+        KakaoOAuthLinkTokenPayload payload = temporaryTokenStore.findLink(request.getLinkToken())
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_OAUTH_LINK_TOKEN_INVALID));
+
+        if (!payload.email().equals(request.getEmail())) {
+            throw new CustomException(ErrorCode.AUTH_OAUTH_LINK_TOKEN_INVALID);
+        }
+
+        User user = userRepository.findByEmailAndDeletedAtIsNull(request.getEmail())
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+        validateAccountIsNotLocked(user);
+
+        UserAuthIdentity localIdentity = userAuthIdentityRepository
+                .findByUserAndProviderAndDeletedAtIsNull(user, PROVIDER_LOCAL)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND));
+        validatePassword(localIdentity, request.getPassword());
+
+        UserAuthIdentity existingKakaoIdentity = userAuthIdentityRepository
+                .findByProviderAndProviderSubjectAndDeletedAtIsNull(PROVIDER_KAKAO, payload.providerSubject())
+                .orElse(null);
+        if (existingKakaoIdentity != null && !existingKakaoIdentity.getUser().getId().equals(user.getId())) {
+            throw new CustomException(ErrorCode.AUTH_OAUTH_PROVIDER_ALREADY_LINKED);
+        }
+
+        UserAuthIdentity userKakaoIdentity = userAuthIdentityRepository
+                .findByUserAndProviderAndDeletedAtIsNull(user, PROVIDER_KAKAO)
+                .orElse(null);
+        if (userKakaoIdentity != null
+                && !userKakaoIdentity.getProviderSubject().equals(payload.providerSubject())) {
+            throw new CustomException(ErrorCode.AUTH_OAUTH_ACCOUNT_ALREADY_LINKED);
+        }
+
+        UserAuthIdentity kakaoIdentity = userKakaoIdentity == null
+                ? userAuthIdentityRepository.save(UserAuthIdentity.createOAuth(
+                        user,
+                        PROVIDER_KAKAO,
+                        payload.providerSubject(),
+                        false
+                ))
+                : userKakaoIdentity;
+
+        if (!user.isEmailVerified()) {
+            user.verifyEmail();
+        }
+        recordLoginSuccess(user, kakaoIdentity, context);
+        temporaryTokenStore.deleteLink(request.getLinkToken());
+        return authTokenService.issueTokens(user, context);
+    }
+
+    public AuthTokenResponse completeNickname(KakaoNicknameRequest request, AuthTokenRequestContext context) {
+        if (!isValidNickname(request.getNickname())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        KakaoOAuthSignupTokenPayload payload = temporaryTokenStore.findSignup(request.getSignupToken())
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_OAUTH_SIGNUP_TOKEN_INVALID));
+
+        if (userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull(
+                PROVIDER_KAKAO,
+                payload.providerSubject()
+        ).isPresent()) {
+            throw new CustomException(ErrorCode.AUTH_OAUTH_PROVIDER_ALREADY_LINKED);
+        }
+        if (userRepository.existsByEmail(payload.email())) {
+            throw new CustomException(ErrorCode.AUTH_EMAIL_ALREADY_EXISTS);
+        }
+
+        AuthTokenResponse response = createKakaoUserAndIssueTokens(
+                payload.providerSubject(),
+                payload.email(),
+                request.getNickname(),
+                context
+        );
+        temporaryTokenStore.deleteSignup(request.getSignupToken());
+        return response;
+    }
+
+    private KakaoOAuthLoginResult loginWithExistingKakaoIdentity(
+            UserAuthIdentity kakaoIdentity,
+            AuthTokenRequestContext context
+    ) {
+        User user = kakaoIdentity.getUser();
+        validateAccountIsNotLocked(user);
+        recordLoginSuccess(user, kakaoIdentity, context);
+        return KakaoOAuthLoginResult.existingLogin(authTokenService.issueTokens(user, context));
+    }
+
+    private KakaoOAuthLoginResult loginWithNewKakaoIdentity(
+            KakaoUserInfo kakaoUserInfo,
+            boolean agreedToTerms,
+            AuthTokenRequestContext context
+    ) {
+        User existingUser = userRepository.findByEmailAndDeletedAtIsNull(kakaoUserInfo.email())
+                .orElse(null);
+        if (existingUser != null) {
+            String linkToken = temporaryTokenStore.saveLink(
+                    new KakaoOAuthLinkTokenPayload(kakaoUserInfo.providerSubject(), kakaoUserInfo.email()),
+                    KAKAO_TEMP_TOKEN_TTL_SECONDS
+            );
+            return KakaoOAuthLoginResult.accountLinkRequired(
+                    KakaoAccountLinkRequiredResponse.of(kakaoUserInfo.email(), linkToken, KAKAO_TEMP_TOKEN_TTL_SECONDS)
+            );
+        }
+
+        validateTermsAgreed(agreedToTerms);
+        if (!isValidNickname(kakaoUserInfo.nickname())) {
+            String suggestedNickname = resolveSuggestedNickname(kakaoUserInfo.nickname());
+            String signupToken = temporaryTokenStore.saveSignup(
+                    new KakaoOAuthSignupTokenPayload(
+                            kakaoUserInfo.providerSubject(),
+                            kakaoUserInfo.email(),
+                            suggestedNickname
+                    ),
+                    KAKAO_TEMP_TOKEN_TTL_SECONDS
+            );
+            return KakaoOAuthLoginResult.nicknameRequired(
+                    KakaoNicknameRequiredResponse.of(signupToken, suggestedNickname)
+            );
+        }
+
+        return KakaoOAuthLoginResult.signupLogin(createKakaoUserAndIssueTokens(
+                kakaoUserInfo.providerSubject(),
+                kakaoUserInfo.email(),
+                kakaoUserInfo.nickname(),
+                context
+        ));
+    }
+
+    private AuthTokenResponse createKakaoUserAndIssueTokens(
+            String providerSubject,
+            String email,
+            String nickname,
+            AuthTokenRequestContext context
+    ) {
+        User user = User.create(UuidV7Generator.generate(), email, nickname);
+        user.verifyEmail();
+        User savedUser = userRepository.save(user);
+
+        UserAuthIdentity kakaoIdentity = UserAuthIdentity.createOAuth(
+                savedUser,
+                PROVIDER_KAKAO,
+                providerSubject,
+                true
+        );
+        userAuthIdentityRepository.save(kakaoIdentity);
+
+        recordLoginSuccess(savedUser, kakaoIdentity, context);
+        return authTokenService.issueTokens(savedUser, context);
+    }
+
+    private void validateUsableKakaoEmail(KakaoUserInfo kakaoUserInfo) {
+        if (!kakaoUserInfo.hasUsableEmail()) {
+            throw new CustomException(ErrorCode.AUTH_OAUTH_EMAIL_REQUIRED);
+        }
+    }
+
+    private void validateTermsAgreed(boolean agreedToTerms) {
+        if (!agreedToTerms) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private void validateAccountIsNotLocked(User user) {
+        if (user.isLocked()) {
+            throw new CustomException(ErrorCode.AUTH_ACCOUNT_LOCKED);
+        }
+    }
+
+    private void validatePassword(UserAuthIdentity localIdentity, String password) {
+        if (!StringUtils.hasText(localIdentity.getPasswordHash())
+                || !passwordEncoder.matches(password, localIdentity.getPasswordHash())) {
+            throw new CustomException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        }
+    }
+
+    private void recordLoginSuccess(User user, UserAuthIdentity kakaoIdentity, AuthTokenRequestContext context) {
+        user.recordLoginSuccess(context.getIpAddress());
+        kakaoIdentity.recordLoginSuccess();
+    }
+
+    private boolean isValidNickname(String nickname) {
+        return StringUtils.hasText(nickname) && NICKNAME_PATTERN.matcher(nickname).matches();
+    }
+
+    private String resolveSuggestedNickname(String kakaoNickname) {
+        if (!StringUtils.hasText(kakaoNickname)) {
+            return null;
+        }
+
+        String suggestedNickname = kakaoNickname.replaceAll("[^가-힣A-Za-z]", "");
+        if (suggestedNickname.length() > 12) {
+            suggestedNickname = suggestedNickname.substring(0, 12);
+        }
+        if (!isValidNickname(suggestedNickname)) {
+            return null;
+        }
+        return suggestedNickname;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthSignupTokenPayload.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthSignupTokenPayload.java
@@ -1,0 +1,8 @@
+package com.f1.quiket.domain.auth.service;
+
+public record KakaoOAuthSignupTokenPayload(
+        String providerSubject,
+        String email,
+        String suggestedNickname
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthTemporaryTokenStore.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthTemporaryTokenStore.java
@@ -1,0 +1,91 @@
+package com.f1.quiket.domain.auth.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Kakao OAuth 임시 토큰 저장소
+ */
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthTemporaryTokenStore {
+
+    private static final String SIGNUP_TOKEN_PREFIX = "auth:kakao:signup:";
+    private static final String LINK_TOKEN_PREFIX = "auth:kakao:link:";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public String saveSignup(KakaoOAuthSignupTokenPayload payload, long ttlSeconds) {
+        return save(SIGNUP_TOKEN_PREFIX, payload, ttlSeconds);
+    }
+
+    public Optional<KakaoOAuthSignupTokenPayload> findSignup(String signupToken) {
+        return find(SIGNUP_TOKEN_PREFIX, signupToken, KakaoOAuthSignupTokenPayload.class);
+    }
+
+    public void deleteSignup(String signupToken) {
+        delete(SIGNUP_TOKEN_PREFIX, signupToken);
+    }
+
+    public String saveLink(KakaoOAuthLinkTokenPayload payload, long ttlSeconds) {
+        return save(LINK_TOKEN_PREFIX, payload, ttlSeconds);
+    }
+
+    public Optional<KakaoOAuthLinkTokenPayload> findLink(String linkToken) {
+        return find(LINK_TOKEN_PREFIX, linkToken, KakaoOAuthLinkTokenPayload.class);
+    }
+
+    public void deleteLink(String linkToken) {
+        delete(LINK_TOKEN_PREFIX, linkToken);
+    }
+
+    private String save(String prefix, Object payload, long ttlSeconds) {
+        try {
+            String token = UUID.randomUUID().toString();
+            stringRedisTemplate.opsForValue()
+                    .set(prefix + token, objectMapper.writeValueAsString(payload), Duration.ofSeconds(ttlSeconds));
+            return token;
+        } catch (DataAccessException | JsonProcessingException e) {
+            throw new CustomException(ErrorCode.AUTH_OAUTH_TEMP_TOKEN_STORE_FAILED);
+        }
+    }
+
+    private <T> Optional<T> find(String prefix, String token, Class<T> payloadType) {
+        if (!StringUtils.hasText(token)) {
+            return Optional.empty();
+        }
+
+        try {
+            String payload = stringRedisTemplate.opsForValue().get(prefix + token);
+            if (!StringUtils.hasText(payload)) {
+                return Optional.empty();
+            }
+            return Optional.of(objectMapper.readValue(payload, payloadType));
+        } catch (DataAccessException | JsonProcessingException e) {
+            throw new CustomException(ErrorCode.AUTH_OAUTH_TEMP_TOKEN_STORE_FAILED);
+        }
+    }
+
+    private void delete(String prefix, String token) {
+        if (!StringUtils.hasText(token)) {
+            return;
+        }
+
+        try {
+            stringRedisTemplate.delete(prefix + token);
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.AUTH_OAUTH_TEMP_TOKEN_STORE_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/f1/quiket/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/f1/quiket/global/auth/JwtAuthenticationFilter.java
@@ -92,6 +92,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 "/api/v1/auth/email-verifications/confirm",
                 "/api/v1/auth/login",
                 "/api/v1/auth/token/refresh",
+                "/api/v1/auth/oauth/kakao",
                 "/api-docs",
                 "/swagger-ui",
                 "/v3/api-docs"

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -33,6 +33,15 @@ public enum ErrorCode {
     AUTH_INVALID_TOKEN(401, "AUTH_INVALID_TOKEN", "토큰이 올바르지 않습니다."),
     AUTH_EXPIRED_TOKEN(401, "AUTH_EXPIRED_TOKEN", "토큰이 만료되었습니다."),
     AUTH_REVOKED_REFRESH_TOKEN(401, "AUTH_REVOKED_REFRESH_TOKEN", "폐기된 Refresh Token입니다."),
+    AUTH_OAUTH_INVALID_TOKEN(401, "AUTH_OAUTH_INVALID_TOKEN", "Kakao Access Token이 올바르지 않습니다."),
+    AUTH_OAUTH_EMAIL_REQUIRED(400, "AUTH_OAUTH_EMAIL_REQUIRED", "Kakao 계정의 유효한 이메일 제공 동의가 필요합니다."),
+    AUTH_OAUTH_ACCOUNT_LINK_REQUIRED(409, "AUTH_OAUTH_ACCOUNT_LINK_REQUIRED", "동일 이메일로 가입된 계정이 있습니다. 계정 연동이 필요합니다."),
+    AUTH_OAUTH_LINK_TOKEN_INVALID(401, "AUTH_OAUTH_LINK_TOKEN_INVALID", "Kakao 계정 연동 토큰이 올바르지 않거나 만료되었습니다."),
+    AUTH_OAUTH_SIGNUP_TOKEN_INVALID(401, "AUTH_OAUTH_SIGNUP_TOKEN_INVALID", "Kakao 회원가입 토큰이 올바르지 않거나 만료되었습니다."),
+    AUTH_OAUTH_ACCOUNT_ALREADY_LINKED(409, "AUTH_OAUTH_ACCOUNT_ALREADY_LINKED", "이미 Kakao 계정이 연동된 사용자입니다."),
+    AUTH_OAUTH_PROVIDER_ALREADY_LINKED(409, "AUTH_OAUTH_PROVIDER_ALREADY_LINKED", "이미 다른 사용자에게 연동된 Kakao 계정입니다."),
+    AUTH_OAUTH_TEMP_TOKEN_STORE_FAILED(503, "AUTH_OAUTH_TEMP_TOKEN_STORE_FAILED", "Kakao OAuth 임시 토큰 처리에 실패했습니다."),
+    AUTH_OAUTH_USER_INFO_FAILED(503, "AUTH_OAUTH_USER_INFO_FAILED", "Kakao 사용자 정보 조회에 실패했습니다."),
 
     // 5xx Server Errors
     INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/com/f1/quiket/global/response/SuccessCode.java
+++ b/src/main/java/com/f1/quiket/global/response/SuccessCode.java
@@ -30,6 +30,7 @@ public enum SuccessCode {
     AUTH_OAUTH_LOGIN_SUCCESS(200, "AUTH_OAUTH_LOGIN_SUCCESS", "Kakao 로그인이 완료되었습니다."),
     AUTH_OAUTH_SIGNUP_SUCCESS(201, "AUTH_OAUTH_SIGNUP_SUCCESS", "Kakao 회원가입 및 로그인이 완료되었습니다."),
     AUTH_OAUTH_LINK_SUCCESS(200, "AUTH_OAUTH_LINK_SUCCESS", "Kakao 계정 연동 및 로그인이 완료되었습니다."),
+    AUTH_OAUTH_NICKNAME_COMPLETED(200, "AUTH_OAUTH_NICKNAME_COMPLETED", "닉네임 설정 및 로그인이 완료되었습니다."),
     AUTH_NICKNAME_REQUIRED(202, "AUTH_NICKNAME_REQUIRED", "닉네임 설정이 필요합니다."),
     ;
 

--- a/src/main/java/com/f1/quiket/global/response/SuccessCode.java
+++ b/src/main/java/com/f1/quiket/global/response/SuccessCode.java
@@ -27,6 +27,10 @@ public enum SuccessCode {
     AUTH_TOKEN_REFRESHED(200, "AUTH_TOKEN_REFRESHED", "토큰이 재발급되었습니다."),
     AUTH_LOGOUT_SUCCESS(200, "AUTH_LOGOUT_SUCCESS", "로그아웃이 완료되었습니다."),
     AUTH_ME_SUCCESS(200, "AUTH_ME_SUCCESS", "내 정보 조회가 완료되었습니다."),
+    AUTH_OAUTH_LOGIN_SUCCESS(200, "AUTH_OAUTH_LOGIN_SUCCESS", "Kakao 로그인이 완료되었습니다."),
+    AUTH_OAUTH_SIGNUP_SUCCESS(201, "AUTH_OAUTH_SIGNUP_SUCCESS", "Kakao 회원가입 및 로그인이 완료되었습니다."),
+    AUTH_OAUTH_LINK_SUCCESS(200, "AUTH_OAUTH_LINK_SUCCESS", "Kakao 계정 연동 및 로그인이 완료되었습니다."),
+    AUTH_NICKNAME_REQUIRED(202, "AUTH_NICKNAME_REQUIRED", "닉네임 설정이 필요합니다."),
     ;
 
     private final int status;

--- a/src/main/java/com/f1/quiket/infra/kakao/client/KakaoApiClient.java
+++ b/src/main/java/com/f1/quiket/infra/kakao/client/KakaoApiClient.java
@@ -1,0 +1,94 @@
+package com.f1.quiket.infra.kakao.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.infra.kakao.config.KakaoOAuthProperties;
+import com.f1.quiket.infra.kakao.dto.KakaoUserInfo;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
+
+/**
+ * Kakao 사용자 정보 API 클라이언트
+ */
+@Component
+@RequiredArgsConstructor
+public class KakaoApiClient {
+
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final RestClient kakaoRestClient;
+    private final KakaoOAuthProperties kakaoOAuthProperties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public KakaoUserInfo getUserInfo(String kakaoAccessToken) {
+        try {
+            String responseBody = kakaoRestClient.get()
+                    .uri(kakaoOAuthProperties.getUserInfoUri())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(AUTHORIZATION, BEARER_PREFIX + kakaoAccessToken)
+                    .retrieve()
+                    .body(String.class);
+
+            return parseUserInfo(responseBody);
+        } catch (RestClientResponseException e) {
+            if (e.getStatusCode().is4xxClientError()) {
+                throw new CustomException(ErrorCode.AUTH_OAUTH_INVALID_TOKEN);
+            }
+            throw new CustomException(ErrorCode.AUTH_OAUTH_USER_INFO_FAILED);
+        } catch (RestClientException | IOException e) {
+            throw new CustomException(ErrorCode.AUTH_OAUTH_USER_INFO_FAILED);
+        }
+    }
+
+    private KakaoUserInfo parseUserInfo(String responseBody) throws IOException {
+        JsonNode rootNode = objectMapper.readTree(responseBody);
+        JsonNode idNode = rootNode.path("id");
+        if (idNode.isMissingNode() || idNode.isNull() || !StringUtils.hasText(idNode.asText())) {
+            throw new CustomException(ErrorCode.AUTH_OAUTH_USER_INFO_FAILED);
+        }
+
+        JsonNode kakaoAccountNode = rootNode.path("kakao_account");
+        return new KakaoUserInfo(
+                idNode.asText(),
+                textOrNull(kakaoAccountNode.path("email")),
+                booleanOrNull(kakaoAccountNode.path("is_email_valid")),
+                booleanOrNull(kakaoAccountNode.path("is_email_verified")),
+                resolveNickname(rootNode, kakaoAccountNode)
+        );
+    }
+
+    private String resolveNickname(JsonNode rootNode, JsonNode kakaoAccountNode) {
+        String profileNickname = textOrNull(kakaoAccountNode.path("profile").path("nickname"));
+        if (StringUtils.hasText(profileNickname)) {
+            return profileNickname;
+        }
+        return textOrNull(rootNode.path("properties").path("nickname"));
+    }
+
+    private String textOrNull(JsonNode node) {
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        String value = node.asText();
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        return value;
+    }
+
+    private Boolean booleanOrNull(JsonNode node) {
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        return node.asBoolean();
+    }
+}

--- a/src/main/java/com/f1/quiket/infra/kakao/client/KakaoApiClient.java
+++ b/src/main/java/com/f1/quiket/infra/kakao/client/KakaoApiClient.java
@@ -38,12 +38,17 @@ public class KakaoApiClient {
                     .retrieve()
                     .body(String.class);
 
+            if (!StringUtils.hasText(responseBody)) {
+                throw new CustomException(ErrorCode.AUTH_OAUTH_USER_INFO_FAILED);
+            }
             return parseUserInfo(responseBody);
         } catch (RestClientResponseException e) {
-            if (e.getStatusCode().is4xxClientError()) {
+            if (e.getStatusCode().value() == 401 || e.getStatusCode().value() == 403) {
                 throw new CustomException(ErrorCode.AUTH_OAUTH_INVALID_TOKEN);
             }
             throw new CustomException(ErrorCode.AUTH_OAUTH_USER_INFO_FAILED);
+        } catch (CustomException e) {
+            throw e;
         } catch (RestClientException | IOException e) {
             throw new CustomException(ErrorCode.AUTH_OAUTH_USER_INFO_FAILED);
         }

--- a/src/main/java/com/f1/quiket/infra/kakao/config/KakaoOAuthConfig.java
+++ b/src/main/java/com/f1/quiket/infra/kakao/config/KakaoOAuthConfig.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.infra.kakao.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Kakao OAuth 클라이언트 설정
+ */
+@Configuration
+@EnableConfigurationProperties(KakaoOAuthProperties.class)
+public class KakaoOAuthConfig {
+
+    @Bean
+    public RestClient kakaoRestClient() {
+        return RestClient.builder().build();
+    }
+}

--- a/src/main/java/com/f1/quiket/infra/kakao/config/KakaoOAuthProperties.java
+++ b/src/main/java/com/f1/quiket/infra/kakao/config/KakaoOAuthProperties.java
@@ -1,0 +1,20 @@
+package com.f1.quiket.infra.kakao.config;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Kakao OAuth 설정값 바인딩
+ */
+@Getter
+@Setter
+@Validated
+@ConfigurationProperties(prefix = "kakao.oauth")
+public class KakaoOAuthProperties {
+
+    @NotBlank(message = "kakao.oauth.user-info-uri 값 필수")
+    private String userInfoUri;
+}

--- a/src/main/java/com/f1/quiket/infra/kakao/dto/KakaoUserInfo.java
+++ b/src/main/java/com/f1/quiket/infra/kakao/dto/KakaoUserInfo.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.infra.kakao.dto;
+
+import org.springframework.util.StringUtils;
+
+public record KakaoUserInfo(
+        String providerSubject,
+        String email,
+        Boolean emailValid,
+        Boolean emailVerified,
+        String nickname
+) {
+
+    public boolean hasUsableEmail() {
+        return StringUtils.hasText(email)
+                && !Boolean.FALSE.equals(emailValid)
+                && !Boolean.FALSE.equals(emailVerified);
+    }
+}

--- a/src/main/java/com/f1/quiket/infra/kakao/dto/KakaoUserInfo.java
+++ b/src/main/java/com/f1/quiket/infra/kakao/dto/KakaoUserInfo.java
@@ -12,7 +12,7 @@ public record KakaoUserInfo(
 
     public boolean hasUsableEmail() {
         return StringUtils.hasText(email)
-                && !Boolean.FALSE.equals(emailValid)
-                && !Boolean.FALSE.equals(emailVerified);
+                && Boolean.TRUE.equals(emailValid)
+                && Boolean.TRUE.equals(emailVerified);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,3 +44,7 @@ quiket:
     secret: ${QUIKET_JWT_SECRET:local-dev-jwt-secret-for-quiket-f1-authentication}
     access-token-expires-in-seconds: 3600
     refresh-token-expires-in-seconds: 1209600
+
+kakao:
+  oauth:
+    user-info-uri: https://kapi.kakao.com/v2/user/me

--- a/src/test/java/com/f1/quiket/domain/auth/service/KakaoOAuthServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/auth/service/KakaoOAuthServiceTest.java
@@ -79,7 +79,7 @@ class KakaoOAuthServiceTest {
 
     @Test
     void login_creates_user_and_kakao_identity_when_new_user_has_valid_nickname() {
-        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token");
+        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token", true);
         when(kakaoApiClient.getUserInfo("kakao-access-token"))
                 .thenReturn(kakaoUserInfo("123456789", "new@example.com", "카카오"));
         when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
@@ -126,7 +126,7 @@ class KakaoOAuthServiceTest {
 
     @Test
     void login_returns_nickname_required_when_kakao_nickname_is_invalid() {
-        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token");
+        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token", true);
         when(kakaoApiClient.getUserInfo("kakao-access-token"))
                 .thenReturn(kakaoUserInfo("123456789", "new@example.com", "카카오123"));
         when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
@@ -154,6 +154,35 @@ class KakaoOAuthServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.AUTH_OAUTH_EMAIL_REQUIRED);
+    }
+
+    @Test
+    void login_fails_when_kakao_email_flags_are_missing() {
+        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token", true);
+        when(kakaoApiClient.getUserInfo("kakao-access-token"))
+                .thenReturn(new KakaoUserInfo("123456789", "user@example.com", null, null, "카카오"));
+        when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> kakaoOAuthService.login(request, tokenRequestContext()))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_OAUTH_EMAIL_REQUIRED);
+    }
+
+    @Test
+    void login_fails_when_new_kakao_user_does_not_agree_to_terms() {
+        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token");
+        when(kakaoApiClient.getUserInfo("kakao-access-token"))
+                .thenReturn(kakaoUserInfo("123456789", "new@example.com", "카카오"));
+        when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmailAndDeletedAtIsNull("new@example.com")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> kakaoOAuthService.login(request, tokenRequestContext()))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
     }
 
     @Test
@@ -218,6 +247,12 @@ class KakaoOAuthServiceTest {
     private KakaoLoginRequest kakaoLoginRequest(String kakaoAccessToken) {
         KakaoLoginRequest request = new KakaoLoginRequest();
         ReflectionTestUtils.setField(request, "kakaoAccessToken", kakaoAccessToken);
+        return request;
+    }
+
+    private KakaoLoginRequest kakaoLoginRequest(String kakaoAccessToken, boolean agreedToTerms) {
+        KakaoLoginRequest request = kakaoLoginRequest(kakaoAccessToken);
+        ReflectionTestUtils.setField(request, "agreedToTerms", agreedToTerms);
         return request;
     }
 

--- a/src/test/java/com/f1/quiket/domain/auth/service/KakaoOAuthServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/auth/service/KakaoOAuthServiceTest.java
@@ -1,0 +1,269 @@
+package com.f1.quiket.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.auth.dto.AuthTokenResponse;
+import com.f1.quiket.domain.auth.dto.AuthUserResponse;
+import com.f1.quiket.domain.auth.dto.KakaoAccountLinkRequest;
+import com.f1.quiket.domain.auth.dto.KakaoLoginRequest;
+import com.f1.quiket.domain.auth.dto.KakaoNicknameRequest;
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.infra.kakao.client.KakaoApiClient;
+import com.f1.quiket.infra.kakao.dto.KakaoUserInfo;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class KakaoOAuthServiceTest {
+
+    private KakaoApiClient kakaoApiClient;
+    private UserRepository userRepository;
+    private UserAuthIdentityRepository userAuthIdentityRepository;
+    private AuthTokenService authTokenService;
+    private KakaoOAuthTemporaryTokenStore temporaryTokenStore;
+    private KakaoOAuthService kakaoOAuthService;
+
+    @BeforeEach
+    void setUp() {
+        kakaoApiClient = mock(KakaoApiClient.class);
+        userRepository = mock(UserRepository.class);
+        userAuthIdentityRepository = mock(UserAuthIdentityRepository.class);
+        authTokenService = mock(AuthTokenService.class);
+        temporaryTokenStore = mock(KakaoOAuthTemporaryTokenStore.class);
+
+        kakaoOAuthService = new KakaoOAuthService(
+                kakaoApiClient,
+                userRepository,
+                userAuthIdentityRepository,
+                new BCryptPasswordEncoder(),
+                authTokenService,
+                temporaryTokenStore
+        );
+    }
+
+    @Test
+    void login_succeeds_when_kakao_identity_exists() {
+        User user = verifiedUser("user@example.com", "도토리");
+        UserAuthIdentity kakaoIdentity = UserAuthIdentity.createOAuth(user, "kakao", "123456789", true);
+        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token");
+
+        when(kakaoApiClient.getUserInfo("kakao-access-token"))
+                .thenReturn(kakaoUserInfo("123456789", "user@example.com", "도토리"));
+        when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
+                .thenReturn(Optional.of(kakaoIdentity));
+        when(authTokenService.issueTokens(eq(user), any(AuthTokenRequestContext.class)))
+                .thenReturn(tokenResponse(user, List.of(kakaoIdentity)));
+
+        KakaoOAuthLoginResult result = kakaoOAuthService.login(request, tokenRequestContext());
+
+        assertThat(result.getStatus()).isEqualTo(KakaoOAuthLoginStatus.EXISTING_LOGIN);
+        assertThat(result.getTokenResponse().getAccessToken()).isEqualTo("access-token");
+        assertThat(user.getLastLoginIp()).isEqualTo("127.0.0.1");
+        assertThat(kakaoIdentity.getLastLoginAt()).isNotNull();
+    }
+
+    @Test
+    void login_creates_user_and_kakao_identity_when_new_user_has_valid_nickname() {
+        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token");
+        when(kakaoApiClient.getUserInfo("kakao-access-token"))
+                .thenReturn(kakaoUserInfo("123456789", "new@example.com", "카카오"));
+        when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmailAndDeletedAtIsNull("new@example.com")).thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(userAuthIdentityRepository.save(any(UserAuthIdentity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(authTokenService.issueTokens(any(User.class), any(AuthTokenRequestContext.class)))
+                .thenAnswer(invocation -> tokenResponse(invocation.getArgument(0), List.of()));
+
+        KakaoOAuthLoginResult result = kakaoOAuthService.login(request, tokenRequestContext());
+
+        assertThat(result.getStatus()).isEqualTo(KakaoOAuthLoginStatus.SIGNUP_LOGIN);
+        assertThat(result.getTokenResponse().getUser().getEmail()).isEqualTo("new@example.com");
+        assertThat(result.getTokenResponse().getUser().isEmailVerified()).isTrue();
+
+        ArgumentCaptor<UserAuthIdentity> identityCaptor = ArgumentCaptor.forClass(UserAuthIdentity.class);
+        verify(userAuthIdentityRepository).save(identityCaptor.capture());
+        assertThat(identityCaptor.getValue().getProvider()).isEqualTo("kakao");
+        assertThat(identityCaptor.getValue().getProviderSubject()).isEqualTo("123456789");
+        assertThat(identityCaptor.getValue().getPasswordHash()).isNull();
+    }
+
+    @Test
+    void login_returns_account_link_required_when_same_email_user_exists() {
+        User user = verifiedUser("user@example.com", "도토리");
+        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token");
+        when(kakaoApiClient.getUserInfo("kakao-access-token"))
+                .thenReturn(kakaoUserInfo("123456789", "user@example.com", "카카오"));
+        when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmailAndDeletedAtIsNull("user@example.com")).thenReturn(Optional.of(user));
+        when(temporaryTokenStore.saveLink(any(KakaoOAuthLinkTokenPayload.class), eq(600L)))
+                .thenReturn("link-token");
+
+        KakaoOAuthLoginResult result = kakaoOAuthService.login(request, tokenRequestContext());
+
+        assertThat(result.getStatus()).isEqualTo(KakaoOAuthLoginStatus.ACCOUNT_LINK_REQUIRED);
+        assertThat(result.getAccountLinkRequiredResponse().getEmail()).isEqualTo("user@example.com");
+        assertThat(result.getAccountLinkRequiredResponse().getProvider()).isEqualTo("kakao");
+        assertThat(result.getAccountLinkRequiredResponse().getLinkToken()).isEqualTo("link-token");
+    }
+
+    @Test
+    void login_returns_nickname_required_when_kakao_nickname_is_invalid() {
+        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token");
+        when(kakaoApiClient.getUserInfo("kakao-access-token"))
+                .thenReturn(kakaoUserInfo("123456789", "new@example.com", "카카오123"));
+        when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
+                .thenReturn(Optional.empty());
+        when(userRepository.findByEmailAndDeletedAtIsNull("new@example.com")).thenReturn(Optional.empty());
+        when(temporaryTokenStore.saveSignup(any(KakaoOAuthSignupTokenPayload.class), eq(600L)))
+                .thenReturn("signup-token");
+
+        KakaoOAuthLoginResult result = kakaoOAuthService.login(request, tokenRequestContext());
+
+        assertThat(result.getStatus()).isEqualTo(KakaoOAuthLoginStatus.NICKNAME_REQUIRED);
+        assertThat(result.getNicknameRequiredResponse().getSignupToken()).isEqualTo("signup-token");
+        assertThat(result.getNicknameRequiredResponse().getSuggestedNickname()).isEqualTo("카카오");
+    }
+
+    @Test
+    void login_fails_when_kakao_email_is_missing() {
+        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token");
+        when(kakaoApiClient.getUserInfo("kakao-access-token"))
+                .thenReturn(new KakaoUserInfo("123456789", null, null, null, "카카오"));
+        when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> kakaoOAuthService.login(request, tokenRequestContext()))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_OAUTH_EMAIL_REQUIRED);
+    }
+
+    @Test
+    void link_adds_kakao_identity_after_local_password_validation() {
+        User user = verifiedUser("user@example.com", "도토리");
+        UserAuthIdentity localIdentity = UserAuthIdentity.createLocal(
+                user,
+                new BCryptPasswordEncoder().encode("Password123!"),
+                true
+        );
+        KakaoAccountLinkRequest request = kakaoAccountLinkRequest(
+                "link-token",
+                "user@example.com",
+                "Password123!"
+        );
+
+        when(temporaryTokenStore.findLink("link-token"))
+                .thenReturn(Optional.of(new KakaoOAuthLinkTokenPayload("123456789", "user@example.com")));
+        when(userRepository.findByEmailAndDeletedAtIsNull("user@example.com")).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(localIdentity));
+        when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
+                .thenReturn(Optional.empty());
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "kakao"))
+                .thenReturn(Optional.empty());
+        when(userAuthIdentityRepository.save(any(UserAuthIdentity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(authTokenService.issueTokens(eq(user), any(AuthTokenRequestContext.class)))
+                .thenReturn(tokenResponse(user, List.of(localIdentity)));
+
+        AuthTokenResponse response = kakaoOAuthService.link(request, tokenRequestContext());
+
+        assertThat(response.getAccessToken()).isEqualTo("access-token");
+        ArgumentCaptor<UserAuthIdentity> identityCaptor = ArgumentCaptor.forClass(UserAuthIdentity.class);
+        verify(userAuthIdentityRepository).save(identityCaptor.capture());
+        assertThat(identityCaptor.getValue().getProvider()).isEqualTo("kakao");
+        assertThat(identityCaptor.getValue().getProviderSubject()).isEqualTo("123456789");
+        verify(temporaryTokenStore).deleteLink("link-token");
+    }
+
+    @Test
+    void completeNickname_creates_user_from_signup_token() {
+        KakaoNicknameRequest request = kakaoNicknameRequest("signup-token", "도토리");
+        when(temporaryTokenStore.findSignup("signup-token"))
+                .thenReturn(Optional.of(new KakaoOAuthSignupTokenPayload("123456789", "new@example.com", "카카오")));
+        when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
+                .thenReturn(Optional.empty());
+        when(userRepository.existsByEmail("new@example.com")).thenReturn(false);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(userAuthIdentityRepository.save(any(UserAuthIdentity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(authTokenService.issueTokens(any(User.class), any(AuthTokenRequestContext.class)))
+                .thenAnswer(invocation -> tokenResponse(invocation.getArgument(0), List.of()));
+
+        AuthTokenResponse response = kakaoOAuthService.completeNickname(request, tokenRequestContext());
+
+        assertThat(response.getUser().getEmail()).isEqualTo("new@example.com");
+        assertThat(response.getUser().getNickname()).isEqualTo("도토리");
+        verify(temporaryTokenStore).deleteSignup("signup-token");
+    }
+
+    private KakaoLoginRequest kakaoLoginRequest(String kakaoAccessToken) {
+        KakaoLoginRequest request = new KakaoLoginRequest();
+        ReflectionTestUtils.setField(request, "kakaoAccessToken", kakaoAccessToken);
+        return request;
+    }
+
+    private KakaoAccountLinkRequest kakaoAccountLinkRequest(String linkToken, String email, String password) {
+        KakaoAccountLinkRequest request = new KakaoAccountLinkRequest();
+        ReflectionTestUtils.setField(request, "linkToken", linkToken);
+        ReflectionTestUtils.setField(request, "email", email);
+        ReflectionTestUtils.setField(request, "password", password);
+        ReflectionTestUtils.setField(request, "agreedToLink", true);
+        return request;
+    }
+
+    private KakaoNicknameRequest kakaoNicknameRequest(String signupToken, String nickname) {
+        KakaoNicknameRequest request = new KakaoNicknameRequest();
+        ReflectionTestUtils.setField(request, "signupToken", signupToken);
+        ReflectionTestUtils.setField(request, "nickname", nickname);
+        return request;
+    }
+
+    private KakaoUserInfo kakaoUserInfo(String providerSubject, String email, String nickname) {
+        return new KakaoUserInfo(providerSubject, email, true, true, nickname);
+    }
+
+    private User verifiedUser(String email, String nickname) {
+        User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", email, nickname);
+        ReflectionTestUtils.setField(user, "id", 1L);
+        user.verifyEmail();
+        return user;
+    }
+
+    private AuthTokenRequestContext tokenRequestContext() {
+        return AuthTokenRequestContext.builder()
+                .deviceId("device-id")
+                .deviceName("Galaxy S24")
+                .userAgent("Android")
+                .ipAddress("127.0.0.1")
+                .build();
+    }
+
+    private AuthTokenResponse tokenResponse(User user, List<UserAuthIdentity> identities) {
+        return AuthTokenResponse.of(
+                "access-token",
+                "refresh-token",
+                3600L,
+                1209600L,
+                AuthUserResponse.of(user, identities)
+        );
+    }
+}

--- a/src/test/java/com/f1/quiket/infra/kakao/client/KakaoApiClientTest.java
+++ b/src/test/java/com/f1/quiket/infra/kakao/client/KakaoApiClientTest.java
@@ -75,4 +75,28 @@ class KakaoApiClientTest {
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.AUTH_OAUTH_INVALID_TOKEN);
     }
+
+    @Test
+    void getUserInfo_fails_when_response_body_blank() {
+        mockServer.expect(requestTo(USER_INFO_URI))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer kakao-access-token"))
+                .andRespond(withSuccess(" ", MediaType.APPLICATION_JSON));
+
+        assertThatThrownBy(() -> kakaoApiClient.getUserInfo("kakao-access-token"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_OAUTH_USER_INFO_FAILED);
+    }
+
+    @Test
+    void getUserInfo_maps_non_auth_4xx_to_user_info_failed() {
+        mockServer.expect(requestTo(USER_INFO_URI))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer kakao-access-token"))
+                .andRespond(withStatus(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> kakaoApiClient.getUserInfo("kakao-access-token"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_OAUTH_USER_INFO_FAILED);
+    }
 }

--- a/src/test/java/com/f1/quiket/infra/kakao/client/KakaoApiClientTest.java
+++ b/src/test/java/com/f1/quiket/infra/kakao/client/KakaoApiClientTest.java
@@ -1,0 +1,78 @@
+package com.f1.quiket.infra.kakao.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.infra.kakao.config.KakaoOAuthProperties;
+import com.f1.quiket.infra.kakao.dto.KakaoUserInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class KakaoApiClientTest {
+
+    private static final String USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+
+    private MockRestServiceServer mockServer;
+    private KakaoApiClient kakaoApiClient;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+
+        KakaoOAuthProperties properties = new KakaoOAuthProperties();
+        properties.setUserInfoUri(USER_INFO_URI);
+        kakaoApiClient = new KakaoApiClient(builder.build(), properties);
+    }
+
+    @Test
+    void getUserInfo_extracts_provider_subject_email_and_nickname() {
+        mockServer.expect(requestTo(USER_INFO_URI))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer kakao-access-token"))
+                .andRespond(withSuccess("""
+                        {
+                          "id": 123456789,
+                          "kakao_account": {
+                            "is_email_valid": true,
+                            "is_email_verified": true,
+                            "email": "user@example.com",
+                            "profile": {
+                              "nickname": "도토리"
+                            }
+                          }
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        KakaoUserInfo response = kakaoApiClient.getUserInfo("kakao-access-token");
+
+        assertThat(response.providerSubject()).isEqualTo("123456789");
+        assertThat(response.email()).isEqualTo("user@example.com");
+        assertThat(response.emailValid()).isTrue();
+        assertThat(response.emailVerified()).isTrue();
+        assertThat(response.nickname()).isEqualTo("도토리");
+        assertThat(response.hasUsableEmail()).isTrue();
+    }
+
+    @Test
+    void getUserInfo_fails_when_kakao_token_invalid() {
+        mockServer.expect(requestTo(USER_INFO_URI))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer invalid-token"))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> kakaoApiClient.getUserInfo("invalid-token"))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.AUTH_OAUTH_INVALID_TOKEN);
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -36,3 +36,7 @@ quiket:
     secret: test-jwt-secret-for-quiket-f1-authentication
     access-token-expires-in-seconds: 3600
     refresh-token-expires-in-seconds: 1209600
+
+kakao:
+  oauth:
+    user-info-uri: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- Kakao Android SDK에서 전달받은 `kakaoAccessToken` 기반 OAuth 로그인 흐름 구현
- Kakao 사용자 정보 조회 API 연동 및 `provider_subject` 기반 인증 수단 조회 구현
- 신규 Kakao 사용자 생성, 기존 이메일 계정 연동, 닉네임 설정 필요 분기 구현
- 로그인/연동 성공 시 기존 Quiket JWT Access Token / Refresh Token 발급 흐름 연결

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `GET https://kapi.kakao.com/v2/user/me` 호출용 Kakao API 클라이언트 추가
- `/api/v1/auth/oauth/kakao/login`, `/link`, `/nickname` 엔드포인트 추가
- Kakao signupToken/linkToken Redis TTL 기반 임시 저장소 추가
- `user_auth_identities(provider=kakao)` 생성/조회 및 Local 계정 연동 로직 추가
- Kakao OAuth 예외/성공 응답 코드 추가
- Kakao OAuth 서비스/클라이언트 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test`
2. Android Kakao SDK에서 받은 `kakaoAccessToken`으로 `/api/v1/auth/oauth/kakao/login` 호출
3. 기존 이메일 계정이면 `linkToken` 수신 후 `/api/v1/auth/oauth/kakao/link` 호출

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #10

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- MVP 기준 Kakao만 구현했고, Google/Naver/Apple 확장은 `provider` 분기 확장으로 이어갈 수 있게 구성했습니다.
- Kakao 이메일이 없거나 유효하지 않은 경우 `AUTH_OAUTH_EMAIL_REQUIRED`로 처리합니다.
- Kakao 닉네임이 Quiket 닉네임 정책과 맞지 않으면 `signupToken`을 내려서 닉네임 설정 API로 이어집니다.
- Kakao 공식 문서 기준 Android SDK 로그인 성공 후 `token.accessToken`을 서버로 전달하는 방식과 사용자 정보 조회 API를 반영했습니다.

---

## 🧑‍💻 Assignee

- @imclaremont
