### PR TITLE
[Feat] 홈 메인 조회 API 구현

### DIFF
--- a/docs/db/quiket-ddl-mvp.sql
+++ b/docs/db/quiket-ddl-mvp.sql
@@ -247,6 +247,7 @@ CREATE TABLE subject_other_details (
 -- 시험 일정 (D-Day) - MVP: 과목당 1개
 CREATE TABLE subject_exam_schedules (
     id                  BIGINT          NOT NULL AUTO_INCREMENT          COMMENT 'PK',
+    public_id           CHAR(36)        NOT NULL                         COMMENT '외부 노출용 UUID v7',
     subject_id          BIGINT          NOT NULL                         COMMENT '과목 ID',
     user_id             BIGINT          NOT NULL                         COMMENT '사용자 ID (조회 성능용 역정규화)',
     exam_name           VARCHAR(100)    NULL                             COMMENT '시험명 (미입력 시 과목명 사용)',
@@ -256,6 +257,7 @@ CREATE TABLE subject_exam_schedules (
     deleted_at          DATETIME(3)     NULL                             COMMENT '삭제 시각 (soft delete)',
 
     PRIMARY KEY (id),
+    UNIQUE KEY uq_subject_exam_schedules_public_id (public_id),
     UNIQUE KEY uq_subject_exam_schedules_subject_id (subject_id),  -- MVP: 과목당 1개
     KEY idx_subject_exam_schedules_user_id_exam_date (user_id, exam_date),
     KEY idx_subject_exam_schedules_exam_date (exam_date)
@@ -727,6 +729,7 @@ CREATE TABLE quiz_play_answers (
 -- 결과 요약: 풀이 세션당 1개, 결과 제출 API와 동일 트랜잭션으로 저장
 CREATE TABLE quiz_results (
     id                      BIGINT          NOT NULL AUTO_INCREMENT          COMMENT 'PK',
+    public_id               CHAR(36)        NOT NULL                         COMMENT '외부 노출용 UUID v7',
     play_session_id         BIGINT          NOT NULL                         COMMENT '풀이 세션 ID',
     quiz_session_id         BIGINT          NOT NULL                         COMMENT '퀴즈 세션 ID (역정규화)',
     user_id                 BIGINT          NOT NULL                         COMMENT '사용자 ID (역정규화)',
@@ -756,6 +759,7 @@ CREATE TABLE quiz_results (
     updated_at              DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
 
     PRIMARY KEY (id),
+    UNIQUE KEY uq_quiz_results_public_id (public_id),
     UNIQUE KEY uq_quiz_results_play_session_id (play_session_id),
     KEY idx_quiz_results_user_id_created_at (user_id, created_at),
     KEY idx_quiz_results_quiz_session_id (quiz_session_id),

--- a/src/main/java/com/f1/quiket/domain/chapter/entity/Chapter.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/entity/Chapter.java
@@ -1,0 +1,47 @@
+package com.f1.quiket.domain.chapter.entity;
+
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 챕터 엔티티
+ */
+@Entity
+@Table(
+        name = "chapters",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_chapters_public_id", columnNames = "public_id")
+        },
+        indexes = {
+                @Index(name = "idx_chapters_subject_id_deleted_at", columnList = "subject_id, deleted_at"),
+                @Index(name = "idx_chapters_user_id_created_at", columnList = "user_id, created_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Chapter extends BaseEntity {
+
+    @Column(name = "public_id", length = 36, nullable = false)
+    String publicId;
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "name", length = 30, nullable = false)
+    String name;
+
+    @Column(name = "display_order", nullable = false)
+    Integer displayOrder;
+}

--- a/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.chapter.repository;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 챕터 조회 리포지토리
+ */
+@Repository
+public interface ChapterRepository extends JpaRepository<Chapter, Long> {
+
+    /**
+     * 사용자 챕터 목록 조회
+     */
+    List<Chapter> findAllByUserIdAndDeletedAtIsNull(Long userId);
+}

--- a/src/main/java/com/f1/quiket/domain/home/controller/HomeController.java
+++ b/src/main/java/com/f1/quiket/domain/home/controller/HomeController.java
@@ -39,8 +39,8 @@ public class HomeController {
     @GetMapping("/recent-activities")
     public ResponseEntity<ApiResponse<RecentActivityPageResponse>> getRecentActivities(
             @AuthenticationPrincipal UserPrincipal principal,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(name="page", defaultValue = "0") int page,
+            @RequestParam(name="size", defaultValue = "10") int size
     ) {
         RecentActivityPageResponse response = homeService.getRecentActivities(principal.getPublicId(), page, size);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));

--- a/src/main/java/com/f1/quiket/domain/home/controller/HomeController.java
+++ b/src/main/java/com/f1/quiket/domain/home/controller/HomeController.java
@@ -1,0 +1,48 @@
+package com.f1.quiket.domain.home.controller;
+
+import com.f1.quiket.domain.home.dto.HomeDataResponse;
+import com.f1.quiket.domain.home.dto.RecentActivityPageResponse;
+import com.f1.quiket.domain.home.service.HomeService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 홈 화면 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/home")
+public class HomeController {
+
+    private final HomeService homeService;
+
+    /**
+     * 홈 메인 데이터 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<HomeDataResponse>> getHome(@AuthenticationPrincipal UserPrincipal principal) {
+        HomeDataResponse response = homeService.getHome(principal.getPublicId());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 홈 최근활동 목록 조회
+     */
+    @GetMapping("/recent-activities")
+    public ResponseEntity<ApiResponse<RecentActivityPageResponse>> getRecentActivities(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        RecentActivityPageResponse response = homeService.getRecentActivities(principal.getPublicId(), page, size);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/home/controller/HomeController.java
+++ b/src/main/java/com/f1/quiket/domain/home/controller/HomeController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/home")
+@RequestMapping("/api/v1/home")
 public class HomeController {
 
     private final HomeService homeService;

--- a/src/main/java/com/f1/quiket/domain/home/dto/HomeDataResponse.java
+++ b/src/main/java/com/f1/quiket/domain/home/dto/HomeDataResponse.java
@@ -1,0 +1,24 @@
+package com.f1.quiket.domain.home.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 홈 메인 데이터 응답 DTO
+ */
+@Getter
+@Builder
+public class HomeDataResponse {
+
+    /** 사용자 요약 */
+    private final HomeUserSummaryResponse user;
+    /** 홈 히어로 영역 */
+    private final HomeHeroResponse hero;
+    /** D-Day 카드 목록 */
+    private final List<SubjectExamScheduleResponse> dDayCards;
+    /** 과목 요약 목록 */
+    private final List<SubjectSummaryResponse> subjects;
+    /** 최근활동 목록 */
+    private final List<RecentActivityResponse> recentActivities;
+}

--- a/src/main/java/com/f1/quiket/domain/home/dto/HomeHeroResponse.java
+++ b/src/main/java/com/f1/quiket/domain/home/dto/HomeHeroResponse.java
@@ -1,0 +1,27 @@
+package com.f1.quiket.domain.home.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 홈 히어로 응답 DTO
+ */
+@Getter
+@Builder
+public class HomeHeroResponse {
+
+    /** 활성 퀴즈 존재 여부 */
+    private final boolean hasActiveQuiz;
+    /** 활성 퀴즈 정보 */
+    private final RecentActivityResponse activeQuiz;
+
+    /**
+     * 활성 퀴즈 기반 생성
+     */
+    public static HomeHeroResponse from(RecentActivityResponse activeQuiz) {
+        return HomeHeroResponse.builder()
+                .hasActiveQuiz(activeQuiz != null)
+                .activeQuiz(activeQuiz)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/home/dto/HomeUserSummaryResponse.java
+++ b/src/main/java/com/f1/quiket/domain/home/dto/HomeUserSummaryResponse.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.home.dto;
 
 import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.entity.type.UserLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -31,30 +32,7 @@ public class HomeUserSummaryResponse {
                 .dotoriBalance(user.getDotoriBalance())
                 .xpTotal(user.getXpTotal())
                 .currentLevel(user.getCurrentLevel())
-                .levelName(resolveLevelName(user.getCurrentLevel()))
+                .levelName(UserLevel.titleOf(user.getCurrentLevel()))
                 .build();
-    }
-
-    /**
-     * 레벨명 산출
-     */
-    private static String resolveLevelName(Integer currentLevel) {
-        // 기본 레벨 구간
-        if (currentLevel == null || currentLevel <= 1) {
-            return "새싹 다람쥐";
-        }
-        // 초급 레벨 구간
-        if (currentLevel <= 3) {
-            return "펜굴리는 다람쥐";
-        }
-        // 중급 레벨 구간
-        if (currentLevel <= 6) {
-            return "문제푸는 다람쥐";
-        }
-        // 고급 레벨 구간
-        if (currentLevel <= 9) {
-            return "퀴즈장인 다람쥐";
-        }
-        return "마스터 다람쥐";
     }
 }

--- a/src/main/java/com/f1/quiket/domain/home/dto/HomeUserSummaryResponse.java
+++ b/src/main/java/com/f1/quiket/domain/home/dto/HomeUserSummaryResponse.java
@@ -1,0 +1,60 @@
+package com.f1.quiket.domain.home.dto;
+
+import com.f1.quiket.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 홈 사용자 요약 응답 DTO
+ */
+@Getter
+@Builder
+public class HomeUserSummaryResponse {
+
+    /** 닉네임 */
+    private final String nickname;
+    /** 도토리 잔고 */
+    private final Integer dotoriBalance;
+    /** 누적 XP */
+    private final Integer xpTotal;
+    /** 현재 레벨 */
+    private final Integer currentLevel;
+    /** 레벨명 */
+    private final String levelName;
+
+    /**
+     * 사용자 엔티티 기반 생성
+     */
+    public static HomeUserSummaryResponse from(User user) {
+        return HomeUserSummaryResponse.builder()
+                .nickname(user.getNickname())
+                .dotoriBalance(user.getDotoriBalance())
+                .xpTotal(user.getXpTotal())
+                .currentLevel(user.getCurrentLevel())
+                .levelName(resolveLevelName(user.getCurrentLevel()))
+                .build();
+    }
+
+    /**
+     * 레벨명 산출
+     */
+    private static String resolveLevelName(Integer currentLevel) {
+        // 기본 레벨 구간
+        if (currentLevel == null || currentLevel <= 1) {
+            return "새싹 다람쥐";
+        }
+        // 초급 레벨 구간
+        if (currentLevel <= 3) {
+            return "펜굴리는 다람쥐";
+        }
+        // 중급 레벨 구간
+        if (currentLevel <= 6) {
+            return "문제푸는 다람쥐";
+        }
+        // 고급 레벨 구간
+        if (currentLevel <= 9) {
+            return "퀴즈장인 다람쥐";
+        }
+        return "마스터 다람쥐";
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/home/dto/RecentActivityPageResponse.java
+++ b/src/main/java/com/f1/quiket/domain/home/dto/RecentActivityPageResponse.java
@@ -1,0 +1,46 @@
+package com.f1.quiket.domain.home.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 최근활동 페이지 응답 DTO
+ */
+@Getter
+@Builder
+public class RecentActivityPageResponse {
+
+    /** 최근활동 목록 */
+    private final List<RecentActivityResponse> content;
+    /** 페이지 번호 */
+    private final int page;
+    /** 페이지 크기 */
+    private final int size;
+    /** 전체 요소 수 */
+    private final long totalElements;
+    /** 전체 페이지 수 */
+    private final int totalPages;
+    /** 다음 페이지 존재 여부 */
+    private final boolean hasNext;
+
+    /**
+     * 페이지 응답 생성
+     */
+    public static RecentActivityPageResponse of(
+            List<RecentActivityResponse> content,
+            int page,
+            int size,
+            long totalElements
+    ) {
+        int totalPages = size == 0 ? 0 : (int) Math.ceil((double) totalElements / size);
+        return RecentActivityPageResponse.builder()
+                .content(content)
+                .page(page)
+                .size(size)
+                .totalElements(totalElements)
+                .totalPages(totalPages)
+                .hasNext(page + 1 < totalPages)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/home/dto/RecentActivityResponse.java
+++ b/src/main/java/com/f1/quiket/domain/home/dto/RecentActivityResponse.java
@@ -1,0 +1,38 @@
+package com.f1.quiket.domain.home.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 최근활동 응답 DTO
+ */
+@Getter
+@Builder
+public class RecentActivityResponse {
+
+    /** 활동 식별자 */
+    private final String activityId;
+    /** 활동 유형 */
+    private final RecentActivityType activityType;
+    /** 퀴즈 세션 식별자 */
+    private final String quizSessionId;
+    /** 풀이 세션 식별자 */
+    private final String playSessionId;
+    /** 결과 식별자 */
+    private final String resultId;
+    /** 활동 제목 */
+    private final String title;
+    /** 과목 식별자 */
+    private final String subjectId;
+    /** 과목명 */
+    private final String subjectName;
+    /** 활동 상태 */
+    private final String status;
+    /** 진행률 */
+    private final Integer progressPct;
+    /** 점수 문구 */
+    private final String scoreText;
+    /** 생성 시각 */
+    private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/f1/quiket/domain/home/dto/RecentActivityType.java
+++ b/src/main/java/com/f1/quiket/domain/home/dto/RecentActivityType.java
@@ -1,0 +1,29 @@
+package com.f1.quiket.domain.home.dto;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 최근활동 유형
+ */
+@Getter
+@RequiredArgsConstructor
+public enum RecentActivityType {
+
+    QUIZ_GENERATING("quiz_generating"),
+    QUIZ_READY("quiz_ready"),
+    QUIZ_IN_PROGRESS("quiz_in_progress"),
+    QUIZ_COMPLETED("quiz_completed"),
+    LECTURE_UPLOADED("lecture_uploaded");
+
+    private final String value;
+
+    /**
+     * API 응답 값 변환
+     */
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/home/dto/SubjectExamScheduleResponse.java
+++ b/src/main/java/com/f1/quiket/domain/home/dto/SubjectExamScheduleResponse.java
@@ -1,0 +1,56 @@
+package com.f1.quiket.domain.home.dto;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 시험 일정 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectExamScheduleResponse {
+
+    /** 일정 식별자 */
+    private final String id;
+    /** 과목 식별자 */
+    private final String subjectId;
+    /** 시험명 */
+    private final String examName;
+    /** 시험일 */
+    private final LocalDate examDate;
+    /** D-Day */
+    private final Integer dDay;
+
+    /**
+     * 일정 응답 생성
+     */
+    public static SubjectExamScheduleResponse of(
+            String id,
+            String subjectId,
+            String subjectName,
+            String examName,
+            LocalDate examDate
+    ) {
+        return SubjectExamScheduleResponse.builder()
+                .id(id)
+                .subjectId(subjectId)
+                .examName(examName == null || examName.isBlank() ? subjectName : examName)
+                .examDate(examDate)
+                .dDay(calculateDDay(examDate))
+                .build();
+    }
+
+    /**
+     * D-Day 산출
+     */
+    private static Integer calculateDDay(LocalDate examDate) {
+        long remainDays = ChronoUnit.DAYS.between(LocalDate.now(), examDate);
+        // 지난 시험일 제외
+        if (remainDays < 0) {
+            return null;
+        }
+        return Math.toIntExact(remainDays);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/home/dto/SubjectSummaryResponse.java
+++ b/src/main/java/com/f1/quiket/domain/home/dto/SubjectSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.f1.quiket.domain.home.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 요약 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectSummaryResponse {
+
+    /** 과목 식별자 */
+    private final String id;
+    /** 과목명 */
+    private final String name;
+    /** 학습 목적 */
+    private final String purpose;
+    /** 챕터 수 */
+    private final Integer chapterCount;
+    /** 파트 수 */
+    private final Integer partCount;
+    /** 마지막 활동 시각 */
+    private final LocalDateTime lastActivityAt;
+    /** 시험 일정 */
+    private final SubjectExamScheduleResponse examSchedule;
+}

--- a/src/main/java/com/f1/quiket/domain/home/service/HomeService.java
+++ b/src/main/java/com/f1/quiket/domain/home/service/HomeService.java
@@ -1,0 +1,521 @@
+package com.f1.quiket.domain.home.service;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.home.dto.HomeDataResponse;
+import com.f1.quiket.domain.home.dto.HomeHeroResponse;
+import com.f1.quiket.domain.home.dto.HomeUserSummaryResponse;
+import com.f1.quiket.domain.home.dto.RecentActivityPageResponse;
+import com.f1.quiket.domain.home.dto.RecentActivityResponse;
+import com.f1.quiket.domain.home.dto.RecentActivityType;
+import com.f1.quiket.domain.home.dto.SubjectExamScheduleResponse;
+import com.f1.quiket.domain.home.dto.SubjectSummaryResponse;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.entity.SubjectExamSchedule;
+import com.f1.quiket.domain.subject.repository.SubjectExamScheduleRepository;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 홈 화면 비즈니스 로직
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeService {
+
+    private static final int HOME_SUBJECT_SIZE = 10;
+    private static final int HOME_D_DAY_SIZE = 1;
+    private static final int HOME_RECENT_ACTIVITY_SIZE = 5;
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private static final String QUIZ_SESSION_COMPLETED = "completed";
+    private static final String PLAY_SESSION_IN_PROGRESS = "in_progress";
+
+    private final UserRepository userRepository;
+    private final SubjectRepository subjectRepository;
+    private final SubjectExamScheduleRepository subjectExamScheduleRepository;
+    private final ChapterRepository chapterRepository;
+    private final PartRepository partRepository;
+    private final QuizSessionRepository quizSessionRepository;
+    private final QuizPlaySessionRepository quizPlaySessionRepository;
+    private final QuizResultRepository quizResultRepository;
+
+    /**
+     * 홈 메인 데이터 조회
+     */
+    public HomeDataResponse getHome(String publicId) {
+        User user = findUser(publicId);
+        HomeReadModel readModel = loadHomeReadModel(user.getId());
+        List<RecentActivityResponse> allRecentActivities = buildRecentActivities(readModel);
+        List<RecentActivityResponse> recentActivities = sliceRecentActivities(
+                allRecentActivities,
+                0,
+                HOME_RECENT_ACTIVITY_SIZE
+        );
+
+        return HomeDataResponse.builder()
+                .user(HomeUserSummaryResponse.from(user))
+                .hero(HomeHeroResponse.from(findActiveQuiz(allRecentActivities)))
+                .dDayCards(findDDayScheduleResponses(readModel))
+                .subjects(findSubjectSummaryResponses(readModel))
+                .recentActivities(recentActivities)
+                .build();
+    }
+
+    /**
+     * 최근활동 페이지 조회
+     */
+    public RecentActivityPageResponse getRecentActivities(String publicId, int page, int size) {
+        User user = findUser(publicId);
+        int normalizedPage = Math.max(page, 0);
+        int normalizedSize = normalizeSize(size);
+        HomeReadModel readModel = loadHomeReadModel(user.getId());
+        List<RecentActivityResponse> activities = buildRecentActivities(readModel);
+        List<RecentActivityResponse> content = sliceRecentActivities(activities, normalizedPage, normalizedSize);
+
+        return RecentActivityPageResponse.of(content, normalizedPage, normalizedSize, activities.size());
+    }
+
+    /**
+     * 사용자 조회
+     */
+    private User findUser(String publicId) {
+        return userRepository.findByPublicIdAndDeletedAtIsNull(publicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    /**
+     * 홈 조회 모델 로딩
+     */
+    private HomeReadModel loadHomeReadModel(Long userId) {
+        List<Subject> subjects = subjectRepository.findAllByUserIdAndDeletedAtIsNull(userId);
+        List<Chapter> chapters = chapterRepository.findAllByUserIdAndDeletedAtIsNull(userId);
+        List<Part> parts = partRepository.findAllByUserIdAndDeletedAtIsNull(userId);
+        List<SubjectExamSchedule> schedules = loadSubjectSchedules(userId, subjects);
+        List<QuizSession> quizSessions = quizSessionRepository.findAllByUserIdAndDeletedAtIsNull(userId);
+        List<QuizPlaySession> playSessions = quizPlaySessionRepository.findAllByUserId(userId);
+        List<QuizResult> quizResults = quizResultRepository.findAllByUserId(userId);
+
+        return new HomeReadModel(userId, subjects, chapters, parts, schedules, quizSessions, playSessions, quizResults);
+    }
+
+    /**
+     * 과목 시험 일정 로딩
+     */
+    private List<SubjectExamSchedule> loadSubjectSchedules(Long userId, List<Subject> subjects) {
+        List<Long> subjectIds = subjects.stream()
+                .map(Subject::getId)
+                .toList();
+        if (subjectIds.isEmpty()) {
+            return List.of();
+        }
+        return subjectExamScheduleRepository.findAllBySubjectIdInAndDeletedAtIsNull(subjectIds).stream()
+                // 사용자 소유 일정만 사용
+                .filter(schedule -> userId.equals(schedule.getUserId()))
+                .toList();
+    }
+
+    /**
+     * 페이지 크기 보정
+     */
+    private int normalizeSize(int size) {
+        // 기본 페이지 크기 보정
+        if (size < 1) {
+            return DEFAULT_PAGE_SIZE;
+        }
+        return Math.min(size, MAX_PAGE_SIZE);
+    }
+
+    /**
+     * 최근활동 목록 자르기
+     */
+    private List<RecentActivityResponse> sliceRecentActivities(List<RecentActivityResponse> activities, int page, int size) {
+        int fromIndex = Math.min(page * size, activities.size());
+        int toIndex = Math.min(fromIndex + size, activities.size());
+        return activities.subList(fromIndex, toIndex);
+    }
+
+    /**
+     * 최근활동 응답 목록 생성
+     */
+    private List<RecentActivityResponse> buildRecentActivities(HomeReadModel readModel) {
+        // V2: 여러 도메인 활동을 정확히 페이징하기 위한 읽기 모델 전환 필요
+        List<RecentActivityResponse> activities = new java.util.ArrayList<>();
+        Map<Long, Subject> subjectMap = readModel.subjectMap();
+        Map<Long, QuizSession> quizSessionMap = readModel.quizSessionMap();
+        Map<Long, QuizPlaySession> playSessionMap = readModel.playSessionMap();
+        Set<Long> startedQuizSessionIds = readModel.playSessions().stream()
+                .map(QuizPlaySession::getQuizSessionId)
+                .collect(Collectors.toSet());
+
+        activities.addAll(buildReadyQuizActivities(readModel.quizSessions(), startedQuizSessionIds, subjectMap));
+        activities.addAll(buildInProgressQuizActivities(readModel.playSessions(), quizSessionMap, subjectMap));
+        activities.addAll(buildCompletedQuizActivities(readModel.quizResults(), quizSessionMap, playSessionMap, subjectMap));
+
+        return activities.stream()
+                .sorted(Comparator.comparing(RecentActivityResponse::getCreatedAt, Comparator.nullsLast(Comparator.reverseOrder())))
+                .toList();
+    }
+
+    /**
+     * 생성 후 미시작 퀴즈 활동 생성
+     */
+    private List<RecentActivityResponse> buildReadyQuizActivities(
+            List<QuizSession> quizSessions,
+            Set<Long> startedQuizSessionIds,
+            Map<Long, Subject> subjectMap
+    ) {
+        return quizSessions.stream()
+                // 생성 완료 후 아직 풀이를 시작하지 않은 퀴즈
+                .filter(session -> QUIZ_SESSION_COMPLETED.equals(session.getStatus()))
+                .filter(session -> !startedQuizSessionIds.contains(session.getId()))
+                .map(session -> toReadyQuizActivity(session, subjectMap.get(session.getSubjectId())))
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    /**
+     * 진행 중 퀴즈 활동 생성
+     */
+    private List<RecentActivityResponse> buildInProgressQuizActivities(
+            List<QuizPlaySession> playSessions,
+            Map<Long, QuizSession> quizSessionMap,
+            Map<Long, Subject> subjectMap
+    ) {
+        return playSessions.stream()
+                // 제출 전 풀이 세션만 노출
+                .filter(playSession -> PLAY_SESSION_IN_PROGRESS.equals(playSession.getStatus()))
+                .map(playSession -> toInProgressQuizActivity(
+                        playSession,
+                        quizSessionMap.get(playSession.getQuizSessionId()),
+                        subjectMap.get(playSession.getSubjectId())
+                ))
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    /**
+     * 완료 퀴즈 활동 생성
+     */
+    private List<RecentActivityResponse> buildCompletedQuizActivities(
+            List<QuizResult> quizResults,
+            Map<Long, QuizSession> quizSessionMap,
+            Map<Long, QuizPlaySession> playSessionMap,
+            Map<Long, Subject> subjectMap
+    ) {
+        return quizResults.stream()
+                .map(result -> toCompletedQuizActivity(
+                        result,
+                        quizSessionMap.get(result.getQuizSessionId()),
+                        playSessionMap.get(result.getPlaySessionId()),
+                        subjectMap.get(result.getSubjectId())
+                ))
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    /**
+     * D-Day 응답 목록 조회
+     */
+    private List<SubjectExamScheduleResponse> findDDayScheduleResponses(HomeReadModel readModel) {
+        return subjectExamScheduleRepository
+                .findByUserIdAndDeletedAtIsNullAndExamDateGreaterThanEqualOrderByExamDateAscCreatedAtDesc(
+                        readModel.userId(),
+                        LocalDate.now(),
+                        PageRequest.of(0, HOME_D_DAY_SIZE)
+                )
+                .stream()
+                .map(schedule -> toSubjectExamScheduleResponse(schedule, readModel.subjectMap().get(schedule.getSubjectId())))
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    /**
+     * 과목 요약 응답 목록 조회
+     */
+    private List<SubjectSummaryResponse> findSubjectSummaryResponses(HomeReadModel readModel) {
+        Map<Long, Long> chapterCountMap = countBySubjectId(readModel.chapters(), Chapter::getSubjectId);
+        Map<Long, Long> partCountMap = countBySubjectId(readModel.parts(), Part::getSubjectId);
+        Map<Long, SubjectExamSchedule> scheduleMap = readModel.scheduleMap();
+
+        return readModel.subjects().stream()
+                .sorted(Comparator
+                        .comparing((Subject subject) -> resolveLastActivityAt(subject.getId(), readModel), Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(Subject::getCreatedAt, Comparator.reverseOrder()))
+                .limit(HOME_SUBJECT_SIZE)
+                .map(subject -> toSubjectSummaryResponse(
+                        subject,
+                        chapterCountMap.getOrDefault(subject.getId(), 0L),
+                        partCountMap.getOrDefault(subject.getId(), 0L),
+                        resolveLastActivityAt(subject.getId(), readModel),
+                        scheduleMap.get(subject.getId())
+                ))
+                .toList();
+    }
+
+    /**
+     * 과목별 개수 집계
+     */
+    private <T> Map<Long, Long> countBySubjectId(Collection<T> values, Function<T, Long> subjectIdExtractor) {
+        return values.stream()
+                .collect(Collectors.groupingBy(subjectIdExtractor, Collectors.counting()));
+    }
+
+    /**
+     * 과목 마지막 활동 시각 산출
+     */
+    private LocalDateTime resolveLastActivityAt(Long subjectId, HomeReadModel readModel) {
+        return java.util.stream.Stream.of(
+                        latest(readModel.quizSessions(), subjectId, QuizSession::getSubjectId, QuizSession::getCreatedAt),
+                        latest(readModel.playSessions(), subjectId, QuizPlaySession::getSubjectId, QuizPlaySession::getUpdatedAt),
+                        latest(readModel.quizResults(), subjectId, QuizResult::getSubjectId, QuizResult::getCreatedAt)
+                )
+                .flatMap(Optional::stream)
+                .max(LocalDateTime::compareTo)
+                .orElse(null);
+    }
+
+    /**
+     * 과목별 최신 시각 조회
+     */
+    private <T> Optional<LocalDateTime> latest(
+            Collection<T> values,
+            Long subjectId,
+            Function<T, Long> subjectIdExtractor,
+            Function<T, LocalDateTime> dateTimeExtractor
+    ) {
+        return values.stream()
+                // 동일 과목 데이터만 집계
+                .filter(value -> subjectId.equals(subjectIdExtractor.apply(value)))
+                .map(dateTimeExtractor)
+                .max(LocalDateTime::compareTo);
+    }
+
+    /**
+     * 활성 퀴즈 선택
+     */
+    private RecentActivityResponse findActiveQuiz(List<RecentActivityResponse> recentActivities) {
+        return recentActivities.stream()
+                // 최근 5개 밖 활성 퀴즈 누락 방지를 위한 전체 활동 기준 판단
+                .filter(activity -> RecentActivityType.QUIZ_IN_PROGRESS.equals(activity.getActivityType())
+                        || RecentActivityType.QUIZ_READY.equals(activity.getActivityType()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * 미시작 퀴즈 응답 변환
+     */
+    private Optional<RecentActivityResponse> toReadyQuizActivity(QuizSession quizSession, Subject subject) {
+        if (subject == null) {
+            return Optional.empty();
+        }
+        return Optional.of(RecentActivityResponse.builder()
+                .activityId(quizSession.getPublicId())
+                .activityType(RecentActivityType.QUIZ_READY)
+                .quizSessionId(quizSession.getPublicId())
+                .title(buildQuizTitle(subject.getName(), quizSession.getQuizType(), quizSession.getQuestionCount()))
+                .subjectId(subject.getPublicId())
+                .subjectName(subject.getName())
+                .status(quizSession.getStatus())
+                .progressPct(100)
+                .createdAt(Optional.ofNullable(quizSession.getCompletedAt()).orElse(quizSession.getUpdatedAt()))
+                .build());
+    }
+
+    /**
+     * 진행 중 퀴즈 응답 변환
+     */
+    private Optional<RecentActivityResponse> toInProgressQuizActivity(
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject
+    ) {
+        if (quizSession == null || subject == null) {
+            return Optional.empty();
+        }
+        return Optional.of(RecentActivityResponse.builder()
+                .activityId(playSession.getClientSessionId())
+                .activityType(RecentActivityType.QUIZ_IN_PROGRESS)
+                .quizSessionId(quizSession.getPublicId())
+                .playSessionId(playSession.getClientSessionId())
+                .title(buildQuizTitle(subject.getName(), quizSession.getQuizType(), quizSession.getQuestionCount()))
+                .subjectId(subject.getPublicId())
+                .subjectName(subject.getName())
+                .status(playSession.getStatus())
+                .progressPct(calculateProgressPct(playSession, quizSession))
+                .createdAt(playSession.getUpdatedAt())
+                .build());
+    }
+
+    /**
+     * 완료 퀴즈 응답 변환
+     */
+    private Optional<RecentActivityResponse> toCompletedQuizActivity(
+            QuizResult result,
+            QuizSession quizSession,
+            QuizPlaySession playSession,
+            Subject subject
+    ) {
+        if (quizSession == null || playSession == null || subject == null) {
+            return Optional.empty();
+        }
+        return Optional.of(RecentActivityResponse.builder()
+                .activityId(playSession.getClientSessionId())
+                .activityType(RecentActivityType.QUIZ_COMPLETED)
+                .quizSessionId(quizSession.getPublicId())
+                .playSessionId(playSession.getClientSessionId())
+                .resultId(result.getPublicId())
+                .title(buildQuizTitle(subject.getName(), quizSession.getQuizType(), result.getTotalCount()))
+                .subjectId(subject.getPublicId())
+                .subjectName(subject.getName())
+                .status(QUIZ_SESSION_COMPLETED)
+                .progressPct(100)
+                .scoreText(result.getCorrectCount() + "/" + result.getTotalCount())
+                .createdAt(result.getCreatedAt())
+                .build());
+    }
+
+    /**
+     * 진행률 산출
+     */
+    private Integer calculateProgressPct(QuizPlaySession playSession, QuizSession quizSession) {
+        // 문제 수 없음 방어
+        if (quizSession.getQuestionCount() == null || quizSession.getQuestionCount() == 0) {
+            return 0;
+        }
+        return Math.min(100, (playSession.getLastQuestionIndex() * 100) / quizSession.getQuestionCount());
+    }
+
+    /**
+     * 퀴즈 제목 생성
+     */
+    private String buildQuizTitle(String subjectName, String quizType, Integer questionCount) {
+        return subjectName + " " + toQuizTypeLabel(quizType) + " " + questionCount + "문제";
+    }
+
+    /**
+     * 퀴즈 유형 라벨 변환
+     */
+    private String toQuizTypeLabel(String quizType) {
+        return switch (quizType) {
+            case "multiple_choice" -> "객관식";
+            case "ox" -> "OX";
+            default -> quizType;
+        };
+    }
+
+    /**
+     * 과목 요약 응답 변환
+     */
+    private SubjectSummaryResponse toSubjectSummaryResponse(
+            Subject subject,
+            Long chapterCount,
+            Long partCount,
+            LocalDateTime lastActivityAt,
+            SubjectExamSchedule schedule
+    ) {
+        return SubjectSummaryResponse.builder()
+                .id(subject.getPublicId())
+                .name(subject.getName())
+                .purpose(subject.getPurpose())
+                .chapterCount(Math.toIntExact(chapterCount))
+                .partCount(Math.toIntExact(partCount))
+                .lastActivityAt(lastActivityAt)
+                .examSchedule(toSubjectExamScheduleResponse(schedule, subject).orElse(null))
+                .build();
+    }
+
+    /**
+     * 시험 일정 응답 변환
+     */
+    private Optional<SubjectExamScheduleResponse> toSubjectExamScheduleResponse(
+            SubjectExamSchedule schedule,
+            Subject subject
+    ) {
+        if (schedule == null || subject == null) {
+            return Optional.empty();
+        }
+        return Optional.of(SubjectExamScheduleResponse.of(
+                schedule.getPublicId(),
+                subject.getPublicId(),
+                subject.getName(),
+                schedule.getExamName(),
+                schedule.getExamDate()
+        ));
+    }
+
+    /**
+     * 홈 조합용 조회 모델
+     */
+    private record HomeReadModel(
+            Long userId,
+            List<Subject> subjects,
+            List<Chapter> chapters,
+            List<Part> parts,
+            List<SubjectExamSchedule> schedules,
+            List<QuizSession> quizSessions,
+            List<QuizPlaySession> playSessions,
+            List<QuizResult> quizResults
+    ) {
+
+        /**
+         * 과목 맵 생성
+         */
+        private Map<Long, Subject> subjectMap() {
+            return subjects.stream()
+                    .collect(Collectors.toMap(Subject::getId, Function.identity()));
+        }
+
+        /**
+         * 일정 맵 생성
+         */
+        private Map<Long, SubjectExamSchedule> scheduleMap() {
+            return schedules.stream()
+                    .collect(Collectors.toMap(SubjectExamSchedule::getSubjectId, Function.identity()));
+        }
+
+        /**
+         * 퀴즈 세션 맵 생성
+         */
+        private Map<Long, QuizSession> quizSessionMap() {
+            return quizSessions.stream()
+                    .collect(Collectors.toMap(QuizSession::getId, Function.identity()));
+        }
+
+        /**
+         * 풀이 세션 맵 생성
+         */
+        private Map<Long, QuizPlaySession> playSessionMap() {
+            return playSessions.stream()
+                    .collect(Collectors.toMap(QuizPlaySession::getId, Function.identity()));
+        }
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/part/entity/Part.java
+++ b/src/main/java/com/f1/quiket/domain/part/entity/Part.java
@@ -1,0 +1,55 @@
+package com.f1.quiket.domain.part.entity;
+
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 파트 엔티티
+ */
+@Entity
+@Table(
+        name = "parts",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_parts_public_id", columnNames = "public_id")
+        },
+        indexes = {
+                @Index(name = "idx_parts_subject_id_deleted_at", columnList = "subject_id, deleted_at"),
+                @Index(name = "idx_parts_user_id_created_at", columnList = "user_id, created_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Part extends BaseEntity {
+
+    @Column(name = "public_id", length = 36, nullable = false)
+    String publicId;
+
+    @Column(name = "chapter_id", nullable = false)
+    Long chapterId;
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "name", length = 100, nullable = false)
+    String name;
+
+    @Column(name = "part_number", nullable = false)
+    Integer partNumber;
+
+    @Lob
+    @Column(name = "content")
+    String content;
+}

--- a/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.part.repository;
+
+import com.f1.quiket.domain.part.entity.Part;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 파트 조회 리포지토리
+ */
+@Repository
+public interface PartRepository extends JpaRepository<Part, Long> {
+
+    /**
+     * 사용자 파트 목록 조회
+     */
+    List<Part> findAllByUserIdAndDeletedAtIsNull(Long userId);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -1,0 +1,66 @@
+package com.f1.quiket.domain.quiz.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 퀴즈 풀이 세션 엔티티
+ */
+@Entity
+@Table(
+        name = "quiz_play_sessions",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_quiz_play_sessions_client_session_id", columnNames = "client_session_id")
+        },
+        indexes = {
+                @Index(name = "idx_quiz_play_sessions_quiz_session_id", columnList = "quiz_session_id"),
+                @Index(name = "idx_quiz_play_sessions_user_id_status", columnList = "user_id, status"),
+                @Index(name = "idx_quiz_play_sessions_user_id_created_at", columnList = "user_id, created_at"),
+                @Index(name = "idx_quiz_play_sessions_subject_id_created_at", columnList = "subject_id, created_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuizPlaySession {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "client_session_id", length = 36, nullable = false)
+    String clientSessionId;
+
+    @Column(name = "quiz_session_id", nullable = false)
+    Long quizSessionId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "status", length = 20, nullable = false)
+    String status;
+
+    @Column(name = "last_question_index", nullable = false)
+    Integer lastQuestionIndex;
+
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
@@ -1,0 +1,69 @@
+package com.f1.quiket.domain.quiz.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 퀴즈 결과 엔티티
+ */
+@Entity
+@Table(
+        name = "quiz_results",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_quiz_results_public_id", columnNames = "public_id"),
+                @UniqueConstraint(name = "uq_quiz_results_play_session_id", columnNames = "play_session_id")
+        },
+        indexes = {
+                @Index(name = "idx_quiz_results_user_id_created_at", columnList = "user_id, created_at"),
+                @Index(name = "idx_quiz_results_quiz_session_id", columnList = "quiz_session_id"),
+                @Index(name = "idx_quiz_results_subject_id_created_at", columnList = "subject_id, created_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuizResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "public_id", length = 36, nullable = false)
+    String publicId;
+
+    @Column(name = "play_session_id", nullable = false)
+    Long playSessionId;
+
+    @Column(name = "quiz_session_id", nullable = false)
+    Long quizSessionId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "total_count", nullable = false)
+    Integer totalCount;
+
+    @Column(name = "correct_count", nullable = false)
+    Integer correctCount;
+
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizSession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizSession.java
@@ -1,0 +1,55 @@
+package com.f1.quiket.domain.quiz.entity;
+
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 퀴즈 세션 엔티티
+ */
+@Entity
+@Table(
+        name = "quiz_sessions",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_quiz_sessions_public_id", columnNames = "public_id")
+        },
+        indexes = {
+                @Index(name = "idx_quiz_sessions_user_id_status", columnList = "user_id, status"),
+                @Index(name = "idx_quiz_sessions_user_id_created_at", columnList = "user_id, created_at"),
+                @Index(name = "idx_quiz_sessions_subject_id_created_at", columnList = "subject_id, created_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuizSession extends BaseEntity {
+
+    @Column(name = "public_id", length = 36, nullable = false)
+    String publicId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "quiz_type", length = 20, nullable = false)
+    String quizType;
+
+    @Column(name = "question_count", nullable = false)
+    Integer questionCount;
+
+    @Column(name = "status", length = 20, nullable = false)
+    String status;
+
+    @Column(name = "completed_at")
+    LocalDateTime completedAt;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.quiz.repository;
+
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 퀴즈 풀이 세션 조회 리포지토리
+ */
+@Repository
+public interface QuizPlaySessionRepository extends JpaRepository<QuizPlaySession, Long> {
+
+    /**
+     * 사용자 풀이 세션 목록 조회
+     */
+    List<QuizPlaySession> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.quiz.repository;
+
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 퀴즈 결과 조회 리포지토리
+ */
+@Repository
+public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
+
+    /**
+     * 사용자 결과 목록 조회
+     */
+    List<QuizResult> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.quiz.repository;
+
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 퀴즈 세션 조회 리포지토리
+ */
+@Repository
+public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> {
+
+    /**
+     * 사용자 퀴즈 세션 목록 조회
+     */
+    List<QuizSession> findAllByUserIdAndDeletedAtIsNull(Long userId);
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/Subject.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/Subject.java
@@ -1,0 +1,44 @@
+package com.f1.quiket.domain.subject.entity;
+
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 과목 엔티티
+ */
+@Entity
+@Table(
+        name = "subjects",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_subjects_public_id", columnNames = "public_id")
+        },
+        indexes = {
+                @Index(name = "idx_subjects_user_id_deleted_at", columnList = "user_id, deleted_at"),
+                @Index(name = "idx_subjects_user_id_created_at", columnList = "user_id, created_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Subject extends BaseEntity {
+
+    @Column(name = "public_id", length = 36, nullable = false)
+    String publicId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "name", length = 30, nullable = false)
+    String name;
+
+    @Column(name = "purpose", length = 20, nullable = false)
+    String purpose;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/SubjectExamSchedule.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/SubjectExamSchedule.java
@@ -1,0 +1,49 @@
+package com.f1.quiket.domain.subject.entity;
+
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 과목 시험 일정 엔티티
+ */
+@Entity
+@Table(
+        name = "subject_exam_schedules",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_subject_exam_schedules_public_id", columnNames = "public_id"),
+                @UniqueConstraint(name = "uq_subject_exam_schedules_subject_id", columnNames = "subject_id")
+        },
+        indexes = {
+                @Index(name = "idx_subject_exam_schedules_user_id_exam_date", columnList = "user_id, exam_date"),
+                @Index(name = "idx_subject_exam_schedules_exam_date", columnList = "exam_date")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SubjectExamSchedule extends BaseEntity {
+
+    @Column(name = "public_id", length = 36, nullable = false)
+    String publicId;
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "exam_name", length = 100)
+    String examName;
+
+    @Column(name = "exam_date", nullable = false)
+    LocalDate examDate;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamScheduleRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamScheduleRepository.java
@@ -1,0 +1,30 @@
+package com.f1.quiket.domain.subject.repository;
+
+import com.f1.quiket.domain.subject.entity.SubjectExamSchedule;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 과목 시험 일정 조회 리포지토리
+ */
+@Repository
+public interface SubjectExamScheduleRepository extends JpaRepository<SubjectExamSchedule, Long> {
+
+    /**
+     * D-Day 대상 일정 조회
+     */
+    List<SubjectExamSchedule> findByUserIdAndDeletedAtIsNullAndExamDateGreaterThanEqualOrderByExamDateAscCreatedAtDesc(
+            Long userId,
+            LocalDate examDate,
+            Pageable pageable
+    );
+
+    /**
+     * 과목별 일정 목록 조회
+     */
+    List<SubjectExamSchedule> findAllBySubjectIdInAndDeletedAtIsNull(Collection<Long> subjectIds);
+}

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.subject.repository;
+
+import com.f1.quiket.domain.subject.entity.Subject;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 과목 조회 리포지토리
+ */
+@Repository
+public interface SubjectRepository extends JpaRepository<Subject, Long> {
+
+    /**
+     * 사용자 과목 목록 조회
+     */
+    List<Subject> findAllByUserIdAndDeletedAtIsNull(Long userId);
+}

--- a/src/main/java/com/f1/quiket/domain/user/entity/type/UserLevel.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/type/UserLevel.java
@@ -1,0 +1,51 @@
+package com.f1.quiket.domain.user.entity.type;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 사용자 레벨 명칭
+ */
+@Getter
+@RequiredArgsConstructor
+public enum UserLevel {
+
+    LEVEL_1(1, "첫걸음 다람쥐"),
+    LEVEL_2(2, "결심한 다람쥐"),
+    LEVEL_3(3, "펜굴리는 다람쥐"),
+    LEVEL_4(4, "노력형 다람쥐"),
+    LEVEL_5(5, "열공 다람쥐"),
+    LEVEL_6(6, "똑똑한 다람쥐"),
+    LEVEL_7(7, "박식한 다람쥐"),
+    LEVEL_8(8, "통달한 다람쥐"),
+    LEVEL_9(9, "현자 다람쥐"),
+    LEVEL_10(10, "레전드 다람쥐");
+
+    private final int level;
+    private final String title;
+
+    /**
+     * 레벨 기준 명칭 조회
+     */
+    public static String titleOf(Integer level) {
+        return Arrays.stream(values())
+                .filter(userLevel -> userLevel.level == normalize(level))
+                .findFirst()
+                .orElse(LEVEL_1)
+                .getTitle();
+    }
+
+    /**
+     * 레벨 범위 보정
+     */
+    private static int normalize(Integer level) {
+        if (level == null || level < LEVEL_1.level) {
+            return LEVEL_1.level;
+        }
+        if (level > LEVEL_10.level) {
+            return LEVEL_10.level;
+        }
+        return level;
+    }
+}

--- a/src/main/resources/db/migration/V4__add_public_id_to_exam_schedules_and_quiz_results.sql
+++ b/src/main/resources/db/migration/V4__add_public_id_to_exam_schedules_and_quiz_results.sql
@@ -1,0 +1,24 @@
+-- 시험 일정, 퀴즈 결과 외부 노출용 public_id 추가
+-- 기존 데이터 대응을 위해 NULL 허용 후, UUID v7로 채우고 NOT NULL로 변경
+
+ALTER TABLE subject_exam_schedules
+    ADD COLUMN public_id CHAR(36) NULL COMMENT '외부 노출용 UUID v7' AFTER id;
+
+UPDATE subject_exam_schedules
+SET public_id = UUID()
+WHERE public_id IS NULL;
+
+ALTER TABLE subject_exam_schedules
+    MODIFY public_id CHAR(36) NOT NULL COMMENT '외부 노출용 UUID v7',
+    ADD UNIQUE KEY uq_subject_exam_schedules_public_id (public_id);
+
+ALTER TABLE quiz_results
+    ADD COLUMN public_id CHAR(36) NULL COMMENT '외부 노출용 UUID v7' AFTER id;
+
+UPDATE quiz_results
+SET public_id = UUID()
+WHERE public_id IS NULL;
+
+ALTER TABLE quiz_results
+    MODIFY public_id CHAR(36) NOT NULL COMMENT '외부 노출용 UUID v7',
+    ADD UNIQUE KEY uq_quiz_results_public_id (public_id);

--- a/src/test/java/com/f1/quiket/domain/home/service/HomeServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/home/service/HomeServiceTest.java
@@ -1,0 +1,256 @@
+package com.f1.quiket.domain.home.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.home.dto.HomeDataResponse;
+import com.f1.quiket.domain.home.dto.RecentActivityPageResponse;
+import com.f1.quiket.domain.home.dto.RecentActivityType;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.entity.SubjectExamSchedule;
+import com.f1.quiket.domain.subject.repository.SubjectExamScheduleRepository;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class HomeServiceTest {
+
+    private UserRepository userRepository;
+    private SubjectRepository subjectRepository;
+    private SubjectExamScheduleRepository subjectExamScheduleRepository;
+    private ChapterRepository chapterRepository;
+    private PartRepository partRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private QuizPlaySessionRepository quizPlaySessionRepository;
+    private QuizResultRepository quizResultRepository;
+    private HomeService homeService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        subjectExamScheduleRepository = mock(SubjectExamScheduleRepository.class);
+        chapterRepository = mock(ChapterRepository.class);
+        partRepository = mock(PartRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        quizResultRepository = mock(QuizResultRepository.class);
+
+        homeService = new HomeService(
+                userRepository,
+                subjectRepository,
+                subjectExamScheduleRepository,
+                chapterRepository,
+                partRepository,
+                quizSessionRepository,
+                quizPlaySessionRepository,
+                quizResultRepository
+        );
+    }
+
+    @Test
+    void getHome_finds_active_quiz_from_all_activities_even_when_not_in_recent_five() {
+        User user = user();
+        Subject subject = subject(10L, "subject-public-id", "데이터베이스", LocalDateTime.now().minusDays(10));
+        QuizSession inProgressQuiz = quizSession(1L, "quiz-in-progress", subject.getId(), "completed", 10, LocalDateTime.now().minusDays(3));
+        QuizPlaySession inProgressPlay = playSession(101L, "play-in-progress", inProgressQuiz.getId(), subject.getId(), "in_progress", 3, LocalDateTime.now().minusDays(3));
+        List<QuizSession> completedQuizzes = java.util.stream.IntStream.rangeClosed(2, 6)
+                .mapToObj(index -> quizSession((long) index, "quiz-completed-" + index, subject.getId(), "completed", 10, LocalDateTime.now().minusHours(index)))
+                .toList();
+        List<QuizPlaySession> submittedPlays = completedQuizzes.stream()
+                .map(quiz -> playSession(quiz.getId() + 200, "play-completed-" + quiz.getId(), quiz.getId(), subject.getId(), "submitted", 10, quiz.getCreatedAt().plusMinutes(10)))
+                .toList();
+        List<QuizResult> results = submittedPlays.stream()
+                .map(play -> quizResult(play.getId() + 300, "result-public-" + play.getId(), play.getId(), play.getQuizSessionId(), subject.getId(), play.getUpdatedAt().plusMinutes(10)))
+                .toList();
+
+        mockCommonHomeData(user, List.of(subject), List.of(), List.of(), List.of(), concat(List.of(inProgressQuiz), completedQuizzes), concat(List.of(inProgressPlay), submittedPlays), results);
+
+        HomeDataResponse response = homeService.getHome(user.getPublicId());
+
+        assertThat(response.getRecentActivities()).hasSize(5);
+        assertThat(response.getRecentActivities())
+                .allSatisfy(activity -> assertThat(activity.getActivityType()).isEqualTo(RecentActivityType.QUIZ_COMPLETED));
+        assertThat(response.getHero().isHasActiveQuiz()).isTrue();
+        assertThat(response.getHero().getActiveQuiz().getActivityType()).isEqualTo(RecentActivityType.QUIZ_IN_PROGRESS);
+        assertThat(response.getHero().getActiveQuiz().getPlaySessionId()).isEqualTo("play-in-progress");
+    }
+
+    @Test
+    void getRecentActivities_returns_enum_types_and_paged_content() {
+        User user = user();
+        Subject subject = subject(10L, "subject-public-id", "데이터베이스", LocalDateTime.now().minusDays(10));
+        QuizSession readyQuiz = quizSession(1L, "quiz-ready", subject.getId(), "completed", 10, LocalDateTime.now().minusHours(3));
+        QuizSession inProgressQuiz = quizSession(2L, "quiz-in-progress", subject.getId(), "completed", 10, LocalDateTime.now().minusHours(2));
+        QuizSession completedQuiz = quizSession(3L, "quiz-completed", subject.getId(), "completed", 10, LocalDateTime.now().minusHours(1));
+        QuizPlaySession inProgressPlay = playSession(201L, "play-in-progress", inProgressQuiz.getId(), subject.getId(), "in_progress", 4, LocalDateTime.now().minusHours(2));
+        QuizPlaySession submittedPlay = playSession(202L, "play-completed", completedQuiz.getId(), subject.getId(), "submitted", 10, LocalDateTime.now().minusHours(1));
+        QuizResult result = quizResult(301L, "result-public-id", submittedPlay.getId(), completedQuiz.getId(), subject.getId(), LocalDateTime.now());
+
+        mockCommonHomeData(user, List.of(subject), List.of(), List.of(), List.of(), List.of(readyQuiz, inProgressQuiz, completedQuiz), List.of(inProgressPlay, submittedPlay), List.of(result));
+
+        RecentActivityPageResponse response = homeService.getRecentActivities(user.getPublicId(), 0, 2);
+
+        assertThat(response.getContent()).hasSize(2);
+        assertThat(response.getContent().get(0).getActivityType()).isEqualTo(RecentActivityType.QUIZ_COMPLETED);
+        assertThat(response.getContent().get(0).getResultId()).isEqualTo("result-public-id");
+        assertThat(response.getContent().get(1).getActivityType()).isEqualTo(RecentActivityType.QUIZ_IN_PROGRESS);
+        assertThat(response.getTotalElements()).isEqualTo(3);
+        assertThat(response.getTotalPages()).isEqualTo(2);
+        assertThat(response.isHasNext()).isTrue();
+    }
+
+    @Test
+    void getHome_returns_one_future_dDay_card_with_schedule_public_id() {
+        User user = user();
+        Subject subject = subject(10L, "subject-public-id", "데이터베이스", LocalDateTime.now().minusDays(10));
+        SubjectExamSchedule schedule = schedule(100L, "schedule-public-id", subject.getId(), user.getId(), "중간고사", LocalDate.now().plusDays(3));
+
+        mockCommonHomeData(user, List.of(subject), List.of(chapter(1L, subject.getId(), user.getId())), List.of(part(1L, subject.getId(), user.getId())), List.of(schedule), List.of(), List.of(), List.of());
+        when(subjectExamScheduleRepository.findByUserIdAndDeletedAtIsNullAndExamDateGreaterThanEqualOrderByExamDateAscCreatedAtDesc(eq(user.getId()), any(LocalDate.class), any()))
+                .thenReturn(List.of(schedule));
+
+        HomeDataResponse response = homeService.getHome(user.getPublicId());
+
+        assertThat(response.getDDayCards()).hasSize(1);
+        assertThat(response.getDDayCards().get(0).getId()).isEqualTo("schedule-public-id");
+        assertThat(response.getSubjects().get(0).getChapterCount()).isEqualTo(1);
+        assertThat(response.getSubjects().get(0).getPartCount()).isEqualTo(1);
+        assertThat(response.getSubjects().get(0).getExamSchedule().getId()).isEqualTo("schedule-public-id");
+    }
+
+    private void mockCommonHomeData(User user, List<Subject> subjects, List<Chapter> chapters, List<Part> parts, List<SubjectExamSchedule> schedules, List<QuizSession> quizSessions, List<QuizPlaySession> playSessions, List<QuizResult> quizResults) {
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(subjectRepository.findAllByUserIdAndDeletedAtIsNull(user.getId())).thenReturn(subjects);
+        when(chapterRepository.findAllByUserIdAndDeletedAtIsNull(user.getId())).thenReturn(chapters);
+        when(partRepository.findAllByUserIdAndDeletedAtIsNull(user.getId())).thenReturn(parts);
+        when(subjectExamScheduleRepository.findAllBySubjectIdInAndDeletedAtIsNull(any())).thenReturn(schedules);
+        when(subjectExamScheduleRepository.findByUserIdAndDeletedAtIsNullAndExamDateGreaterThanEqualOrderByExamDateAscCreatedAtDesc(eq(user.getId()), any(LocalDate.class), any()))
+                .thenReturn(List.of());
+        when(quizSessionRepository.findAllByUserIdAndDeletedAtIsNull(user.getId())).thenReturn(quizSessions);
+        when(quizPlaySessionRepository.findAllByUserId(user.getId())).thenReturn(playSessions);
+        when(quizResultRepository.findAllByUserId(user.getId())).thenReturn(quizResults);
+    }
+
+    private User user() {
+        User user = User.create("user-public-id", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "dotoriBalance", 12);
+        ReflectionTestUtils.setField(user, "xpTotal", 360);
+        ReflectionTestUtils.setField(user, "currentLevel", 3);
+        return user;
+    }
+
+    private Subject subject(Long id, String publicId, String name, LocalDateTime createdAt) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", 1L);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        ReflectionTestUtils.setField(subject, "createdAt", createdAt);
+        return subject;
+    }
+
+    private Chapter chapter(Long id, Long subjectId, Long userId) {
+        Chapter chapter = newEntity(Chapter.class);
+        ReflectionTestUtils.setField(chapter, "id", id);
+        ReflectionTestUtils.setField(chapter, "subjectId", subjectId);
+        ReflectionTestUtils.setField(chapter, "userId", userId);
+        return chapter;
+    }
+
+    private Part part(Long id, Long subjectId, Long userId) {
+        Part part = newEntity(Part.class);
+        ReflectionTestUtils.setField(part, "id", id);
+        ReflectionTestUtils.setField(part, "subjectId", subjectId);
+        ReflectionTestUtils.setField(part, "userId", userId);
+        return part;
+    }
+
+    private SubjectExamSchedule schedule(Long id, String publicId, Long subjectId, Long userId, String examName, LocalDate examDate) {
+        SubjectExamSchedule schedule = newEntity(SubjectExamSchedule.class);
+        ReflectionTestUtils.setField(schedule, "id", id);
+        ReflectionTestUtils.setField(schedule, "publicId", publicId);
+        ReflectionTestUtils.setField(schedule, "subjectId", subjectId);
+        ReflectionTestUtils.setField(schedule, "userId", userId);
+        ReflectionTestUtils.setField(schedule, "examName", examName);
+        ReflectionTestUtils.setField(schedule, "examDate", examDate);
+        return schedule;
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long subjectId, String status, Integer questionCount, LocalDateTime createdAt) {
+        QuizSession quizSession = newEntity(QuizSession.class);
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        ReflectionTestUtils.setField(quizSession, "publicId", publicId);
+        ReflectionTestUtils.setField(quizSession, "userId", 1L);
+        ReflectionTestUtils.setField(quizSession, "subjectId", subjectId);
+        ReflectionTestUtils.setField(quizSession, "quizType", "multiple_choice");
+        ReflectionTestUtils.setField(quizSession, "questionCount", questionCount);
+        ReflectionTestUtils.setField(quizSession, "status", status);
+        ReflectionTestUtils.setField(quizSession, "createdAt", createdAt);
+        ReflectionTestUtils.setField(quizSession, "updatedAt", createdAt);
+        ReflectionTestUtils.setField(quizSession, "completedAt", createdAt);
+        return quizSession;
+    }
+
+    private QuizPlaySession playSession(Long id, String clientSessionId, Long quizSessionId, Long subjectId, String status, Integer lastQuestionIndex, LocalDateTime updatedAt) {
+        QuizPlaySession playSession = newEntity(QuizPlaySession.class);
+        ReflectionTestUtils.setField(playSession, "id", id);
+        ReflectionTestUtils.setField(playSession, "clientSessionId", clientSessionId);
+        ReflectionTestUtils.setField(playSession, "quizSessionId", quizSessionId);
+        ReflectionTestUtils.setField(playSession, "userId", 1L);
+        ReflectionTestUtils.setField(playSession, "subjectId", subjectId);
+        ReflectionTestUtils.setField(playSession, "status", status);
+        ReflectionTestUtils.setField(playSession, "lastQuestionIndex", lastQuestionIndex);
+        ReflectionTestUtils.setField(playSession, "createdAt", updatedAt.minusMinutes(5));
+        ReflectionTestUtils.setField(playSession, "updatedAt", updatedAt);
+        return playSession;
+    }
+
+    private QuizResult quizResult(Long id, String publicId, Long playSessionId, Long quizSessionId, Long subjectId, LocalDateTime createdAt) {
+        QuizResult result = newEntity(QuizResult.class);
+        ReflectionTestUtils.setField(result, "id", id);
+        ReflectionTestUtils.setField(result, "publicId", publicId);
+        ReflectionTestUtils.setField(result, "playSessionId", playSessionId);
+        ReflectionTestUtils.setField(result, "quizSessionId", quizSessionId);
+        ReflectionTestUtils.setField(result, "userId", 1L);
+        ReflectionTestUtils.setField(result, "subjectId", subjectId);
+        ReflectionTestUtils.setField(result, "totalCount", 10);
+        ReflectionTestUtils.setField(result, "correctCount", 8);
+        ReflectionTestUtils.setField(result, "createdAt", createdAt);
+        ReflectionTestUtils.setField(result, "updatedAt", createdAt);
+        return result;
+    }
+
+    @SafeVarargs
+    private <T> List<T> concat(List<T>... values) {
+        return java.util.Arrays.stream(values)
+                .flatMap(List::stream)
+                .toList();
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}


### PR DESCRIPTION
## 🧩 Description

- 홈 화면 진입에 필요한 사용자 요약, 히어로 활성 퀴즈, D-Day 카드, 과목 요약, 최근활동 데이터를 조회하는 API를 구현했습니다.
- 최근활동 전체 목록을 페이지 단위로 조회할 수 있는 API를 추가했습니다.

---

## 🛠️ Changes

- `GET /home` 홈 메인 데이터 조회 API 추가
- `GET /home/recent-activities` 최근활동 페이지 조회 API 추가
- 홈 화면 응답 DTO 추가
- 과목, 시험 일정, 퀴즈 세션, 풀이 세션, 퀴즈 결과 데이터를 조합하는 `HomeService` 추가
- 활성 퀴즈 선정, 최근활동 페이징, D-Day 카드, 과목별 챕터/파트 개수 집계 테스트 추가
- DDL 문서에 `subject_exam_schedules.public_id`, `quiz_results.public_id` 외부 노출용 식별자 추가

---

## 🧪 How to Test

1. `./gradlew test`
2. Postman으로 `GET /home` API 응답 확인
3. Postman으로 `GET /home/recent-activities?page=0&size=10` API 응답 확인

---

## 🔗 Related Issue

Closes #32

---

## ⚠️ Notes

- 최근활동 목록 조회 API V2 구현 시 여러 도메인 활동을 정확히 페이징하기 위한 조회 방식 변경 필요.

---

## 🧑‍💻 Assignee

- @ja2hoon