### PR TITLE
[Fix] 계정 잠금 응답 메시지를 OpenAPI 계약과 일치하게 보정

### DIFF
--- a/src/main/java/com/f1/quiket/domain/auth/service/LocalAuthService.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/LocalAuthService.java
@@ -224,6 +224,14 @@ public class LocalAuthService {
 
     private CustomException loginFailureException(ErrorCode errorCode, User user, boolean resetCodeSent) {
         LoginFailureResponse response = LoginFailureResponse.of(user, MAX_FAILED_LOGIN_COUNT, resetCodeSent);
-        return new CustomException(errorCode, errorCode.getMessage(), response);
+        return new CustomException(errorCode, resolveLoginFailureMessage(errorCode), response);
+    }
+
+    private String resolveLoginFailureMessage(ErrorCode errorCode) {
+        // 잠금 케이스만 OpenAPI 계약에 맞춰 재설정 안내 문구를 덧붙여 응답
+        if (errorCode == ErrorCode.AUTH_ACCOUNT_LOCKED) {
+            return errorCode.getMessage() + " 비밀번호 재설정을 진행해주세요.";
+        }
+        return errorCode.getMessage();
     }
 }

--- a/src/test/java/com/f1/quiket/domain/auth/service/LocalAuthServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/auth/service/LocalAuthServiceTest.java
@@ -219,6 +219,7 @@ class LocalAuthServiceTest {
         );
 
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_ACCOUNT_LOCKED);
+        assertThat(exception.getMessage()).isEqualTo("계정이 잠금 처리되었습니다. 비밀번호 재설정을 진행해주세요.");
         assertThat(exception.getData()).isInstanceOf(LoginFailureResponse.class);
         LoginFailureResponse data = (LoginFailureResponse) exception.getData();
         assertThat(data.getFailedLoginCount()).isEqualTo(5);


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- PR #38 Copilot 리뷰 피드백 반영
- `LocalAuthService.loginFailureException()` 이 잠금 케이스에서도 `ErrorCode.getMessage()` 인 `"계정이 잠금 처리되었습니다."` 를 그대로 사용해 OpenAPI 문서의 예시 메시지와 어긋남
- 런타임 응답이 문서와 일치하도록 잠금 케이스만 메시지를 오버라이드

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `LocalAuthService.resolveLoginFailureMessage()` 신규 헬퍼 추가
- `AUTH_ACCOUNT_LOCKED` 인 경우 `"계정이 잠금 처리되었습니다. 비밀번호 재설정을 진행해주세요."` 로 응답
- 다른 ErrorCode 는 기존과 동일하게 `errorCode.getMessage()` 사용
- `LocalAuthServiceTest.login_locks_account_after_five_failures()` 에 메시지 회귀 방지 assertion 추가

---

## 🧪 How to Test

1. `./gradlew test --tests "com.f1.quiket.domain.auth.service.LocalAuthServiceTest"` 로 8개 단위 테스트 전체 통과 확인
2. 5회 연속 비밀번호 오입력 → 6회차 시도 시 응답 메시지가 `"계정이 잠금 처리되었습니다. 비밀번호 재설정을 진행해주세요."` 와 일치하는지 점검
3. 비밀번호 1회 오입력 시 응답 메시지는 기존 `"이메일 또는 비밀번호가 올바르지 않습니다."` 그대로인지 회귀 점검

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #41

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- `ErrorCode.AUTH_ACCOUNT_LOCKED` enum 자체 메시지는 다른 컨텍스트에서도 사용되므로 변경하지 않고 호출 지점에서만 메시지를 보강
- 잠금 직전(5회 실패) 과 이미 잠긴 상태에서 재로그인 시도 양쪽 모두 동일 문구로 통일

---

## 🧑‍💻 Assignee

- @imclaremont