### PR TITLE
[Docs] 머지 전략 지침 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@ return ResponseEntity.status(errorCode.getStatus())
 
 ### 머지 전략
 
-- 작업 브랜치(`feat/*`, `fix/*`, `refactor/*`, `docs/*`, `chore/*`, `test/*`) → `develop`: Squash merge 사용
+- 작업 브랜치(`type/#issue-number-description`, 예: `feat/#123-login-api`) → `develop`: Squash merge 사용
 - `develop` → `main`: Merge commit 사용
 - 작업 브랜치 내부 커밋은 리뷰 편의를 위해 원자적으로 작성
 - Squash merge 커밋 메시지는 PR 제목 기준으로 작성

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,8 +184,14 @@ return ResponseEntity.status(errorCode.getStatus())
 - 작업 브랜치(`type/#issue-number-description`, 예: `feat/#123-login-api`) → `develop`: Squash merge 사용
 - `develop` → `main`: Merge commit 사용
 - 작업 브랜치 내부 커밋은 리뷰 편의를 위해 원자적으로 작성
-- Squash merge 커밋 메시지는 PR 제목 기준으로 작성
 - `main` 병합 커밋은 릴리즈 단위 추적 목적
+
+### Git 메시지 컨벤션
+
+- 커밋 메시지: `type: 한국어 핵심`
+- PR 제목: `[Type] 한국어 핵심`
+- Squash merge 커밋 메시지: `type: 한국어 핵심 (#PR번호)`
+- `develop` → `main` Merge commit 메시지: `[Release] 버전/날짜 배포`
 
 ### 이슈 및 PR 제목
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,14 @@ return ResponseEntity.status(errorCode.getStatus())
 - 서로 다른 목적의 변경은 논리 단위별로 커밋 분리
 - 리뷰와 롤백이 쉬운 단위로 커밋 작성
 
+### 머지 전략
+
+- 작업 브랜치(`feat/*`, `fix/*`, `refactor/*`, `docs/*`, `chore/*`, `test/*`) → `develop`: Squash merge 사용
+- `develop` → `main`: Merge commit 사용
+- 작업 브랜치 내부 커밋은 리뷰 편의를 위해 원자적으로 작성
+- Squash merge 커밋 메시지는 PR 제목 기준으로 작성
+- `main` 병합 커밋은 릴리즈 단위 추적 목적
+
 ### 이슈 및 PR 제목
 
 - 형식: `[Type] 제목`


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- AGENTS.md에 브랜치별 머지 전략 지침 추가
- 작업 브랜치 → develop, develop → main 흐름의 머지 방식 명시

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- 작업 브랜치에서 `develop`으로는 Squash merge 사용 명시
- `develop`에서 `main`으로는 Merge commit 사용 명시
- 작업 브랜치 내부 커밋 원자성 및 Squash merge 메시지 기준 보강

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `git diff --check`
2. 문서 변경 사항 확인
3. 해당 없음: 문서 변경만 포함

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #59

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 코드 변경 없음

---

## 🧑‍💻 Assignee

- @imclaremont