### PR TITLE
[Feat] 퀴즈 생성 옵션 검증 및 세션 생성 구현

### DIFF
--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -3604,7 +3604,6 @@ components:
         - quizType
         - questionCount
         - playMode
-        - difficulty
       properties:
         subjectId:
           type: string
@@ -3624,6 +3623,7 @@ components:
         choiceCount:
           type: integer
           nullable: true
+          description: 객관식 보기 수. quizType이 multiple_choice이고 미입력 시 4로 처리
           enum:
             - 4
             - 5
@@ -3652,7 +3652,9 @@ components:
           minimum: 1
           example: 60
         difficulty:
-          $ref: '#/components/schemas/QuizDifficulty'
+          description: 미입력 시 medium으로 처리
+          allOf:
+            - $ref: '#/components/schemas/QuizDifficulty'
 
     QuizGenerationAcceptedResponse:
       allOf:

--- a/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
@@ -4,6 +4,8 @@ import com.f1.quiket.domain.part.entity.Part;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -32,5 +34,22 @@ public interface PartRepository extends JpaRepository<Part, Long> {
             Collection<String> publicIds,
             Long subjectId,
             Long userId
+    );
+
+    /**
+     * 출제 범위 파트 본문 길이 합계 (50자당 1문제 정책 검증용)
+     */
+    @Query("""
+            select coalesce(sum(length(p.content)), 0)
+            from Part p
+            where p.publicId in :publicIds
+              and p.subjectId = :subjectId
+              and p.userId = :userId
+              and p.deletedAt is null
+            """)
+    long sumContentLengthByPublicIds(
+            @Param("publicIds") Collection<String> publicIds,
+            @Param("subjectId") Long subjectId,
+            @Param("userId") Long userId
     );
 }

--- a/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.part.repository;
 
 import com.f1.quiket.domain.part.entity.Part;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -20,6 +21,15 @@ public interface PartRepository extends JpaRepository<Part, Long> {
      * 과목 파트 목록 조회
      */
     List<Part> findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByChapterIdAscPartNumberAscCreatedAtAsc(
+            Long subjectId,
+            Long userId
+    );
+
+    /**
+     * 과목 파트 목록 조회
+     */
+    List<Part> findAllByPublicIdInAndSubjectIdAndUserIdAndDeletedAtIsNull(
+            Collection<String> publicIds,
             Long subjectId,
             Long userId
     );

--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
@@ -1,0 +1,46 @@
+package com.f1.quiket.domain.quiz.controller;
+
+import com.f1.quiket.domain.quiz.dto.QuizCreateRequest;
+import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
+import com.f1.quiket.domain.quiz.service.QuizSessionCreateService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 퀴즈 세션 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/quiz-sessions")
+public class QuizSessionController {
+
+    private final QuizSessionCreateService quizSessionCreateService;
+
+    /**
+     * 퀴즈 생성 요청
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<QuizGenerationAcceptedResponse>> createQuizSession(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody QuizCreateRequest request
+    ) {
+        QuizGenerationAcceptedResponse response = quizSessionCreateService.createQuizSession(
+                principal.getUserId(),
+                request
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .body(ApiResponse.success(SuccessCode.ACCEPTED, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizCreateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizCreateRequest.java
@@ -1,0 +1,50 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 퀴즈 생성 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class QuizCreateRequest {
+
+    @NotBlank(message = "과목 ID는 필수입니다")
+    private String subjectId;
+
+    @NotEmpty(message = "출제 범위는 최소 1개 이상 선택해야 합니다")
+    private List<@NotBlank(message = "파트 ID는 비어 있을 수 없습니다") String> partIds;
+
+    @NotBlank(message = "퀴즈 형식은 필수입니다")
+    @Pattern(regexp = "multiple_choice|ox", message = "퀴즈 형식이 올바르지 않습니다")
+    private String quizType;
+
+    private Integer choiceCount;
+
+    @NotNull(message = "문제 수는 필수입니다")
+    @Min(value = 1, message = "문제 수는 1개 이상이어야 합니다")
+    @Max(value = 100, message = "문제 수는 100개 이하여야 합니다")
+    private Integer questionCount;
+
+    @NotBlank(message = "풀이 방식은 필수입니다")
+    @Pattern(regexp = "one_by_one|all_at_once", message = "풀이 방식이 올바르지 않습니다")
+    private String playMode;
+
+    private Boolean timerEnabled;
+
+    @Pattern(regexp = "per_question|total", message = "타이머 범위가 올바르지 않습니다")
+    private String timerScope;
+
+    private Integer timerSeconds;
+
+    @Pattern(regexp = "easy|medium|hard", message = "난이도가 올바르지 않습니다")
+    private String difficulty;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationAcceptedResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationAcceptedResponse.java
@@ -17,6 +17,7 @@ public class QuizGenerationAcceptedResponse {
     private final Integer estimatedSeconds;
 
     public static QuizGenerationAcceptedResponse from(QuizSession quizSession) {
+        // TODO: estimatedSeconds — AI 생성 도입 후 출제 범위/문제수 기반 추정값 산출 후속 이슈에서 대체
         return QuizGenerationAcceptedResponse.builder()
                 .quizSessionId(quizSession.getPublicId())
                 .jobId(quizSession.getJobId())

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationAcceptedResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationAcceptedResponse.java
@@ -1,0 +1,27 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 생성 접수 응답 DTO
+ */
+@Getter
+@Builder
+public class QuizGenerationAcceptedResponse {
+
+    private final String quizSessionId;
+    private final String jobId;
+    private final String status;
+    private final Integer estimatedSeconds;
+
+    public static QuizGenerationAcceptedResponse from(QuizSession quizSession) {
+        return QuizGenerationAcceptedResponse.builder()
+                .quizSessionId(quizSession.getPublicId())
+                .jobId(quizSession.getJobId())
+                .status(quizSession.getStatus())
+                .estimatedSeconds(null)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizSession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizSession.java
@@ -24,7 +24,8 @@ import lombok.experimental.FieldDefaults;
         indexes = {
                 @Index(name = "idx_quiz_sessions_user_id_status", columnList = "user_id, status"),
                 @Index(name = "idx_quiz_sessions_user_id_created_at", columnList = "user_id, created_at"),
-                @Index(name = "idx_quiz_sessions_subject_id_created_at", columnList = "subject_id, created_at")
+                @Index(name = "idx_quiz_sessions_subject_id_created_at", columnList = "subject_id, created_at"),
+                @Index(name = "idx_quiz_sessions_status_created_at", columnList = "status, created_at")
         }
 )
 @Getter
@@ -44,12 +45,71 @@ public class QuizSession extends BaseEntity {
     @Column(name = "quiz_type", length = 20, nullable = false)
     String quizType;
 
+    @Column(name = "choice_count")
+    Integer choiceCount;
+
     @Column(name = "question_count", nullable = false)
     Integer questionCount;
+
+    @Column(name = "play_mode", length = 20, nullable = false)
+    String playMode;
+
+    @Column(name = "timer_enabled", nullable = false)
+    Boolean timerEnabled;
+
+    @Column(name = "timer_scope", length = 20)
+    String timerScope;
+
+    @Column(name = "timer_seconds")
+    Integer timerSeconds;
+
+    @Column(name = "difficulty", length = 10, nullable = false)
+    String difficulty;
 
     @Column(name = "status", length = 20, nullable = false)
     String status;
 
+    @Column(name = "job_id", length = 100)
+    String jobId;
+
+    @Column(name = "fail_reason", length = 255)
+    String failReason;
+
+    @Column(name = "generated_count")
+    Integer generatedCount;
+
     @Column(name = "completed_at")
     LocalDateTime completedAt;
+
+    public static QuizSession create(
+            String publicId,
+            Long userId,
+            Long subjectId,
+            String quizType,
+            Integer choiceCount,
+            Integer questionCount,
+            String playMode,
+            Boolean timerEnabled,
+            String timerScope,
+            Integer timerSeconds,
+            String difficulty,
+            String status,
+            String jobId
+    ) {
+        QuizSession quizSession = new QuizSession();
+        quizSession.publicId = publicId;
+        quizSession.userId = userId;
+        quizSession.subjectId = subjectId;
+        quizSession.quizType = quizType;
+        quizSession.choiceCount = choiceCount;
+        quizSession.questionCount = questionCount;
+        quizSession.playMode = playMode;
+        quizSession.timerEnabled = timerEnabled;
+        quizSession.timerScope = timerScope;
+        quizSession.timerSeconds = timerSeconds;
+        quizSession.difficulty = difficulty;
+        quizSession.status = status;
+        quizSession.jobId = jobId;
+        return quizSession;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizSessionScope.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizSessionScope.java
@@ -1,0 +1,59 @@
+package com.f1.quiket.domain.quiz.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 퀴즈 세션 출제 범위 엔티티
+ */
+@Entity
+@Table(
+        name = "quiz_session_scopes",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_quiz_session_scopes_session_part",
+                        columnNames = {"quiz_session_id", "part_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_quiz_session_scopes_quiz_session_id", columnList = "quiz_session_id"),
+                @Index(name = "idx_quiz_session_scopes_part_id", columnList = "part_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuizSessionScope {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "quiz_session_id", nullable = false)
+    Long quizSessionId;
+
+    @Column(name = "part_id", nullable = false)
+    Long partId;
+
+    @Column(name = "chapter_id", nullable = false)
+    Long chapterId;
+
+    public static QuizSessionScope create(Long quizSessionId, Long partId, Long chapterId) {
+        QuizSessionScope scope = new QuizSessionScope();
+        scope.quizSessionId = quizSessionId;
+        scope.partId = partId;
+        scope.chapterId = chapterId;
+        return scope;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.quiz.repository;
 
 import com.f1.quiket.domain.quiz.entity.QuizSession;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -15,4 +16,9 @@ public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> 
      * 사용자 퀴즈 세션 목록 조회
      */
     List<QuizSession> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 사용자 생성 중 퀴즈 존재 여부
+     */
+    boolean existsByUserIdAndStatusInAndDeletedAtIsNull(Long userId, Collection<String> statuses);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionScopeRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionScopeRepository.java
@@ -1,0 +1,12 @@
+package com.f1.quiket.domain.quiz.repository;
+
+import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 퀴즈 세션 출제 범위 리포지토리
+ */
+@Repository
+public interface QuizSessionScopeRepository extends JpaRepository<QuizSessionScope, Long> {
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationLockStore.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationLockStore.java
@@ -1,0 +1,55 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 사용자당 퀴즈 생성 1건 제한용 분산락 저장소
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QuizGenerationLockStore {
+
+    private static final String LOCK_KEY_PREFIX = "quiz:gen:lock:";
+    private static final String LOCK_VALUE = "locked";
+    private static final Duration LOCK_TTL = Duration.ofSeconds(10L);
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    /**
+     * 사용자 단위 락 획득 (NX + TTL)
+     */
+    public void acquire(Long userId) {
+        try {
+            Boolean acquired = stringRedisTemplate.opsForValue()
+                    .setIfAbsent(buildKey(userId), LOCK_VALUE, LOCK_TTL);
+            if (!Boolean.TRUE.equals(acquired)) {
+                throw new CustomException(ErrorCode.QUIZ_GENERATION_IN_PROGRESS);
+            }
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    /**
+     * 락 해제 (실패 시 로그 후 무시, TTL로 자연 만료)
+     */
+    public void release(Long userId) {
+        try {
+            stringRedisTemplate.delete(buildKey(userId));
+        } catch (DataAccessException e) {
+            log.warn("퀴즈 생성 분산락 해제 실패. userId={}", userId, e);
+        }
+    }
+
+    private String buildKey(Long userId) {
+        return LOCK_KEY_PREFIX + userId;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
@@ -1,0 +1,208 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.dto.QuizCreateRequest;
+import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.global.util.UuidV7Generator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * 퀴즈 세션 생성 비즈니스 로직
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizSessionCreateService {
+
+    private static final String QUIZ_TYPE_MULTIPLE_CHOICE = "multiple_choice";
+    private static final String QUIZ_TYPE_OX = "ox";
+    private static final String PLAY_MODE_ONE_BY_ONE = "one_by_one";
+    private static final String PLAY_MODE_ALL_AT_ONCE = "all_at_once";
+    private static final String TIMER_SCOPE_PER_QUESTION = "per_question";
+    private static final String TIMER_SCOPE_TOTAL = "total";
+    private static final String DIFFICULTY_MEDIUM = "medium";
+    private static final String STATUS_PENDING = "pending";
+    private static final List<String> ACTIVE_GENERATION_STATUSES = List.of("pending", "in_progress");
+
+    private final SubjectRepository subjectRepository;
+    private final PartRepository partRepository;
+    private final QuizSessionRepository quizSessionRepository;
+    private final QuizSessionScopeRepository quizSessionScopeRepository;
+
+    /**
+     * 퀴즈 세션 생성
+     */
+    public QuizGenerationAcceptedResponse createQuizSession(Long userId, QuizCreateRequest request) {
+        validateActiveGeneration(userId);
+
+        Subject subject = findSubject(userId, request.getSubjectId());
+        QuizOptionValues optionValues = resolveOptions(request);
+        List<Part> parts = findScopeParts(userId, subject.getId(), request.getPartIds());
+
+        QuizSession quizSession = QuizSession.create(
+                UuidV7Generator.generate(),
+                userId,
+                subject.getId(),
+                optionValues.quizType(),
+                optionValues.choiceCount(),
+                request.getQuestionCount(),
+                optionValues.playMode(),
+                optionValues.timerEnabled(),
+                optionValues.timerScope(),
+                optionValues.timerSeconds(),
+                optionValues.difficulty(),
+                STATUS_PENDING,
+                createJobId()
+        );
+
+        QuizSession savedQuizSession = quizSessionRepository.save(quizSession);
+        quizSessionScopeRepository.saveAll(createScopes(savedQuizSession.getId(), parts));
+
+        return QuizGenerationAcceptedResponse.from(savedQuizSession);
+    }
+
+    private void validateActiveGeneration(Long userId) {
+        if (quizSessionRepository.existsByUserIdAndStatusInAndDeletedAtIsNull(userId, ACTIVE_GENERATION_STATUSES)) {
+            throw new CustomException(ErrorCode.QUIZ_GENERATION_IN_PROGRESS);
+        }
+    }
+
+    private Subject findSubject(Long userId, String subjectPublicId) {
+        return subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subjectPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+    }
+
+    private List<Part> findScopeParts(Long userId, Long subjectId, List<String> partPublicIds) {
+        validateDuplicatePartIds(partPublicIds);
+
+        List<Part> parts = partRepository.findAllByPublicIdInAndSubjectIdAndUserIdAndDeletedAtIsNull(
+                partPublicIds,
+                subjectId,
+                userId
+        );
+        if (parts.size() != partPublicIds.size()) {
+            throw new CustomException(ErrorCode.QUIZ_SCOPE_INVALID);
+        }
+        return parts;
+    }
+
+    private void validateDuplicatePartIds(List<String> partPublicIds) {
+        Set<String> uniquePartIds = partPublicIds.stream().collect(Collectors.toSet());
+        if (uniquePartIds.size() != partPublicIds.size()) {
+            throw new CustomException(ErrorCode.QUIZ_SCOPE_INVALID);
+        }
+    }
+
+    private QuizOptionValues resolveOptions(QuizCreateRequest request) {
+        String quizType = request.getQuizType();
+        validatePlayMode(request.getPlayMode());
+        Integer choiceCount = resolveChoiceCount(quizType, request.getChoiceCount());
+        Boolean timerEnabled = Boolean.TRUE.equals(request.getTimerEnabled());
+        TimerValues timerValues = resolveTimer(request.getPlayMode(), timerEnabled, request.getTimerScope(), request.getTimerSeconds());
+        String difficulty = StringUtils.hasText(request.getDifficulty()) ? request.getDifficulty() : DIFFICULTY_MEDIUM;
+        validateDifficulty(difficulty);
+
+        return new QuizOptionValues(
+                quizType,
+                choiceCount,
+                request.getPlayMode(),
+                timerEnabled,
+                timerValues.timerScope(),
+                timerValues.timerSeconds(),
+                difficulty
+        );
+    }
+
+    private void validatePlayMode(String playMode) {
+        if (!PLAY_MODE_ONE_BY_ONE.equals(playMode) && !PLAY_MODE_ALL_AT_ONCE.equals(playMode)) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+    }
+
+    private void validateDifficulty(String difficulty) {
+        if (!Set.of("easy", "medium", "hard").contains(difficulty)) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+    }
+
+    private Integer resolveChoiceCount(String quizType, Integer choiceCount) {
+        if (QUIZ_TYPE_MULTIPLE_CHOICE.equals(quizType)) {
+            Integer resolvedChoiceCount = choiceCount == null ? 4 : choiceCount;
+            if (resolvedChoiceCount != 4 && resolvedChoiceCount != 5) {
+                throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+            }
+            return resolvedChoiceCount;
+        }
+
+        if (QUIZ_TYPE_OX.equals(quizType)) {
+            if (choiceCount != null) {
+                throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+            }
+            return null;
+        }
+
+        throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+    }
+
+    private TimerValues resolveTimer(String playMode, Boolean timerEnabled, String timerScope, Integer timerSeconds) {
+        if (!timerEnabled) {
+            if (StringUtils.hasText(timerScope) || timerSeconds != null) {
+                throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+            }
+            return new TimerValues(null, null);
+        }
+
+        if (!StringUtils.hasText(timerScope) || timerSeconds == null || timerSeconds < 1) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+
+        if (PLAY_MODE_ONE_BY_ONE.equals(playMode) && !TIMER_SCOPE_PER_QUESTION.equals(timerScope)) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+
+        if (PLAY_MODE_ALL_AT_ONCE.equals(playMode) && !TIMER_SCOPE_TOTAL.equals(timerScope)) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+
+        return new TimerValues(timerScope, timerSeconds);
+    }
+
+    private List<QuizSessionScope> createScopes(Long quizSessionId, List<Part> parts) {
+        return parts.stream()
+                .map(part -> QuizSessionScope.create(quizSessionId, part.getId(), part.getChapterId()))
+                .toList();
+    }
+
+    private String createJobId() {
+        return "quiz-job-" + UuidV7Generator.generate();
+    }
+
+    private record TimerValues(String timerScope, Integer timerSeconds) {
+    }
+
+    private record QuizOptionValues(
+            String quizType,
+            Integer choiceCount,
+            String playMode,
+            Boolean timerEnabled,
+            String timerScope,
+            Integer timerSeconds,
+            String difficulty
+    ) {
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
@@ -38,21 +38,34 @@ public class QuizSessionCreateService {
     private static final String DIFFICULTY_MEDIUM = "medium";
     private static final String STATUS_PENDING = "pending";
     private static final List<String> ACTIVE_GENERATION_STATUSES = List.of("pending", "in_progress");
+    private static final int CHARS_PER_QUESTION = 50;
 
     private final SubjectRepository subjectRepository;
     private final PartRepository partRepository;
     private final QuizSessionRepository quizSessionRepository;
     private final QuizSessionScopeRepository quizSessionScopeRepository;
+    private final QuizGenerationLockStore quizGenerationLockStore;
 
     /**
      * 퀴즈 세션 생성
      */
     public QuizGenerationAcceptedResponse createQuizSession(Long userId, QuizCreateRequest request) {
+        // 동시 요청(연타·재시도) 차단용 사용자 단위 분산락
+        quizGenerationLockStore.acquire(userId);
+        try {
+            return createQuizSessionInternal(userId, request);
+        } finally {
+            quizGenerationLockStore.release(userId);
+        }
+    }
+
+    private QuizGenerationAcceptedResponse createQuizSessionInternal(Long userId, QuizCreateRequest request) {
         validateActiveGeneration(userId);
 
         Subject subject = findSubject(userId, request.getSubjectId());
         QuizOptionValues optionValues = resolveOptions(request);
         List<Part> parts = findScopeParts(userId, subject.getId(), request.getPartIds());
+        validateQuestionCountAgainstTextLength(userId, subject.getId(), request);
 
         QuizSession quizSession = QuizSession.create(
                 UuidV7Generator.generate(),
@@ -74,6 +87,21 @@ public class QuizSessionCreateService {
         quizSessionScopeRepository.saveAll(createScopes(savedQuizSession.getId(), parts));
 
         return QuizGenerationAcceptedResponse.from(savedQuizSession);
+    }
+
+    /**
+     * 50자당 1문제 정책 검증 (기능명세 QUIZ-GEN-001)
+     */
+    private void validateQuestionCountAgainstTextLength(Long userId, Long subjectId, QuizCreateRequest request) {
+        long totalLength = partRepository.sumContentLengthByPublicIds(
+                request.getPartIds(),
+                subjectId,
+                userId
+        );
+        long maxQuestionCount = totalLength / CHARS_PER_QUESTION;
+        if (request.getQuestionCount() > maxQuestionCount) {
+            throw new CustomException(ErrorCode.QUIZ_SCOPE_TEXT_INSUFFICIENT);
+        }
     }
 
     private void validateActiveGeneration(Long userId) {
@@ -188,6 +216,7 @@ public class QuizSessionCreateService {
                 .toList();
     }
 
+    // TODO: jobId — AI 생성 작업 도입 후 MQ message-id 등 실제 작업 식별자로 대체
     private String createJobId() {
         return "quiz-job-" + UuidV7Generator.generate();
     }

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -52,6 +52,7 @@ public enum ErrorCode {
     // Quiz Errors
     QUIZ_OPTION_INVALID(400, "QUIZ_OPTION_INVALID", "퀴즈 옵션이 올바르지 않습니다."),
     QUIZ_SCOPE_INVALID(400, "QUIZ_SCOPE_INVALID", "출제 범위가 올바르지 않습니다."),
+    QUIZ_SCOPE_TEXT_INSUFFICIENT(422, "QUIZ_SCOPE_TEXT_INSUFFICIENT", "출제 범위의 텍스트가 부족하여 요청한 문제 수를 만들 수 없습니다."),
     QUIZ_GENERATION_IN_PROGRESS(409, "QUIZ_GENERATION_IN_PROGRESS", "이미 생성 중인 퀴즈가 있습니다."),
 
     // 5xx Server Errors

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -49,6 +49,11 @@ public enum ErrorCode {
     // Subject Errors
     SUBJECT_NOT_FOUND(404, "SUBJECT_NOT_FOUND", "과목을 찾을 수 없습니다."),
 
+    // Quiz Errors
+    QUIZ_OPTION_INVALID(400, "QUIZ_OPTION_INVALID", "퀴즈 옵션이 올바르지 않습니다."),
+    QUIZ_SCOPE_INVALID(400, "QUIZ_SCOPE_INVALID", "출제 범위가 올바르지 않습니다."),
+    QUIZ_GENERATION_IN_PROGRESS(409, "QUIZ_GENERATION_IN_PROGRESS", "이미 생성 중인 퀴즈가 있습니다."),
+
     // 5xx Server Errors
     INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다."),
     SERVICE_UNAVAILABLE(503, "C009", "일시적으로 서비스를 이용할 수 없습니다."),

--- a/src/main/resources/db/migration/V5__create_quiz_sessions_and_scopes.sql
+++ b/src/main/resources/db/migration/V5__create_quiz_sessions_and_scopes.sql
@@ -1,0 +1,63 @@
+-- 퀴즈 세션 (QUIZ-OPT-002/004/005/005B/006 + QUIZ-GEN-001 설정값/생성 상태)
+CREATE TABLE quiz_sessions (
+    id                  BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK: 퀴즈 세션 식별자',
+    public_id           CHAR(36) NOT NULL COMMENT '외부 노출용 UUID v7',
+    user_id             BIGINT NOT NULL COMMENT '사용자 ID',
+    subject_id          BIGINT NOT NULL COMMENT '출제 과목 ID (역정규화)',
+
+    quiz_type           VARCHAR(20) NOT NULL COMMENT '퀴즈 형식: multiple_choice / ox',
+    choice_count        TINYINT NULL COMMENT '객관식 보기 수: 4 또는 5 (OX이면 NULL)',
+    question_count      TINYINT UNSIGNED NOT NULL COMMENT '요청 문제 수 (1~100)',
+    play_mode           VARCHAR(20) NOT NULL COMMENT '풀기 방식: one_by_one / all_at_once',
+
+    timer_enabled       TINYINT(1) NOT NULL DEFAULT 0 COMMENT '타이머 사용 여부',
+    timer_scope         VARCHAR(20) NULL COMMENT '타이머 범위: per_question / total',
+    timer_seconds       INT NULL COMMENT '타이머 시간(초 단위 통일 저장)',
+
+    difficulty          VARCHAR(10) NOT NULL DEFAULT 'medium' COMMENT '난이도: easy / medium / hard',
+
+    status              VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT '생성 상태: pending / in_progress / completed / failed',
+    job_id              VARCHAR(100) NULL COMMENT '비동기 작업 ID',
+    fail_reason         VARCHAR(255) NULL COMMENT '실패 사유 (status=failed)',
+    generated_count     TINYINT UNSIGNED NULL COMMENT '실제 생성된 문제 수',
+    completed_at        DATETIME(3) NULL COMMENT '생성 완료 시각',
+
+    created_at          DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at          DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at          DATETIME(3) NULL COMMENT '삭제 시각 (soft delete)',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_quiz_sessions_public_id (public_id),
+    KEY idx_quiz_sessions_user_id_status (user_id, status),
+    KEY idx_quiz_sessions_user_id_created_at (user_id, created_at),
+    KEY idx_quiz_sessions_subject_id_created_at (subject_id, created_at),
+    KEY idx_quiz_sessions_status_created_at (status, created_at),
+
+    CONSTRAINT chk_quiz_sessions_quiz_type
+        CHECK (quiz_type IN ('multiple_choice', 'ox')),
+    CONSTRAINT chk_quiz_sessions_choice_count
+        CHECK (choice_count IS NULL OR choice_count IN (4, 5)),
+    CONSTRAINT chk_quiz_sessions_question_count
+        CHECK (question_count BETWEEN 1 AND 100),
+    CONSTRAINT chk_quiz_sessions_play_mode
+        CHECK (play_mode IN ('one_by_one', 'all_at_once')),
+    CONSTRAINT chk_quiz_sessions_timer_scope
+        CHECK (timer_scope IS NULL OR timer_scope IN ('per_question', 'total')),
+    CONSTRAINT chk_quiz_sessions_difficulty
+        CHECK (difficulty IN ('easy', 'medium', 'hard')),
+    CONSTRAINT chk_quiz_sessions_status
+        CHECK (status IN ('pending', 'in_progress', 'completed', 'failed'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='퀴즈 세션 설정값 및 생성 상태';
+
+-- 퀴즈 세션 출제 범위 (세션당 N개 파트)
+CREATE TABLE quiz_session_scopes (
+    id                  BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    quiz_session_id     BIGINT NOT NULL COMMENT '퀴즈 세션 ID',
+    part_id             BIGINT NOT NULL COMMENT '출제 대상 파트 ID',
+    chapter_id          BIGINT NOT NULL COMMENT '소속 챕터 ID (역정규화)',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_quiz_session_scopes_session_part (quiz_session_id, part_id),
+    KEY idx_quiz_session_scopes_quiz_session_id (quiz_session_id),
+    KEY idx_quiz_session_scopes_part_id (part_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='퀴즈 세션 출제 범위 (파트 단위)';

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
@@ -1,0 +1,312 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.dto.QuizCreateRequest;
+import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizSessionCreateServiceTest {
+
+    private SubjectRepository subjectRepository;
+    private PartRepository partRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private QuizSessionScopeRepository quizSessionScopeRepository;
+    private QuizSessionCreateService quizSessionCreateService;
+
+    @BeforeEach
+    void setUp() {
+        subjectRepository = mock(SubjectRepository.class);
+        partRepository = mock(PartRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        quizSessionScopeRepository = mock(QuizSessionScopeRepository.class);
+        quizSessionCreateService = new QuizSessionCreateService(
+                subjectRepository,
+                partRepository,
+                quizSessionRepository,
+                quizSessionScopeRepository
+        );
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void createQuizSession_saves_session_and_scopes_with_default_options() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId);
+        Part part1 = part(100L, "part-public-1", 1000L, subject.getId(), userId);
+        Part part2 = part(101L, "part-public-2", 1001L, subject.getId(), userId);
+        QuizCreateRequest request = request(
+                subject.getPublicId(),
+                List.of(part1.getPublicId(), part2.getPublicId()),
+                "multiple_choice",
+                null,
+                10,
+                "one_by_one",
+                true,
+                "per_question",
+                60,
+                null
+        );
+
+        when(quizSessionRepository.existsByUserIdAndStatusInAndDeletedAtIsNull(eq(userId), any()))
+                .thenReturn(false);
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), userId))
+                .thenReturn(Optional.of(subject));
+        when(partRepository.findAllByPublicIdInAndSubjectIdAndUserIdAndDeletedAtIsNull(
+                request.getPartIds(),
+                subject.getId(),
+                userId
+        )).thenReturn(List.of(part1, part2));
+        when(quizSessionRepository.save(any(QuizSession.class)))
+                .thenAnswer(invocation -> {
+                    QuizSession quizSession = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(quizSession, "id", 500L);
+                    return quizSession;
+                });
+
+        QuizGenerationAcceptedResponse response = quizSessionCreateService.createQuizSession(userId, request);
+
+        ArgumentCaptor<QuizSession> sessionCaptor = ArgumentCaptor.forClass(QuizSession.class);
+        verify(quizSessionRepository).save(sessionCaptor.capture());
+        QuizSession savedSession = sessionCaptor.getValue();
+        assertThat(savedSession.getPublicId()).isNotBlank();
+        assertThat(savedSession.getUserId()).isEqualTo(userId);
+        assertThat(savedSession.getSubjectId()).isEqualTo(subject.getId());
+        assertThat(savedSession.getQuizType()).isEqualTo("multiple_choice");
+        assertThat(savedSession.getChoiceCount()).isEqualTo(4);
+        assertThat(savedSession.getQuestionCount()).isEqualTo(10);
+        assertThat(savedSession.getPlayMode()).isEqualTo("one_by_one");
+        assertThat(savedSession.getTimerEnabled()).isTrue();
+        assertThat(savedSession.getTimerScope()).isEqualTo("per_question");
+        assertThat(savedSession.getTimerSeconds()).isEqualTo(60);
+        assertThat(savedSession.getDifficulty()).isEqualTo("medium");
+        assertThat(savedSession.getStatus()).isEqualTo("pending");
+        assertThat(savedSession.getJobId()).startsWith("quiz-job-");
+
+        ArgumentCaptor<Iterable<QuizSessionScope>> scopeCaptor = ArgumentCaptor.forClass(Iterable.class);
+        verify(quizSessionScopeRepository).saveAll(scopeCaptor.capture());
+        List<QuizSessionScope> scopes = toList(scopeCaptor.getValue());
+        assertThat(scopes).hasSize(2);
+        assertThat(scopes)
+                .extracting(QuizSessionScope::getQuizSessionId)
+                .containsOnly(500L);
+        assertThat(scopes)
+                .extracting(QuizSessionScope::getPartId)
+                .containsExactly(part1.getId(), part2.getId());
+
+        assertThat(response.getQuizSessionId()).isEqualTo(savedSession.getPublicId());
+        assertThat(response.getJobId()).isEqualTo(savedSession.getJobId());
+        assertThat(response.getStatus()).isEqualTo("pending");
+        assertThat(response.getEstimatedSeconds()).isNull();
+    }
+
+    @Test
+    void createQuizSession_throws_conflict_when_generation_already_active() {
+        Long userId = 1L;
+        QuizCreateRequest request = request(
+                "subject-public-id",
+                List.of("part-public-id"),
+                "multiple_choice",
+                4,
+                10,
+                "one_by_one",
+                false,
+                null,
+                null,
+                "medium"
+        );
+        when(quizSessionRepository.existsByUserIdAndStatusInAndDeletedAtIsNull(eq(userId), any()))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> quizSessionCreateService.createQuizSession(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_GENERATION_IN_PROGRESS);
+
+        verifyNoInteractions(subjectRepository, partRepository, quizSessionScopeRepository);
+    }
+
+    @Test
+    void createQuizSession_throws_invalid_option_when_ox_has_choice_count() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId);
+        QuizCreateRequest request = request(
+                subject.getPublicId(),
+                List.of("part-public-id"),
+                "ox",
+                4,
+                10,
+                "one_by_one",
+                false,
+                null,
+                null,
+                "medium"
+        );
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), userId))
+                .thenReturn(Optional.of(subject));
+
+        assertThatThrownBy(() -> quizSessionCreateService.createQuizSession(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_OPTION_INVALID);
+    }
+
+    @Test
+    void createQuizSession_throws_invalid_option_when_timer_scope_mismatched() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId);
+        QuizCreateRequest request = request(
+                subject.getPublicId(),
+                List.of("part-public-id"),
+                "multiple_choice",
+                4,
+                10,
+                "all_at_once",
+                true,
+                "per_question",
+                60,
+                "medium"
+        );
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), userId))
+                .thenReturn(Optional.of(subject));
+
+        assertThatThrownBy(() -> quizSessionCreateService.createQuizSession(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_OPTION_INVALID);
+    }
+
+    @Test
+    void createQuizSession_throws_invalid_scope_when_part_ids_are_duplicated() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId);
+        QuizCreateRequest request = request(
+                subject.getPublicId(),
+                List.of("part-public-id", "part-public-id"),
+                "multiple_choice",
+                4,
+                10,
+                "one_by_one",
+                false,
+                null,
+                null,
+                "medium"
+        );
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), userId))
+                .thenReturn(Optional.of(subject));
+
+        assertThatThrownBy(() -> quizSessionCreateService.createQuizSession(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_SCOPE_INVALID);
+    }
+
+    @Test
+    void createQuizSession_throws_invalid_scope_when_part_is_not_found() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId);
+        QuizCreateRequest request = request(
+                subject.getPublicId(),
+                List.of("part-public-1", "part-public-2"),
+                "multiple_choice",
+                4,
+                10,
+                "one_by_one",
+                false,
+                null,
+                null,
+                "medium"
+        );
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), userId))
+                .thenReturn(Optional.of(subject));
+        when(partRepository.findAllByPublicIdInAndSubjectIdAndUserIdAndDeletedAtIsNull(
+                request.getPartIds(),
+                subject.getId(),
+                userId
+        )).thenReturn(List.of(part(100L, "part-public-1", 1000L, subject.getId(), userId)));
+
+        assertThatThrownBy(() -> quizSessionCreateService.createQuizSession(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_SCOPE_INVALID);
+    }
+
+    private QuizCreateRequest request(
+            String subjectId,
+            List<String> partIds,
+            String quizType,
+            Integer choiceCount,
+            Integer questionCount,
+            String playMode,
+            Boolean timerEnabled,
+            String timerScope,
+            Integer timerSeconds,
+            String difficulty
+    ) {
+        QuizCreateRequest request = org.springframework.beans.BeanUtils.instantiateClass(QuizCreateRequest.class);
+        ReflectionTestUtils.setField(request, "subjectId", subjectId);
+        ReflectionTestUtils.setField(request, "partIds", partIds);
+        ReflectionTestUtils.setField(request, "quizType", quizType);
+        ReflectionTestUtils.setField(request, "choiceCount", choiceCount);
+        ReflectionTestUtils.setField(request, "questionCount", questionCount);
+        ReflectionTestUtils.setField(request, "playMode", playMode);
+        ReflectionTestUtils.setField(request, "timerEnabled", timerEnabled);
+        ReflectionTestUtils.setField(request, "timerScope", timerScope);
+        ReflectionTestUtils.setField(request, "timerSeconds", timerSeconds);
+        ReflectionTestUtils.setField(request, "difficulty", difficulty);
+        return request;
+    }
+
+    private Subject subject(Long id, String publicId, Long userId) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", "데이터베이스");
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private Part part(Long id, String publicId, Long chapterId, Long subjectId, Long userId) {
+        Part part = newEntity(Part.class);
+        ReflectionTestUtils.setField(part, "id", id);
+        ReflectionTestUtils.setField(part, "publicId", publicId);
+        ReflectionTestUtils.setField(part, "chapterId", chapterId);
+        ReflectionTestUtils.setField(part, "subjectId", subjectId);
+        ReflectionTestUtils.setField(part, "userId", userId);
+        ReflectionTestUtils.setField(part, "name", "데이터 모델링");
+        ReflectionTestUtils.setField(part, "partNumber", 1);
+        return part;
+    }
+
+    private List<QuizSessionScope> toList(Iterable<QuizSessionScope> scopes) {
+        return java.util.stream.StreamSupport.stream(scopes.spliterator(), false)
+                .toList();
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
@@ -34,6 +34,7 @@ class QuizSessionCreateServiceTest {
     private PartRepository partRepository;
     private QuizSessionRepository quizSessionRepository;
     private QuizSessionScopeRepository quizSessionScopeRepository;
+    private QuizGenerationLockStore quizGenerationLockStore;
     private QuizSessionCreateService quizSessionCreateService;
 
     @BeforeEach
@@ -42,11 +43,13 @@ class QuizSessionCreateServiceTest {
         partRepository = mock(PartRepository.class);
         quizSessionRepository = mock(QuizSessionRepository.class);
         quizSessionScopeRepository = mock(QuizSessionScopeRepository.class);
+        quizGenerationLockStore = mock(QuizGenerationLockStore.class);
         quizSessionCreateService = new QuizSessionCreateService(
                 subjectRepository,
                 partRepository,
                 quizSessionRepository,
-                quizSessionScopeRepository
+                quizSessionScopeRepository,
+                quizGenerationLockStore
         );
     }
 
@@ -79,6 +82,8 @@ class QuizSessionCreateServiceTest {
                 subject.getId(),
                 userId
         )).thenReturn(List.of(part1, part2));
+        when(partRepository.sumContentLengthByPublicIds(request.getPartIds(), subject.getId(), userId))
+                .thenReturn(1000L);
         when(quizSessionRepository.save(any(QuizSession.class)))
                 .thenAnswer(invocation -> {
                     QuizSession quizSession = invocation.getArgument(0);
@@ -87,6 +92,9 @@ class QuizSessionCreateServiceTest {
                 });
 
         QuizGenerationAcceptedResponse response = quizSessionCreateService.createQuizSession(userId, request);
+
+        verify(quizGenerationLockStore).acquire(userId);
+        verify(quizGenerationLockStore).release(userId);
 
         ArgumentCaptor<QuizSession> sessionCaptor = ArgumentCaptor.forClass(QuizSession.class);
         verify(quizSessionRepository).save(sessionCaptor.capture());
@@ -251,6 +259,136 @@ class QuizSessionCreateServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(ErrorCode.QUIZ_SCOPE_INVALID);
+    }
+
+    @Test
+    void createQuizSession_throws_invalid_option_when_timer_disabled_but_scope_provided() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId);
+        QuizCreateRequest request = request(
+                subject.getPublicId(),
+                List.of("part-public-id"),
+                "multiple_choice",
+                4,
+                10,
+                "one_by_one",
+                false,
+                "per_question",
+                60,
+                "medium"
+        );
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), userId))
+                .thenReturn(Optional.of(subject));
+
+        assertThatThrownBy(() -> quizSessionCreateService.createQuizSession(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_OPTION_INVALID);
+
+        verify(quizGenerationLockStore).release(userId);
+    }
+
+    @Test
+    void createQuizSession_throws_subject_not_found_when_subject_missing() {
+        Long userId = 1L;
+        String subjectPublicId = "subject-public-id";
+        QuizCreateRequest request = request(
+                subjectPublicId,
+                List.of("part-public-id"),
+                "multiple_choice",
+                4,
+                10,
+                "one_by_one",
+                false,
+                null,
+                null,
+                "medium"
+        );
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subjectPublicId, userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizSessionCreateService.createQuizSession(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.SUBJECT_NOT_FOUND);
+
+        verify(quizGenerationLockStore).release(userId);
+    }
+
+    @Test
+    void createQuizSession_throws_text_insufficient_when_content_length_below_quota() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId);
+        Part part1 = part(100L, "part-public-1", 1000L, subject.getId(), userId);
+        QuizCreateRequest request = request(
+                subject.getPublicId(),
+                List.of(part1.getPublicId()),
+                "multiple_choice",
+                4,
+                10,
+                "one_by_one",
+                false,
+                null,
+                null,
+                "medium"
+        );
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), userId))
+                .thenReturn(Optional.of(subject));
+        when(partRepository.findAllByPublicIdInAndSubjectIdAndUserIdAndDeletedAtIsNull(
+                request.getPartIds(),
+                subject.getId(),
+                userId
+        )).thenReturn(List.of(part1));
+        // 50자당 1문제 정책 — 본문 100자라면 최대 2문제만 가능. 요청 10문제는 거절돼야 함
+        when(partRepository.sumContentLengthByPublicIds(request.getPartIds(), subject.getId(), userId))
+                .thenReturn(100L);
+
+        assertThatThrownBy(() -> quizSessionCreateService.createQuizSession(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_SCOPE_TEXT_INSUFFICIENT);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void createQuizSession_defaults_difficulty_to_medium_when_missing() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId);
+        Part part1 = part(100L, "part-public-1", 1000L, subject.getId(), userId);
+        QuizCreateRequest request = request(
+                subject.getPublicId(),
+                List.of(part1.getPublicId()),
+                "ox",
+                null,
+                5,
+                "all_at_once",
+                false,
+                null,
+                null,
+                null
+        );
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), userId))
+                .thenReturn(Optional.of(subject));
+        when(partRepository.findAllByPublicIdInAndSubjectIdAndUserIdAndDeletedAtIsNull(
+                request.getPartIds(),
+                subject.getId(),
+                userId
+        )).thenReturn(List.of(part1));
+        when(partRepository.sumContentLengthByPublicIds(request.getPartIds(), subject.getId(), userId))
+                .thenReturn(1000L);
+        when(quizSessionRepository.save(any(QuizSession.class)))
+                .thenAnswer(invocation -> {
+                    QuizSession quizSession = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(quizSession, "id", 501L);
+                    return quizSession;
+                });
+
+        quizSessionCreateService.createQuizSession(userId, request);
+
+        ArgumentCaptor<QuizSession> sessionCaptor = ArgumentCaptor.forClass(QuizSession.class);
+        verify(quizSessionRepository).save(sessionCaptor.capture());
+        assertThat(sessionCaptor.getValue().getDifficulty()).isEqualTo("medium");
+        assertThat(sessionCaptor.getValue().getChoiceCount()).isNull();
     }
 
     private QuizCreateRequest request(


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 기능명세 QUIZ-OPT-002/004/005/005B/006 기준 퀴즈 생성 요청 API 구현
- 검증된 옵션을 quiz_sessions와 quiz_session_scopes에 저장

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- POST /api/v1/quiz-sessions 구현
- QuizCreateRequest, QuizGenerationAcceptedResponse DTO 추가
- QuizSession 옵션 저장 필드 확장
- QuizSessionScope 엔티티/리포지토리 추가
- 객관식/OX, 문제 수, 풀이 방식, 타이머, 난이도 옵션 검증 추가
- partIds 소유권 및 과목 소속 검증 추가
- 생성 중 퀴즈 중복 요청 차단 추가
- OpenAPI 난이도 기본값 정책 보정

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. ./gradlew test --tests com.f1.quiket.domain.quiz.service.QuizSessionCreateServiceTest
2. ./gradlew test
3. python3 YAML 파싱 확인

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #51

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- AI 실제 생성 및 생성 상태 조회는 후속 이슈에서 처리
- 생성 접수 상태는 pending 기준으로 저장

---

## 🧑‍💻 Assignee

- @imclaremont