### PR TITLE
[Docs] 결과 식별자 API 명세 정리

### DIFF
--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -1434,18 +1434,18 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /quiz-results/{playSessionId}:
+  /quiz-results/{resultId}:
     get:
       tags:
         - Results
         - History
       summary: 퀴즈 결과 상세 조회
-      description: 과거에 저장된 퀴즈 결과를 조회합니다. 홈 최근활동의 완료 카드에서 진입합니다.
+      description: 과거에 저장된 퀴즈 결과를 조회합니다. 홈 최근활동의 완료 카드에서 resultId로 진입합니다.
       operationId: getQuizResult
       security:
         - bearerAuth: []
       parameters:
-        - $ref: '#/components/parameters/PlaySessionId'
+        - $ref: '#/components/parameters/ResultId'
       responses:
         '200':
           description: 결과 상세 조회 성공
@@ -1458,7 +1458,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /quiz-results/{playSessionId}/review:
+  /quiz-results/{resultId}/review:
     get:
       tags:
         - Results
@@ -1468,7 +1468,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - $ref: '#/components/parameters/PlaySessionId'
+        - $ref: '#/components/parameters/ResultId'
         - name: filter
           in: query
           required: false
@@ -1492,7 +1492,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /quiz-results/{playSessionId}/retry-all:
+  /quiz-results/{resultId}/retry-all:
     post:
       tags:
         - History
@@ -1503,7 +1503,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - $ref: '#/components/parameters/PlaySessionId'
+        - $ref: '#/components/parameters/ResultId'
       requestBody:
         required: true
         content:
@@ -1524,7 +1524,7 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
 
-  /quiz-results/{playSessionId}/retry-wrong:
+  /quiz-results/{resultId}/retry-wrong:
     post:
       tags:
         - History
@@ -1535,7 +1535,7 @@ paths:
       security:
         - bearerAuth: []
       parameters:
-        - $ref: '#/components/parameters/PlaySessionId'
+        - $ref: '#/components/parameters/ResultId'
       requestBody:
         required: true
         content:
@@ -1944,6 +1944,15 @@ components:
         type: string
         format: uuid
         example: 018f8c2e-8123-72ab-96a1-f7c49c1d1111
+    ResultId:
+      name: resultId
+      in: path
+      required: true
+      description: 퀴즈 결과 publicId
+      schema:
+        type: string
+        format: uuid
+        example: 018f8c2e-9999-7b11-b2d1-774f4c1c2222
     PlaySessionId:
       name: playSessionId
       in: path
@@ -2789,6 +2798,7 @@ components:
           type: string
           format: uuid
           nullable: true
+          description: 퀴즈 결과 publicId. activityType이 quiz_completed인 경우 사용
           example: 018f8c2e-9999-7b11-b2d1-774f4c1c2222
         title:
           type: string
@@ -3163,6 +3173,7 @@ components:
         id:
           type: string
           format: uuid
+          description: 시험 일정 publicId
           example: 018f8c2e-1234-7abc-91c1-000000000001
         subjectId:
           type: string
@@ -4008,6 +4019,7 @@ components:
     QuizResult:
       type: object
       required:
+        - resultId
         - playSessionId
         - quizSessionId
         - subjectId
@@ -4020,6 +4032,11 @@ components:
         - rewards
         - reviewItems
       properties:
+        resultId:
+          type: string
+          format: uuid
+          description: 퀴즈 결과 publicId
+          example: 018f8c2e-9999-7b11-b2d1-774f4c1c2222
         playSessionId:
           type: string
           example: android-play-session-uuid


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 홈 최근활동과 결과 상세 API의 결과 식별자 기준 정리
- 시험 일정과 퀴즈 결과 ID가 외부 노출용 publicId임을 명세에 명확화

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- SubjectExamSchedule.id 설명 추가
- RecentActivity.resultId 설명 추가
- QuizResult 응답에 resultId 추가
- quiz-results 상세/해설/다시풀기 경로를 resultId 기준으로 변경

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. python3 YAML 파싱 확인
2. git diff --check 확인

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #44

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 문서 변경만 포함
- 비밀번호 재설정 Redis 정책 정리는 이번 범위 제외

---

## 🧑‍💻 Assignee

- @imclaremont