### PR TITLE
[Feat] 퀴즈 세트 조회 API 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.chapter.repository;
 
 import com.f1.quiket.domain.chapter.entity.Chapter;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -23,4 +24,9 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
             Long subjectId,
             Long userId
     );
+
+    /**
+     * 사용자 챕터 목록 조회 (PK 컬렉션 기반)
+     */
+    List<Chapter> findAllByIdInAndUserIdAndDeletedAtIsNull(Collection<Long> ids, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
@@ -52,4 +52,9 @@ public interface PartRepository extends JpaRepository<Part, Long> {
             @Param("subjectId") Long subjectId,
             @Param("userId") Long userId
     );
+
+    /**
+     * 사용자 파트 목록 조회 (PK 컬렉션 기반)
+     */
+    List<Part> findAllByIdInAndUserIdAndDeletedAtIsNull(Collection<Long> ids, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
@@ -3,8 +3,10 @@ package com.f1.quiket.domain.quiz.controller;
 import com.f1.quiket.domain.quiz.dto.QuizCreateRequest;
 import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
 import com.f1.quiket.domain.quiz.dto.QuizGenerationStatusResponse;
+import com.f1.quiket.domain.quiz.dto.QuizSessionResponse;
 import com.f1.quiket.domain.quiz.service.QuizGenerationStatusService;
 import com.f1.quiket.domain.quiz.service.QuizSessionCreateService;
+import com.f1.quiket.domain.quiz.service.QuizSessionQueryService;
 import com.f1.quiket.global.auth.UserPrincipal;
 import com.f1.quiket.global.response.ApiResponse;
 import com.f1.quiket.global.response.SuccessCode;
@@ -30,6 +32,7 @@ public class QuizSessionController {
 
     private final QuizSessionCreateService quizSessionCreateService;
     private final QuizGenerationStatusService quizGenerationStatusService;
+    private final QuizSessionQueryService quizSessionQueryService;
 
     /**
      * 퀴즈 생성 요청
@@ -58,6 +61,24 @@ public class QuizSessionController {
             @PathVariable("quizSessionId") String quizSessionPublicId
     ) {
         QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
+                principal.getUserId(),
+                quizSessionPublicId
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 퀴즈 세트 조회
+     */
+    @GetMapping("/{quizSessionId}")
+    public ResponseEntity<ApiResponse<QuizSessionResponse>> getQuizSession(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("quizSessionId") String quizSessionPublicId
+    ) {
+        QuizSessionResponse response = quizSessionQueryService.getQuizSession(
                 principal.getUserId(),
                 quizSessionPublicId
         );

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuestionAnswerResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuestionAnswerResponse.java
@@ -1,0 +1,21 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 문항 정답 응답 DTO
+ */
+@Getter
+@Builder
+public class QuestionAnswerResponse {
+
+    private final String answerValue;
+
+    public static QuestionAnswerResponse from(QuestionAnswer answer) {
+        return QuestionAnswerResponse.builder()
+                .answerValue(answer.getAnswerValue())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuestionOptionResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuestionOptionResponse.java
@@ -1,0 +1,25 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 문항 선택지 응답 DTO
+ */
+@Getter
+@Builder
+public class QuestionOptionResponse {
+
+    private final String id;
+    private final Integer optionNumber;
+    private final String content;
+
+    public static QuestionOptionResponse from(QuestionOption option) {
+        return QuestionOptionResponse.builder()
+                .id(String.valueOf(option.getId()))
+                .optionNumber(option.getOptionNumber())
+                .content(option.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizQuestionResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizQuestionResponse.java
@@ -1,0 +1,61 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 문항 응답 DTO
+ */
+@Getter
+@Builder
+public class QuizQuestionResponse {
+
+    private final String id;
+    private final String subjectId;
+    private final String chapterId;
+    private final String partId;
+    private final String partName;
+    private final String questionType;
+    private final String difficulty;
+    private final String summary;
+    private final String body;
+    private final String correctExplanation;
+    private final String incorrectExplanation;
+    private final Integer displayOrder;
+    private final List<QuestionOptionResponse> options;
+    private final QuestionAnswerResponse answer;
+
+    public static QuizQuestionResponse of(
+            Question question,
+            String subjectPublicId,
+            Chapter chapter,
+            Part part,
+            List<QuestionOption> options,
+            QuestionAnswer answer
+    ) {
+        return QuizQuestionResponse.builder()
+                .id(question.getPublicId())
+                .subjectId(subjectPublicId)
+                .chapterId(chapter.getPublicId())
+                .partId(part.getPublicId())
+                .partName(part.getName())
+                .questionType(question.getQuestionType())
+                .difficulty(question.getDifficulty())
+                .summary(question.getSummary())
+                .body(question.getBody())
+                .correctExplanation(question.getCorrectExplanation())
+                .incorrectExplanation(question.getIncorrectExplanation())
+                .displayOrder(question.getDisplayOrder())
+                .options(options.stream()
+                        .map(QuestionOptionResponse::from)
+                        .toList())
+                .answer(QuestionAnswerResponse.from(answer))
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizSessionResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizSessionResponse.java
@@ -1,0 +1,70 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.subject.entity.Subject;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 세트 응답 DTO
+ */
+@Getter
+@Builder
+public class QuizSessionResponse {
+
+    private final String id;
+    private final String subjectId;
+    private final String subjectName;
+    private final String quizType;
+    private final Integer choiceCount;
+    private final Integer questionCount;
+    private final String playMode;
+    private final Boolean timerEnabled;
+    private final String timerScope;
+    private final Integer timerSeconds;
+    private final String difficulty;
+    private final String status;
+    private final List<QuizQuestionResponse> questions;
+
+    public static QuizSessionResponse of(
+            QuizSession quizSession,
+            Subject subject,
+            List<Question> questions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId,
+            Map<Long, Chapter> chaptersById,
+            Map<Long, Part> partsById
+    ) {
+        return QuizSessionResponse.builder()
+                .id(quizSession.getPublicId())
+                .subjectId(subject.getPublicId())
+                .subjectName(subject.getName())
+                .quizType(quizSession.getQuizType())
+                .choiceCount(quizSession.getChoiceCount())
+                .questionCount(quizSession.getQuestionCount())
+                .playMode(quizSession.getPlayMode())
+                .timerEnabled(quizSession.getTimerEnabled())
+                .timerScope(quizSession.getTimerScope())
+                .timerSeconds(quizSession.getTimerSeconds())
+                .difficulty(quizSession.getDifficulty())
+                .status(quizSession.getStatus())
+                .questions(questions.stream()
+                        .map(question -> QuizQuestionResponse.of(
+                                question,
+                                subject.getPublicId(),
+                                chaptersById.get(question.getChapterId()),
+                                partsById.get(question.getPartId()),
+                                optionsByQuestionId.getOrDefault(question.getId(), List.of()),
+                                answersByQuestionId.get(question.getId())
+                        ))
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/Question.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/Question.java
@@ -1,0 +1,82 @@
+package com.f1.quiket.domain.quiz.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 퀴즈 문항 엔티티
+ */
+@Entity
+@Table(
+        name = "questions",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_questions_public_id", columnNames = "public_id")
+        },
+        indexes = {
+                @Index(name = "idx_questions_quiz_session_id_order", columnList = "quiz_session_id, display_order"),
+                @Index(name = "idx_questions_part_id", columnList = "part_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Question {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "public_id", length = 36, nullable = false)
+    String publicId;
+
+    @Column(name = "quiz_session_id", nullable = false)
+    Long quizSessionId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "chapter_id", nullable = false)
+    Long chapterId;
+
+    @Column(name = "part_id", nullable = false)
+    Long partId;
+
+    @Column(name = "question_type", length = 20, nullable = false)
+    String questionType;
+
+    @Column(name = "difficulty", length = 10, nullable = false)
+    String difficulty;
+
+    @Lob
+    @Column(name = "body", nullable = false)
+    String body;
+
+    @Column(name = "summary", length = 20)
+    String summary;
+
+    @Lob
+    @Column(name = "correct_explanation")
+    String correctExplanation;
+
+    @Lob
+    @Column(name = "incorrect_explanation")
+    String incorrectExplanation;
+
+    @Column(name = "display_order", nullable = false)
+    Integer displayOrder;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionAnswer.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionAnswer.java
@@ -1,0 +1,40 @@
+package com.f1.quiket.domain.quiz.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 퀴즈 문항 정답 엔티티
+ */
+@Entity
+@Table(
+        name = "question_answers",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_question_answers_question_id", columnNames = "question_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuestionAnswer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "question_id", nullable = false)
+    Long questionId;
+
+    @Column(name = "answer_value", length = 10, nullable = false)
+    String answerValue;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionOption.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionOption.java
@@ -1,0 +1,52 @@
+package com.f1.quiket.domain.quiz.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 퀴즈 문항 선택지 엔티티
+ */
+@Entity
+@Table(
+        name = "question_options",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_question_options_question_option", columnNames = {"question_id", "option_number"})
+        },
+        indexes = {
+                @Index(name = "idx_question_options_question_id", columnList = "question_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuestionOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "question_id", nullable = false)
+    Long questionId;
+
+    @Column(name = "option_number", nullable = false)
+    Integer optionNumber;
+
+    @Lob
+    @Column(name = "content", nullable = false)
+    String content;
+
+    @Column(name = "is_correct", nullable = false)
+    Boolean correct;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuestionAnswerRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuestionAnswerRepository.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.quiz.repository;
+
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 퀴즈 문항 정답 조회 리포지토리
+ */
+@Repository
+public interface QuestionAnswerRepository extends JpaRepository<QuestionAnswer, Long> {
+
+    /**
+     * 문항 정답 목록 조회
+     */
+    List<QuestionAnswer> findAllByQuestionIdIn(Collection<Long> questionIds);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuestionOptionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuestionOptionRepository.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.quiz.repository;
+
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 퀴즈 문항 선택지 조회 리포지토리
+ */
+@Repository
+public interface QuestionOptionRepository extends JpaRepository<QuestionOption, Long> {
+
+    /**
+     * 문항 선택지 목록 조회
+     */
+    List<QuestionOption> findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(Collection<Long> questionIds);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuestionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuestionRepository.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.quiz.repository;
+
+import com.f1.quiket.domain.quiz.entity.Question;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 퀴즈 문항 조회 리포지토리
+ */
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+
+    /**
+     * 퀴즈 세션 문항 목록 조회
+     */
+    List<Question> findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(Long quizSessionId, Long userId);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionQueryService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionQueryService.java
@@ -1,0 +1,149 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.dto.QuizSessionResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 퀴즈 세트 조회 비즈니스 로직
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizSessionQueryService {
+
+    private static final String STATUS_COMPLETED = "completed";
+
+    private final QuizSessionRepository quizSessionRepository;
+    private final SubjectRepository subjectRepository;
+    private final QuestionRepository questionRepository;
+    private final QuestionOptionRepository questionOptionRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
+    private final ChapterRepository chapterRepository;
+    private final PartRepository partRepository;
+
+    /**
+     * 퀴즈 세트 조회
+     */
+    public QuizSessionResponse getQuizSession(Long userId, String quizSessionPublicId) {
+        QuizSession quizSession = quizSessionRepository
+                .findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        validateCompleted(quizSession);
+
+        Subject subject = subjectRepository.findById(quizSession.getSubjectId())
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+        List<Question> questions = questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(
+                quizSession.getId(),
+                userId
+        );
+        List<Long> questionIds = questions.stream()
+                .map(Question::getId)
+                .toList();
+        Map<Long, List<QuestionOption>> optionsByQuestionId = getOptionsByQuestionId(questionIds);
+        Map<Long, QuestionAnswer> answersByQuestionId = getAnswersByQuestionId(questionIds);
+        Map<Long, Chapter> chaptersById = getChaptersById(questions);
+        Map<Long, Part> partsById = getPartsById(questions);
+        validateQuestionDetails(questions, answersByQuestionId, chaptersById, partsById);
+
+        return QuizSessionResponse.of(
+                quizSession,
+                subject,
+                questions,
+                optionsByQuestionId,
+                answersByQuestionId,
+                chaptersById,
+                partsById
+        );
+    }
+
+    private void validateCompleted(QuizSession quizSession) {
+        if (!STATUS_COMPLETED.equals(quizSession.getStatus())) {
+            throw new CustomException(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+        }
+    }
+
+    private Map<Long, List<QuestionOption>> getOptionsByQuestionId(List<Long> questionIds) {
+        if (questionIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(questionIds)
+                .stream()
+                .collect(Collectors.groupingBy(QuestionOption::getQuestionId));
+    }
+
+    private Map<Long, QuestionAnswer> getAnswersByQuestionId(List<Long> questionIds) {
+        if (questionIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return questionAnswerRepository.findAllByQuestionIdIn(questionIds)
+                .stream()
+                .collect(Collectors.toMap(QuestionAnswer::getQuestionId, Function.identity()));
+    }
+
+    private Map<Long, Chapter> getChaptersById(List<Question> questions) {
+        List<Long> chapterIds = questions.stream()
+                .map(Question::getChapterId)
+                .distinct()
+                .toList();
+        if (chapterIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return chapterRepository.findAllById(chapterIds)
+                .stream()
+                .collect(Collectors.toMap(Chapter::getId, Function.identity()));
+    }
+
+    private Map<Long, Part> getPartsById(List<Question> questions) {
+        List<Long> partIds = questions.stream()
+                .map(Question::getPartId)
+                .distinct()
+                .toList();
+        if (partIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return partRepository.findAllById(partIds)
+                .stream()
+                .collect(Collectors.toMap(Part::getId, Function.identity()));
+    }
+
+    private void validateQuestionDetails(
+            List<Question> questions,
+            Map<Long, QuestionAnswer> answersByQuestionId,
+            Map<Long, Chapter> chaptersById,
+            Map<Long, Part> partsById
+    ) {
+        boolean invalid = questions.stream()
+                .anyMatch(question -> !answersByQuestionId.containsKey(question.getId())
+                        || !chaptersById.containsKey(question.getChapterId())
+                        || !partsById.containsKey(question.getPartId()));
+        if (invalid) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 문항 정보가 올바르지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionQueryService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionQueryService.java
@@ -52,19 +52,21 @@ public class QuizSessionQueryService {
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
         validateCompleted(quizSession);
 
-        Subject subject = subjectRepository.findById(quizSession.getSubjectId())
+        Subject subject = subjectRepository
+                .findByIdAndUserIdAndDeletedAtIsNull(quizSession.getSubjectId(), userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
         List<Question> questions = questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(
                 quizSession.getId(),
                 userId
         );
+        validateQuestionsNotEmpty(questions);
         List<Long> questionIds = questions.stream()
                 .map(Question::getId)
                 .toList();
         Map<Long, List<QuestionOption>> optionsByQuestionId = getOptionsByQuestionId(questionIds);
         Map<Long, QuestionAnswer> answersByQuestionId = getAnswersByQuestionId(questionIds);
-        Map<Long, Chapter> chaptersById = getChaptersById(questions);
-        Map<Long, Part> partsById = getPartsById(questions);
+        Map<Long, Chapter> chaptersById = getChaptersById(userId, questions);
+        Map<Long, Part> partsById = getPartsById(userId, questions);
         validateQuestionDetails(questions, answersByQuestionId, chaptersById, partsById);
 
         return QuizSessionResponse.of(
@@ -81,6 +83,12 @@ public class QuizSessionQueryService {
     private void validateCompleted(QuizSession quizSession) {
         if (!STATUS_COMPLETED.equals(quizSession.getStatus())) {
             throw new CustomException(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+        }
+    }
+
+    private void validateQuestionsNotEmpty(List<Question> questions) {
+        if (questions.isEmpty()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "완료된 퀴즈 세션에 문항이 존재하지 않습니다.");
         }
     }
 
@@ -104,7 +112,7 @@ public class QuizSessionQueryService {
                 .collect(Collectors.toMap(QuestionAnswer::getQuestionId, Function.identity()));
     }
 
-    private Map<Long, Chapter> getChaptersById(List<Question> questions) {
+    private Map<Long, Chapter> getChaptersById(Long userId, List<Question> questions) {
         List<Long> chapterIds = questions.stream()
                 .map(Question::getChapterId)
                 .distinct()
@@ -113,12 +121,12 @@ public class QuizSessionQueryService {
             return Map.of();
         }
 
-        return chapterRepository.findAllById(chapterIds)
+        return chapterRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(chapterIds, userId)
                 .stream()
                 .collect(Collectors.toMap(Chapter::getId, Function.identity()));
     }
 
-    private Map<Long, Part> getPartsById(List<Question> questions) {
+    private Map<Long, Part> getPartsById(Long userId, List<Question> questions) {
         List<Long> partIds = questions.stream()
                 .map(Question::getPartId)
                 .distinct()
@@ -127,7 +135,7 @@ public class QuizSessionQueryService {
             return Map.of();
         }
 
-        return partRepository.findAllById(partIds)
+        return partRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(partIds, userId)
                 .stream()
                 .collect(Collectors.toMap(Part::getId, Function.identity()));
     }

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
@@ -21,4 +21,9 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
      * 사용자 과목 단건 조회
      */
     Optional<Subject> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
+
+    /**
+     * 사용자 과목 단건 조회 (PK 기반)
+     */
+    Optional<Subject> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
 }

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -55,6 +55,7 @@ public enum ErrorCode {
     QUIZ_SCOPE_TEXT_INSUFFICIENT(422, "QUIZ_SCOPE_TEXT_INSUFFICIENT", "출제 범위의 텍스트가 부족하여 요청한 문제 수를 만들 수 없습니다."),
     QUIZ_GENERATION_IN_PROGRESS(409, "QUIZ_GENERATION_IN_PROGRESS", "이미 생성 중인 퀴즈가 있습니다."),
     QUIZ_SESSION_NOT_FOUND(404, "QUIZ_SESSION_NOT_FOUND", "퀴즈 세션을 찾을 수 없습니다."),
+    QUIZ_SESSION_NOT_COMPLETED(409, "QUIZ_SESSION_NOT_COMPLETED", "아직 생성 완료 전인 퀴즈입니다."),
 
     // 5xx Server Errors
     INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다."),

--- a/src/main/resources/db/migration/V6__create_question_schema.sql
+++ b/src/main/resources/db/migration/V6__create_question_schema.sql
@@ -1,0 +1,58 @@
+-- 퀴즈 문항
+CREATE TABLE questions (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK: 문항 식별자',
+    public_id CHAR(36) NOT NULL COMMENT '외부 노출용 UUID v7',
+    quiz_session_id BIGINT NOT NULL COMMENT '소속 퀴즈 세션 ID',
+    user_id BIGINT NOT NULL COMMENT '소유 사용자 ID',
+    subject_id BIGINT NOT NULL COMMENT '출제 과목 ID',
+    chapter_id BIGINT NOT NULL COMMENT '출제 챕터 ID',
+    part_id BIGINT NOT NULL COMMENT '출제 파트 ID',
+    question_type VARCHAR(20) NOT NULL COMMENT '문항 유형',
+    difficulty VARCHAR(10) NOT NULL COMMENT '문항 난이도',
+    body TEXT NOT NULL COMMENT '문항 본문',
+    summary VARCHAR(20) NULL COMMENT 'AI 생성 문항 한줄 요약',
+    correct_explanation TEXT NULL COMMENT '정답해설',
+    incorrect_explanation TEXT NULL COMMENT '오답해설',
+    display_order TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '세션 내 문항 순서',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_questions_public_id (public_id),
+    KEY idx_questions_quiz_session_id_order (quiz_session_id, display_order),
+    KEY idx_questions_part_id (part_id),
+    KEY idx_questions_user_id_created_at (user_id, created_at),
+
+    CONSTRAINT chk_questions_question_type
+        CHECK (question_type IN ('multiple_choice', 'ox')),
+    CONSTRAINT chk_questions_difficulty
+        CHECK (difficulty IN ('easy', 'medium', 'hard')),
+    CONSTRAINT chk_questions_summary
+        CHECK (summary IS NULL OR CHAR_LENGTH(summary) BETWEEN 8 AND 20)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='AI 생성 퀴즈 문항';
+
+-- 퀴즈 문항 선택지
+CREATE TABLE question_options (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    question_id BIGINT NOT NULL COMMENT '문항 ID',
+    option_number TINYINT UNSIGNED NOT NULL COMMENT '보기 번호',
+    content TEXT NOT NULL COMMENT '선택지 내용',
+    is_correct TINYINT(1) NOT NULL DEFAULT 0 COMMENT '정답 여부',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_question_options_question_option (question_id, option_number),
+    KEY idx_question_options_question_id (question_id),
+
+    CONSTRAINT chk_question_options_is_correct
+        CHECK (is_correct IN (0, 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='객관식 문항 선택지';
+
+-- 퀴즈 문항 정답
+CREATE TABLE question_answers (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    question_id BIGINT NOT NULL COMMENT '문항 ID',
+    answer_value VARCHAR(10) NOT NULL COMMENT '정답값',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_question_answers_question_id (question_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='문항 정답 키';

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionQueryServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionQueryServiceTest.java
@@ -1,0 +1,295 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.dto.QuizSessionResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizSessionQueryServiceTest {
+
+    private QuizSessionRepository quizSessionRepository;
+    private SubjectRepository subjectRepository;
+    private QuestionRepository questionRepository;
+    private QuestionOptionRepository questionOptionRepository;
+    private QuestionAnswerRepository questionAnswerRepository;
+    private ChapterRepository chapterRepository;
+    private PartRepository partRepository;
+    private QuizSessionQueryService quizSessionQueryService;
+
+    @BeforeEach
+    void setUp() {
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        questionRepository = mock(QuestionRepository.class);
+        questionOptionRepository = mock(QuestionOptionRepository.class);
+        questionAnswerRepository = mock(QuestionAnswerRepository.class);
+        chapterRepository = mock(ChapterRepository.class);
+        partRepository = mock(PartRepository.class);
+        quizSessionQueryService = new QuizSessionQueryService(
+                quizSessionRepository,
+                subjectRepository,
+                questionRepository,
+                questionOptionRepository,
+                questionAnswerRepository,
+                chapterRepository,
+                partRepository
+        );
+    }
+
+    @Test
+    void getQuizSession_returns_completed_quiz_set() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        Chapter chapter = chapter(100L, "chapter-public-id", subject.getId(), userId, "1장 데이터 모델링", 1);
+        Part part = part(1000L, "part-public-id", chapter.getId(), subject.getId(), userId, "데이터 모델링 개념");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        Question question = question(
+                900L,
+                "question-public-id",
+                quizSession.getId(),
+                userId,
+                subject.getId(),
+                chapter.getId(),
+                part.getId(),
+                1
+        );
+        QuestionOption option1 = option(10000L, question.getId(), 1, "추상화", true);
+        QuestionOption option2 = option(10001L, question.getId(), 2, "정규화", false);
+        QuestionAnswer answer = answer(20000L, question.getId(), "1");
+
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findById(subject.getId()))
+                .thenReturn(Optional.of(subject));
+        when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(quizSession.getId(), userId))
+                .thenReturn(List.of(question));
+        when(questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(List.of(question.getId())))
+                .thenReturn(List.of(option1, option2));
+        when(questionAnswerRepository.findAllByQuestionIdIn(List.of(question.getId())))
+                .thenReturn(List.of(answer));
+        when(chapterRepository.findAllById(List.of(chapter.getId())))
+                .thenReturn(List.of(chapter));
+        when(partRepository.findAllById(List.of(part.getId())))
+                .thenReturn(List.of(part));
+
+        QuizSessionResponse response = quizSessionQueryService.getQuizSession(userId, quizSession.getPublicId());
+
+        assertThat(response.getId()).isEqualTo(quizSession.getPublicId());
+        assertThat(response.getSubjectId()).isEqualTo(subject.getPublicId());
+        assertThat(response.getSubjectName()).isEqualTo("데이터베이스");
+        assertThat(response.getQuizType()).isEqualTo("multiple_choice");
+        assertThat(response.getChoiceCount()).isEqualTo(4);
+        assertThat(response.getQuestionCount()).isEqualTo(1);
+        assertThat(response.getPlayMode()).isEqualTo("one_by_one");
+        assertThat(response.getTimerEnabled()).isTrue();
+        assertThat(response.getTimerScope()).isEqualTo("per_question");
+        assertThat(response.getTimerSeconds()).isEqualTo(60);
+        assertThat(response.getDifficulty()).isEqualTo("medium");
+        assertThat(response.getStatus()).isEqualTo("completed");
+        assertThat(response.getQuestions()).hasSize(1);
+        assertThat(response.getQuestions().get(0).getId()).isEqualTo(question.getPublicId());
+        assertThat(response.getQuestions().get(0).getChapterId()).isEqualTo(chapter.getPublicId());
+        assertThat(response.getQuestions().get(0).getPartId()).isEqualTo(part.getPublicId());
+        assertThat(response.getQuestions().get(0).getPartName()).isEqualTo(part.getName());
+        assertThat(response.getQuestions().get(0).getOptions()).hasSize(2);
+        assertThat(response.getQuestions().get(0).getOptions().get(0).getId()).isEqualTo(String.valueOf(option1.getId()));
+        assertThat(response.getQuestions().get(0).getOptions().get(0).getOptionNumber()).isEqualTo(1);
+        assertThat(response.getQuestions().get(0).getAnswer().getAnswerValue()).isEqualTo("1");
+    }
+
+    @Test
+    void getQuizSession_throws_not_completed_when_generation_pending() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "pending");
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+
+        assertThatThrownBy(() -> quizSessionQueryService.getQuizSession(userId, quizSession.getPublicId()))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+
+        verifyNoInteractions(subjectRepository, questionRepository, questionOptionRepository, questionAnswerRepository);
+    }
+
+    @Test
+    void getQuizSession_throws_not_found_when_quiz_session_missing() {
+        Long userId = 1L;
+        String quizSessionId = "quiz-session-public-id";
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionId, userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizSessionQueryService.getQuizSession(userId, quizSessionId))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_SESSION_NOT_FOUND);
+
+        verifyNoInteractions(subjectRepository, questionRepository, questionOptionRepository, questionAnswerRepository);
+    }
+
+    @Test
+    void getQuizSession_throws_internal_error_when_answer_missing() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        Chapter chapter = chapter(100L, "chapter-public-id", subject.getId(), userId, "1장 데이터 모델링", 1);
+        Part part = part(1000L, "part-public-id", chapter.getId(), subject.getId(), userId, "데이터 모델링 개념");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        Question question = question(
+                900L,
+                "question-public-id",
+                quizSession.getId(),
+                userId,
+                subject.getId(),
+                chapter.getId(),
+                part.getId(),
+                1
+        );
+
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findById(subject.getId()))
+                .thenReturn(Optional.of(subject));
+        when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(quizSession.getId(), userId))
+                .thenReturn(List.of(question));
+        when(questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(List.of(question.getId())))
+                .thenReturn(List.of());
+        when(questionAnswerRepository.findAllByQuestionIdIn(List.of(question.getId())))
+                .thenReturn(List.of());
+        when(chapterRepository.findAllById(List.of(chapter.getId())))
+                .thenReturn(List.of(chapter));
+        when(partRepository.findAllById(List.of(part.getId())))
+                .thenReturn(List.of(part));
+
+        assertThatThrownBy(() -> quizSessionQueryService.getQuizSession(userId, quizSession.getPublicId()))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId, String status) {
+        QuizSession quizSession = QuizSession.create(
+                publicId,
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                1,
+                "one_by_one",
+                true,
+                "per_question",
+                60,
+                "medium",
+                status,
+                "quiz-job-1"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private Question question(
+            Long id,
+            String publicId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            Long chapterId,
+            Long partId,
+            Integer displayOrder
+    ) {
+        Question question = newEntity(Question.class);
+        ReflectionTestUtils.setField(question, "id", id);
+        ReflectionTestUtils.setField(question, "publicId", publicId);
+        ReflectionTestUtils.setField(question, "quizSessionId", quizSessionId);
+        ReflectionTestUtils.setField(question, "userId", userId);
+        ReflectionTestUtils.setField(question, "subjectId", subjectId);
+        ReflectionTestUtils.setField(question, "chapterId", chapterId);
+        ReflectionTestUtils.setField(question, "partId", partId);
+        ReflectionTestUtils.setField(question, "questionType", "multiple_choice");
+        ReflectionTestUtils.setField(question, "difficulty", "medium");
+        ReflectionTestUtils.setField(question, "summary", "모델링의 특징");
+        ReflectionTestUtils.setField(question, "body", "다음 중 데이터 모델링의 특징으로 올바른 것은?");
+        ReflectionTestUtils.setField(question, "correctExplanation", "데이터 모델링은 현실 데이터를 추상화합니다.");
+        ReflectionTestUtils.setField(question, "incorrectExplanation", "선택지는 데이터 모델링의 핵심 특징과 맞지 않습니다.");
+        ReflectionTestUtils.setField(question, "displayOrder", displayOrder);
+        return question;
+    }
+
+    private QuestionOption option(Long id, Long questionId, Integer optionNumber, String content, Boolean correct) {
+        QuestionOption option = newEntity(QuestionOption.class);
+        ReflectionTestUtils.setField(option, "id", id);
+        ReflectionTestUtils.setField(option, "questionId", questionId);
+        ReflectionTestUtils.setField(option, "optionNumber", optionNumber);
+        ReflectionTestUtils.setField(option, "content", content);
+        ReflectionTestUtils.setField(option, "correct", correct);
+        return option;
+    }
+
+    private QuestionAnswer answer(Long id, Long questionId, String answerValue) {
+        QuestionAnswer answer = newEntity(QuestionAnswer.class);
+        ReflectionTestUtils.setField(answer, "id", id);
+        ReflectionTestUtils.setField(answer, "questionId", questionId);
+        ReflectionTestUtils.setField(answer, "answerValue", answerValue);
+        return answer;
+    }
+
+    private Subject subject(Long id, String publicId, Long userId, String name) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private Chapter chapter(Long id, String publicId, Long subjectId, Long userId, String name, Integer displayOrder) {
+        Chapter chapter = newEntity(Chapter.class);
+        ReflectionTestUtils.setField(chapter, "id", id);
+        ReflectionTestUtils.setField(chapter, "publicId", publicId);
+        ReflectionTestUtils.setField(chapter, "subjectId", subjectId);
+        ReflectionTestUtils.setField(chapter, "userId", userId);
+        ReflectionTestUtils.setField(chapter, "name", name);
+        ReflectionTestUtils.setField(chapter, "displayOrder", displayOrder);
+        return chapter;
+    }
+
+    private Part part(Long id, String publicId, Long chapterId, Long subjectId, Long userId, String name) {
+        Part part = newEntity(Part.class);
+        ReflectionTestUtils.setField(part, "id", id);
+        ReflectionTestUtils.setField(part, "publicId", publicId);
+        ReflectionTestUtils.setField(part, "chapterId", chapterId);
+        ReflectionTestUtils.setField(part, "subjectId", subjectId);
+        ReflectionTestUtils.setField(part, "userId", userId);
+        ReflectionTestUtils.setField(part, "name", name);
+        ReflectionTestUtils.setField(part, "partNumber", 1);
+        return part;
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionQueryServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionQueryServiceTest.java
@@ -83,7 +83,7 @@ class QuizSessionQueryServiceTest {
 
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
                 .thenReturn(Optional.of(quizSession));
-        when(subjectRepository.findById(subject.getId()))
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subject.getId(), userId))
                 .thenReturn(Optional.of(subject));
         when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(quizSession.getId(), userId))
                 .thenReturn(List.of(question));
@@ -91,9 +91,9 @@ class QuizSessionQueryServiceTest {
                 .thenReturn(List.of(option1, option2));
         when(questionAnswerRepository.findAllByQuestionIdIn(List.of(question.getId())))
                 .thenReturn(List.of(answer));
-        when(chapterRepository.findAllById(List.of(chapter.getId())))
+        when(chapterRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(List.of(chapter.getId()), userId))
                 .thenReturn(List.of(chapter));
-        when(partRepository.findAllById(List.of(part.getId())))
+        when(partRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(List.of(part.getId()), userId))
                 .thenReturn(List.of(part));
 
         QuizSessionResponse response = quizSessionQueryService.getQuizSession(userId, quizSession.getPublicId());
@@ -152,6 +152,27 @@ class QuizSessionQueryServiceTest {
     }
 
     @Test
+    void getQuizSession_throws_internal_error_when_completed_session_has_no_questions() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subject.getId(), userId))
+                .thenReturn(Optional.of(subject));
+        when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(quizSession.getId(), userId))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> quizSessionQueryService.getQuizSession(userId, quizSession.getPublicId()))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+
+        verifyNoInteractions(questionOptionRepository, questionAnswerRepository, chapterRepository, partRepository);
+    }
+
+    @Test
     void getQuizSession_throws_internal_error_when_answer_missing() {
         Long userId = 1L;
         Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
@@ -171,7 +192,7 @@ class QuizSessionQueryServiceTest {
 
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
                 .thenReturn(Optional.of(quizSession));
-        when(subjectRepository.findById(subject.getId()))
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subject.getId(), userId))
                 .thenReturn(Optional.of(subject));
         when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(quizSession.getId(), userId))
                 .thenReturn(List.of(question));
@@ -179,9 +200,9 @@ class QuizSessionQueryServiceTest {
                 .thenReturn(List.of());
         when(questionAnswerRepository.findAllByQuestionIdIn(List.of(question.getId())))
                 .thenReturn(List.of());
-        when(chapterRepository.findAllById(List.of(chapter.getId())))
+        when(chapterRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(List.of(chapter.getId()), userId))
                 .thenReturn(List.of(chapter));
-        when(partRepository.findAllById(List.of(part.getId())))
+        when(partRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(List.of(part.getId()), userId))
                 .thenReturn(List.of(part));
 
         assertThatThrownBy(() -> quizSessionQueryService.getQuizSession(userId, quizSession.getPublicId()))
@@ -230,7 +251,7 @@ class QuizSessionQueryServiceTest {
         ReflectionTestUtils.setField(question, "partId", partId);
         ReflectionTestUtils.setField(question, "questionType", "multiple_choice");
         ReflectionTestUtils.setField(question, "difficulty", "medium");
-        ReflectionTestUtils.setField(question, "summary", "모델링의 특징");
+        ReflectionTestUtils.setField(question, "summary", "모델링의 핵심 특징");
         ReflectionTestUtils.setField(question, "body", "다음 중 데이터 모델링의 특징으로 올바른 것은?");
         ReflectionTestUtils.setField(question, "correctExplanation", "데이터 모델링은 현실 데이터를 추상화합니다.");
         ReflectionTestUtils.setField(question, "incorrectExplanation", "선택지는 데이터 모델링의 핵심 특징과 맞지 않습니다.");


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 기존 OpenAPI 명세의 `GET /api/v1/quiz-sessions/{quizSessionId}` 구현
- 생성 완료된 퀴즈 세트의 문제, 선택지, 정답, 해설 조회 응답 제공
- 문제 조회에 필요한 런타임 스키마와 JPA 모델 보강

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- 명세에 정의된 `GET /api/v1/quiz-sessions/{quizSessionId}` 구현
- Question / QuestionOption / QuestionAnswer 엔티티 및 Repository 추가
- 퀴즈 세트, 문항, 선택지, 정답 응답 DTO 추가
- `completed` 상태가 아닌 퀴즈 세션 조회 시 409 응답 처리
- 문항 스키마 생성용 Flyway V6 migration 추가
- 퀴즈 세트 조회 서비스 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.domain.quiz.service.QuizSessionQueryServiceTest`
2. `./gradlew clean test`
3. `git diff --cached --check`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #55

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- AI 실제 문제 생성 로직은 후속 이슈 범위
- `question_options`는 현재 DDL/API 명세에 publicId가 없어 응답 `id`에 선택지 PK 문자열 사용

---

## 🧑‍💻 Assignee

- @imclaremont