### PR TITLE
[Feat] 퀴즈 생성 상태 조회 API 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
@@ -55,11 +55,11 @@ public class QuizSessionController {
     @GetMapping("/{quizSessionId}/generation-status")
     public ResponseEntity<ApiResponse<QuizGenerationStatusResponse>> getGenerationStatus(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable String quizSessionId
+            @PathVariable("quizSessionId") String quizSessionPublicId
     ) {
         QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
                 principal.getUserId(),
-                quizSessionId
+                quizSessionPublicId
         );
 
         return ResponseEntity

--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
@@ -2,6 +2,8 @@ package com.f1.quiket.domain.quiz.controller;
 
 import com.f1.quiket.domain.quiz.dto.QuizCreateRequest;
 import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
+import com.f1.quiket.domain.quiz.dto.QuizGenerationStatusResponse;
+import com.f1.quiket.domain.quiz.service.QuizGenerationStatusService;
 import com.f1.quiket.domain.quiz.service.QuizSessionCreateService;
 import com.f1.quiket.global.auth.UserPrincipal;
 import com.f1.quiket.global.response.ApiResponse;
@@ -11,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class QuizSessionController {
 
     private final QuizSessionCreateService quizSessionCreateService;
+    private final QuizGenerationStatusService quizGenerationStatusService;
 
     /**
      * 퀴즈 생성 요청
@@ -42,5 +47,23 @@ public class QuizSessionController {
         return ResponseEntity
                 .status(HttpStatus.ACCEPTED)
                 .body(ApiResponse.success(SuccessCode.ACCEPTED, response));
+    }
+
+    /**
+     * 퀴즈 생성 상태 조회
+     */
+    @GetMapping("/{quizSessionId}/generation-status")
+    public ResponseEntity<ApiResponse<QuizGenerationStatusResponse>> getGenerationStatus(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String quizSessionId
+    ) {
+        QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
+                principal.getUserId(),
+                quizSessionId
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessCode.OK, response));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationStatusResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationStatusResponse.java
@@ -1,0 +1,48 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 생성 상태 응답 DTO
+ */
+@Getter
+@Builder
+public class QuizGenerationStatusResponse {
+
+    private static final String STATUS_PENDING = "pending";
+    private static final String STATUS_IN_PROGRESS = "in_progress";
+    private static final String STATUS_COMPLETED = "completed";
+    private static final String STATUS_FAILED = "failed";
+
+    private final String quizSessionId;
+    private final String jobId;
+    private final String status;
+    private final Integer estimatedSeconds;
+    private final Integer progressPct;
+    private final Integer generatedCount;
+    private final String failReason;
+
+    public static QuizGenerationStatusResponse from(QuizSession quizSession) {
+        // TODO: AI 생성 도입 후 estimatedSeconds 산출
+        return QuizGenerationStatusResponse.builder()
+                .quizSessionId(quizSession.getPublicId())
+                .jobId(quizSession.getJobId())
+                .status(quizSession.getStatus())
+                .estimatedSeconds(null)
+                .progressPct(resolveProgressPct(quizSession.getStatus()))
+                .generatedCount(quizSession.getGeneratedCount())
+                .failReason(quizSession.getFailReason())
+                .build();
+    }
+
+    private static Integer resolveProgressPct(String status) {
+        return switch (status) {
+            case STATUS_PENDING -> 0;
+            case STATUS_IN_PROGRESS -> 50;
+            case STATUS_COMPLETED, STATUS_FAILED -> 100;
+            default -> 0;
+        };
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationStatusResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationStatusResponse.java
@@ -37,6 +37,7 @@ public class QuizGenerationStatusResponse {
                 .build();
     }
 
+    // TODO: progressPct — AI 생성 도입 후 quiz_generation_jobs.progress_pct 실제 진행률 사용. 현재는 상태별 placeholder
     private static Integer resolveProgressPct(String status) {
         return switch (status) {
             case STATUS_PENDING -> 0;

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
@@ -3,6 +3,7 @@ package com.f1.quiket.domain.quiz.repository;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -21,4 +22,9 @@ public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> 
      * 사용자 생성 중 퀴즈 존재 여부
      */
     boolean existsByUserIdAndStatusInAndDeletedAtIsNull(Long userId, Collection<String> statuses);
+
+    /**
+     * 사용자 퀴즈 세션 단건 조회
+     */
+    Optional<QuizSession> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusService.java
@@ -22,8 +22,9 @@ public class QuizGenerationStatusService {
     /**
      * 퀴즈 생성 상태 조회
      */
-    public QuizGenerationStatusResponse getGenerationStatus(Long userId, String quizSessionId) {
-        QuizSession quizSession = quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionId, userId)
+    public QuizGenerationStatusResponse getGenerationStatus(Long userId, String quizSessionPublicId) {
+        QuizSession quizSession = quizSessionRepository
+                .findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionPublicId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
 
         return QuizGenerationStatusResponse.from(quizSession);

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusService.java
@@ -1,0 +1,31 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizGenerationStatusResponse;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 퀴즈 생성 상태 조회 비즈니스 로직
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizGenerationStatusService {
+
+    private final QuizSessionRepository quizSessionRepository;
+
+    /**
+     * 퀴즈 생성 상태 조회
+     */
+    public QuizGenerationStatusResponse getGenerationStatus(Long userId, String quizSessionId) {
+        QuizSession quizSession = quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+
+        return QuizGenerationStatusResponse.from(quizSession);
+    }
+}

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -54,6 +54,7 @@ public enum ErrorCode {
     QUIZ_SCOPE_INVALID(400, "QUIZ_SCOPE_INVALID", "출제 범위가 올바르지 않습니다."),
     QUIZ_SCOPE_TEXT_INSUFFICIENT(422, "QUIZ_SCOPE_TEXT_INSUFFICIENT", "출제 범위의 텍스트가 부족하여 요청한 문제 수를 만들 수 없습니다."),
     QUIZ_GENERATION_IN_PROGRESS(409, "QUIZ_GENERATION_IN_PROGRESS", "이미 생성 중인 퀴즈가 있습니다."),
+    QUIZ_SESSION_NOT_FOUND(404, "QUIZ_SESSION_NOT_FOUND", "퀴즈 세션을 찾을 수 없습니다."),
 
     // 5xx Server Errors
     INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다."),

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusServiceTest.java
@@ -1,0 +1,116 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.dto.QuizGenerationStatusResponse;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizGenerationStatusServiceTest {
+
+    private QuizSessionRepository quizSessionRepository;
+    private QuizGenerationStatusService quizGenerationStatusService;
+
+    @BeforeEach
+    void setUp() {
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        quizGenerationStatusService = new QuizGenerationStatusService(quizSessionRepository);
+    }
+
+    @Test
+    void getGenerationStatus_returns_pending_status() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "pending", "quiz-job-1", null, null);
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+
+        QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
+                userId,
+                quizSession.getPublicId()
+        );
+
+        assertThat(response.getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        assertThat(response.getJobId()).isEqualTo("quiz-job-1");
+        assertThat(response.getStatus()).isEqualTo("pending");
+        assertThat(response.getEstimatedSeconds()).isNull();
+        assertThat(response.getProgressPct()).isZero();
+        assertThat(response.getGeneratedCount()).isNull();
+        assertThat(response.getFailReason()).isNull();
+    }
+
+    @Test
+    void getGenerationStatus_returns_completed_status() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "completed", "quiz-job-1", 8, null);
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+
+        QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
+                userId,
+                quizSession.getPublicId()
+        );
+
+        assertThat(response.getStatus()).isEqualTo("completed");
+        assertThat(response.getProgressPct()).isEqualTo(100);
+        assertThat(response.getGeneratedCount()).isEqualTo(8);
+        assertThat(response.getFailReason()).isNull();
+    }
+
+    @Test
+    void getGenerationStatus_returns_failed_status() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "failed", "quiz-job-1", null, "텍스트 길이 부족");
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+
+        QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
+                userId,
+                quizSession.getPublicId()
+        );
+
+        assertThat(response.getStatus()).isEqualTo("failed");
+        assertThat(response.getProgressPct()).isEqualTo(100);
+        assertThat(response.getGeneratedCount()).isNull();
+        assertThat(response.getFailReason()).isEqualTo("텍스트 길이 부족");
+    }
+
+    @Test
+    void getGenerationStatus_throws_not_found_when_quiz_session_missing() {
+        Long userId = 1L;
+        String quizSessionId = "quiz-session-public-id";
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionId, userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizGenerationStatusService.getGenerationStatus(userId, quizSessionId))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_SESSION_NOT_FOUND);
+    }
+
+    private QuizSession quizSession(
+            String publicId,
+            Long userId,
+            String status,
+            String jobId,
+            Integer generatedCount,
+            String failReason
+    ) {
+        QuizSession quizSession = org.springframework.beans.BeanUtils.instantiateClass(QuizSession.class);
+        ReflectionTestUtils.setField(quizSession, "publicId", publicId);
+        ReflectionTestUtils.setField(quizSession, "userId", userId);
+        ReflectionTestUtils.setField(quizSession, "status", status);
+        ReflectionTestUtils.setField(quizSession, "jobId", jobId);
+        ReflectionTestUtils.setField(quizSession, "generatedCount", generatedCount);
+        ReflectionTestUtils.setField(quizSession, "failReason", failReason);
+        return quizSession;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusServiceTest.java
@@ -48,6 +48,24 @@ class QuizGenerationStatusServiceTest {
     }
 
     @Test
+    void getGenerationStatus_returns_in_progress_status() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "in_progress", "quiz-job-1", null, null);
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+
+        QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
+                userId,
+                quizSession.getPublicId()
+        );
+
+        assertThat(response.getStatus()).isEqualTo("in_progress");
+        assertThat(response.getProgressPct()).isEqualTo(50);
+        assertThat(response.getGeneratedCount()).isNull();
+        assertThat(response.getFailReason()).isNull();
+    }
+
+    @Test
     void getGenerationStatus_returns_completed_status() {
         Long userId = 1L;
         QuizSession quizSession = quizSession("quiz-session-public-id", userId, "completed", "quiz-job-1", 8, null);


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 기능명세 QUIZ-GEN-001 기준 퀴즈 생성 상태 조회 API 구현
- `quiz_sessions` 생성 상태 기준 응답 제공

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `GET /api/v1/quiz-sessions/{quizSessionId}/generation-status` 구현
- 퀴즈 생성 상태 응답 DTO 추가
- 퀴즈 세션 publicId + 사용자 소유권 조회 추가
- 상태별 `progressPct` 기본 매핑 추가
- 생성 상태 조회 서비스 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.domain.quiz.service.QuizGenerationStatusServiceTest`
2. `./gradlew test`
3. `git diff --check`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #53

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- AI 실제 생성 및 상태 갱신 로직은 후속 이슈에서 연결 예정
- 현재 `progressPct`는 `pending=0`, `in_progress=50`, `completed/failed=100` 기본 매핑

---

## 🧑‍💻 Assignee

- @imclaremont