### PR TITLE
[Feat] 퀴즈 출제 범위 조회 API 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
@@ -15,4 +15,12 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
      * 사용자 챕터 목록 조회
      */
     List<Chapter> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 과목 챕터 목록 조회
+     */
+    List<Chapter> findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(
+            Long subjectId,
+            Long userId
+    );
 }

--- a/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
@@ -15,4 +15,12 @@ public interface PartRepository extends JpaRepository<Part, Long> {
      * 사용자 파트 목록 조회
      */
     List<Part> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 과목 파트 목록 조회
+     */
+    List<Part> findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByChapterIdAscPartNumberAscCreatedAtAsc(
+            Long subjectId,
+            Long userId
+    );
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizScopeController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizScopeController.java
@@ -29,9 +29,9 @@ public class QuizScopeController {
     @GetMapping("/{subjectId}/quiz-scope")
     public ResponseEntity<ApiResponse<QuizScopeResponse>> getQuizScope(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable String subjectId
+            @PathVariable("subjectId") String subjectPublicId
     ) {
-        QuizScopeResponse response = quizScopeService.getQuizScope(principal.getUserId(), subjectId);
+        QuizScopeResponse response = quizScopeService.getQuizScope(principal.getUserId(), subjectPublicId);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizScopeController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizScopeController.java
@@ -1,0 +1,37 @@
+package com.f1.quiket.domain.quiz.controller;
+
+import com.f1.quiket.domain.quiz.dto.QuizScopeResponse;
+import com.f1.quiket.domain.quiz.service.QuizScopeService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 퀴즈 출제 범위 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/subjects")
+public class QuizScopeController {
+
+    private final QuizScopeService quizScopeService;
+
+    /**
+     * 퀴즈 출제 범위 조회
+     */
+    @GetMapping("/{subjectId}/quiz-scope")
+    public ResponseEntity<ApiResponse<QuizScopeResponse>> getQuizScope(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId
+    ) {
+        QuizScopeResponse response = quizScopeService.getQuizScope(principal.getUserId(), subjectId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizScopeChapterResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizScopeChapterResponse.java
@@ -1,0 +1,33 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.part.entity.Part;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 출제 범위 챕터 응답 DTO
+ */
+@Getter
+@Builder
+public class QuizScopeChapterResponse {
+
+    private final String id;
+    private final String subjectId;
+    private final String name;
+    private final Integer displayOrder;
+    private final List<QuizScopePartResponse> parts;
+
+    public static QuizScopeChapterResponse of(Chapter chapter, String subjectPublicId, List<Part> parts) {
+        return QuizScopeChapterResponse.builder()
+                .id(chapter.getPublicId())
+                .subjectId(subjectPublicId)
+                .name(chapter.getName())
+                .displayOrder(chapter.getDisplayOrder())
+                .parts(parts.stream()
+                        .map(part -> QuizScopePartResponse.from(part, chapter.getPublicId()))
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizScopePartResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizScopePartResponse.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.quiz.dto;
 
 import com.f1.quiket.domain.part.entity.Part;
+import java.util.regex.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,6 +13,7 @@ import lombok.Getter;
 public class QuizScopePartResponse {
 
     private static final int CONTENT_PREVIEW_LENGTH = 30;
+    private static final Pattern WHITESPACE_PATTERN = Pattern.compile("\\s+");
 
     private final String id;
     private final String chapterId;
@@ -34,7 +36,7 @@ public class QuizScopePartResponse {
             return null;
         }
 
-        String normalizedContent = content.replaceAll("\\s+", " ").trim();
+        String normalizedContent = WHITESPACE_PATTERN.matcher(content).replaceAll(" ").trim();
         if (normalizedContent.length() <= CONTENT_PREVIEW_LENGTH) {
             return normalizedContent;
         }

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizScopePartResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizScopePartResponse.java
@@ -1,0 +1,43 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.part.entity.Part;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 출제 범위 파트 응답 DTO
+ */
+@Getter
+@Builder
+public class QuizScopePartResponse {
+
+    private static final int CONTENT_PREVIEW_LENGTH = 30;
+
+    private final String id;
+    private final String chapterId;
+    private final String name;
+    private final Integer partNumber;
+    private final String contentPreview;
+
+    public static QuizScopePartResponse from(Part part, String chapterPublicId) {
+        return QuizScopePartResponse.builder()
+                .id(part.getPublicId())
+                .chapterId(chapterPublicId)
+                .name(part.getName())
+                .partNumber(part.getPartNumber())
+                .contentPreview(createContentPreview(part.getContent()))
+                .build();
+    }
+
+    private static String createContentPreview(String content) {
+        if (content == null || content.isBlank()) {
+            return null;
+        }
+
+        String normalizedContent = content.replaceAll("\\s+", " ").trim();
+        if (normalizedContent.length() <= CONTENT_PREVIEW_LENGTH) {
+            return normalizedContent;
+        }
+        return normalizedContent.substring(0, CONTENT_PREVIEW_LENGTH) + "...";
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizScopeResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizScopeResponse.java
@@ -1,0 +1,39 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.subject.entity.Subject;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 출제 범위 응답 DTO
+ */
+@Getter
+@Builder
+public class QuizScopeResponse {
+
+    private final String subjectId;
+    private final String subjectName;
+    private final List<QuizScopeChapterResponse> chapters;
+
+    public static QuizScopeResponse of(
+            Subject subject,
+            List<Chapter> chapters,
+            Map<Long, List<Part>> partsByChapterId
+    ) {
+        return QuizScopeResponse.builder()
+                .subjectId(subject.getPublicId())
+                .subjectName(subject.getName())
+                .chapters(chapters.stream()
+                        .map(chapter -> QuizScopeChapterResponse.of(
+                                chapter,
+                                subject.getPublicId(),
+                                partsByChapterId.getOrDefault(chapter.getId(), List.of())
+                        ))
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizScopeService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizScopeService.java
@@ -45,9 +45,10 @@ public class QuizScopeService {
 
     private Subject findSubject(Long userId, String subjectPublicId) {
         return subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subjectPublicId, userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
     }
 
+    // TODO: Part.content(@Lob, 최대 30,000자) 전량 로드 회피 — JPQL projection으로 미리보기 컬럼만 조회 필요
     private Map<Long, List<Part>> findPartsByChapterId(Long userId, Long subjectId) {
         return partRepository
                 .findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByChapterIdAscPartNumberAscCreatedAtAsc(

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizScopeService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizScopeService.java
@@ -1,0 +1,60 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.dto.QuizScopeResponse;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 퀴즈 출제 범위 비즈니스 로직
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizScopeService {
+
+    private final SubjectRepository subjectRepository;
+    private final ChapterRepository chapterRepository;
+    private final PartRepository partRepository;
+
+    /**
+     * 퀴즈 출제 범위 조회
+     */
+    public QuizScopeResponse getQuizScope(Long userId, String subjectPublicId) {
+        Subject subject = findSubject(userId, subjectPublicId);
+        List<Chapter> chapters = chapterRepository
+                .findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(
+                        subject.getId(),
+                        userId
+                );
+        Map<Long, List<Part>> partsByChapterId = findPartsByChapterId(userId, subject.getId());
+
+        return QuizScopeResponse.of(subject, chapters, partsByChapterId);
+    }
+
+    private Subject findSubject(Long userId, String subjectPublicId) {
+        return subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subjectPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+    }
+
+    private Map<Long, List<Part>> findPartsByChapterId(Long userId, Long subjectId) {
+        return partRepository
+                .findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByChapterIdAscPartNumberAscCreatedAtAsc(
+                        subjectId,
+                        userId
+                )
+                .stream()
+                .collect(Collectors.groupingBy(Part::getChapterId));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.subject.repository;
 
 import com.f1.quiket.domain.subject.entity.Subject;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +16,9 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
      * 사용자 과목 목록 조회
      */
     List<Subject> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 사용자 과목 단건 조회
+     */
+    Optional<Subject> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
 }

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -46,6 +46,9 @@ public enum ErrorCode {
     AUTH_OAUTH_TEMP_TOKEN_STORE_FAILED(503, "AUTH_OAUTH_TEMP_TOKEN_STORE_FAILED", "Kakao OAuth 임시 토큰 처리에 실패했습니다."),
     AUTH_OAUTH_USER_INFO_FAILED(503, "AUTH_OAUTH_USER_INFO_FAILED", "Kakao 사용자 정보 조회에 실패했습니다."),
 
+    // Subject Errors
+    SUBJECT_NOT_FOUND(404, "SUBJECT_NOT_FOUND", "과목을 찾을 수 없습니다."),
+
     // 5xx Server Errors
     INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다."),
     SERVICE_UNAVAILABLE(503, "C009", "일시적으로 서비스를 이용할 수 없습니다."),

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizScopeServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizScopeServiceTest.java
@@ -1,0 +1,121 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.dto.QuizScopeResponse;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizScopeServiceTest {
+
+    private SubjectRepository subjectRepository;
+    private ChapterRepository chapterRepository;
+    private PartRepository partRepository;
+    private QuizScopeService quizScopeService;
+
+    @BeforeEach
+    void setUp() {
+        subjectRepository = mock(SubjectRepository.class);
+        chapterRepository = mock(ChapterRepository.class);
+        partRepository = mock(PartRepository.class);
+        quizScopeService = new QuizScopeService(subjectRepository, chapterRepository, partRepository);
+    }
+
+    @Test
+    void getQuizScope_returns_chapters_with_parts() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        Chapter chapter1 = chapter(100L, "chapter-public-1", subject.getId(), userId, "1장 데이터 모델링", 1);
+        Chapter chapter2 = chapter(101L, "chapter-public-2", subject.getId(), userId, "2장 정규화", 2);
+        Part part1 = part(1000L, "part-public-1", chapter1.getId(), subject.getId(), userId, "데이터 모델링 개념", 1, "데이터 모델링은 현실 세계의 데이터를 추상화하여 구조화하는 과정입니다.");
+        Part part2 = part(1001L, "part-public-2", chapter1.getId(), subject.getId(), userId, "데이터 모델링 특징", 2, null);
+
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), userId))
+                .thenReturn(Optional.of(subject));
+        when(chapterRepository.findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId(), userId))
+                .thenReturn(List.of(chapter1, chapter2));
+        when(partRepository.findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByChapterIdAscPartNumberAscCreatedAtAsc(subject.getId(), userId))
+                .thenReturn(List.of(part1, part2));
+
+        QuizScopeResponse response = quizScopeService.getQuizScope(userId, subject.getPublicId());
+
+        assertThat(response.getSubjectId()).isEqualTo(subject.getPublicId());
+        assertThat(response.getSubjectName()).isEqualTo("데이터베이스");
+        assertThat(response.getChapters()).hasSize(2);
+        assertThat(response.getChapters().get(0).getId()).isEqualTo("chapter-public-1");
+        assertThat(response.getChapters().get(0).getParts()).hasSize(2);
+        assertThat(response.getChapters().get(0).getParts().get(0).getId()).isEqualTo("part-public-1");
+        assertThat(response.getChapters().get(0).getParts().get(0).getChapterId()).isEqualTo("chapter-public-1");
+        assertThat(response.getChapters().get(0).getParts().get(0).getContentPreview()).endsWith("...");
+        assertThat(response.getChapters().get(0).getParts().get(1).getContentPreview()).isNull();
+        assertThat(response.getChapters().get(1).getParts()).isEmpty();
+    }
+
+    @Test
+    void getQuizScope_throws_not_found_when_subject_is_not_owned() {
+        Long userId = 1L;
+        String subjectPublicId = "subject-public-id";
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subjectPublicId, userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizScopeService.getQuizScope(userId, subjectPublicId))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+
+        verifyNoInteractions(chapterRepository, partRepository);
+    }
+
+    private Subject subject(Long id, String publicId, Long userId, String name) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private Chapter chapter(Long id, String publicId, Long subjectId, Long userId, String name, Integer displayOrder) {
+        Chapter chapter = newEntity(Chapter.class);
+        ReflectionTestUtils.setField(chapter, "id", id);
+        ReflectionTestUtils.setField(chapter, "publicId", publicId);
+        ReflectionTestUtils.setField(chapter, "subjectId", subjectId);
+        ReflectionTestUtils.setField(chapter, "userId", userId);
+        ReflectionTestUtils.setField(chapter, "name", name);
+        ReflectionTestUtils.setField(chapter, "displayOrder", displayOrder);
+        return chapter;
+    }
+
+    private Part part(Long id, String publicId, Long chapterId, Long subjectId, Long userId, String name, Integer partNumber, String content) {
+        Part part = newEntity(Part.class);
+        ReflectionTestUtils.setField(part, "id", id);
+        ReflectionTestUtils.setField(part, "publicId", publicId);
+        ReflectionTestUtils.setField(part, "chapterId", chapterId);
+        ReflectionTestUtils.setField(part, "subjectId", subjectId);
+        ReflectionTestUtils.setField(part, "userId", userId);
+        ReflectionTestUtils.setField(part, "name", name);
+        ReflectionTestUtils.setField(part, "partNumber", partNumber);
+        ReflectionTestUtils.setField(part, "content", content);
+        return part;
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizScopeServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizScopeServiceTest.java
@@ -76,9 +76,28 @@ class QuizScopeServiceTest {
         assertThatThrownBy(() -> quizScopeService.getQuizScope(userId, subjectPublicId))
                 .isInstanceOf(CustomException.class)
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
-                .isEqualTo(ErrorCode.NOT_FOUND);
+                .isEqualTo(ErrorCode.SUBJECT_NOT_FOUND);
 
         verifyNoInteractions(chapterRepository, partRepository);
+    }
+
+    @Test
+    void getQuizScope_returns_empty_chapters_when_subject_has_none() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), userId))
+                .thenReturn(Optional.of(subject));
+        when(chapterRepository.findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId(), userId))
+                .thenReturn(List.of());
+        when(partRepository.findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByChapterIdAscPartNumberAscCreatedAtAsc(subject.getId(), userId))
+                .thenReturn(List.of());
+
+        QuizScopeResponse response = quizScopeService.getQuizScope(userId, subject.getPublicId());
+
+        assertThat(response.getSubjectId()).isEqualTo(subject.getPublicId());
+        assertThat(response.getSubjectName()).isEqualTo("데이터베이스");
+        assertThat(response.getChapters()).isEmpty();
     }
 
     private Subject subject(Long id, String publicId, Long userId, String name) {


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 기능명세 QUIZ-OPT-001 기준 퀴즈 출제 범위 조회 API 구현
- 과목 publicId로 챕터/파트 목록을 조회해 선택 화면 응답 구성

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- GET /api/v1/subjects/{subjectId}/quiz-scope 컨트롤러 추가
- 과목 소유권 검증 후 챕터/파트 응답 생성
- 출제 범위 응답 DTO 추가
- Subject, Chapter, Part 조회 Repository 메서드 추가
- QuizScopeService 단위 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. ./gradlew test --tests com.f1.quiket.domain.quiz.service.QuizScopeServiceTest
2. ./gradlew test

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #49

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- QUIZ-OPT-001 범위만 포함
- 퀴즈 생성 옵션 저장, 생성 상태 조회, AI 생성 로직은 후속 이슈에서 처리

---

## 🧑‍💻 Assignee

- @imclaremont