### PR TITLE
[Feat] 마이페이지 계정 정보 조회 및 닉네임 변경 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -1,0 +1,42 @@
+package com.f1.quiket.domain.mypage.controller;
+
+import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
+import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.mypage.service.MyPageService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/my")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse<MyProfileResponse>> getMyProfile(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        MyProfileResponse response = myPageService.getMyProfile(principal.getPublicId());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    @PatchMapping("/profile/nickname")
+    public ResponseEntity<ApiResponse<MyProfileResponse>> updateNickname(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody NicknameUpdateRequest request
+    ) {
+        MyProfileResponse response = myPageService.updateNickname(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -16,6 +16,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 마이페이지 API 진입점
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/my")
@@ -23,6 +26,9 @@ public class MyPageController {
 
     private final MyPageService myPageService;
 
+    /**
+     * 마이페이지 계정 정보 조회
+     */
     @GetMapping("/profile")
     public ResponseEntity<ApiResponse<MyProfileResponse>> getMyProfile(
             @AuthenticationPrincipal UserPrincipal principal
@@ -31,6 +37,9 @@ public class MyPageController {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
     }
 
+    /**
+     * 닉네임 변경
+     */
     @PatchMapping("/profile/nickname")
     public ResponseEntity<ApiResponse<MyProfileResponse>> updateNickname(
             @AuthenticationPrincipal UserPrincipal principal,

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/MyProfileResponse.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/MyProfileResponse.java
@@ -1,0 +1,41 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyProfileResponse {
+
+    private final String id;
+    private final String email;
+    private final String nickname;
+    private final Integer dotoriBalance;
+    private final boolean emailVerified;
+    private final String status;
+    private final List<String> providers;
+    private final Integer xpTotal;
+    private final Integer currentLevel;
+    private final LocalDateTime createdAt;
+
+    public static MyProfileResponse of(User user, List<UserAuthIdentity> identities) {
+        return MyProfileResponse.builder()
+                .id(user.getPublicId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .dotoriBalance(user.getDotoriBalance())
+                .emailVerified(user.isEmailVerified())
+                .status(user.getStatus())
+                .providers(identities.stream()
+                        .map(UserAuthIdentity::getProvider)
+                        .toList())
+                .xpTotal(user.getXpTotal())
+                .currentLevel(user.getCurrentLevel())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/MyProfileResponse.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/MyProfileResponse.java
@@ -3,13 +3,22 @@ package com.f1.quiket.domain.mypage.dto;
 import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.user.entity.User;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * 마이페이지 계정 정보 응답 DTO (기능명세 MY-001)
+ */
 @Getter
 @Builder
 public class MyProfileResponse {
+
+    // primary 인증 수단 우선, 그 다음 provider명 알파벳순 — 응답 순서 결정성 보장
+    private static final Comparator<UserAuthIdentity> PROVIDER_ORDER =
+            Comparator.comparing(UserAuthIdentity::isPrimary).reversed()
+                    .thenComparing(UserAuthIdentity::getProvider);
 
     private final String id;
     private final String email;
@@ -31,6 +40,7 @@ public class MyProfileResponse {
                 .emailVerified(user.isEmailVerified())
                 .status(user.getStatus())
                 .providers(identities.stream()
+                        .sorted(PROVIDER_ORDER)
                         .map(UserAuthIdentity::getProvider)
                         .toList())
                 .xpTotal(user.getXpTotal())

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/NicknameUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/NicknameUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NicknameUpdateRequest {
+
+    @NotBlank(message = "닉네임은 필수입니다")
+    @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하여야 합니다")
+    @Pattern(regexp = "^[가-힣A-Za-z]{2,12}$", message = "닉네임은 한글 또는 영문만 사용할 수 있습니다")
+    private String nickname;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
@@ -1,0 +1,42 @@
+package com.f1.quiket.domain.mypage.service;
+
+import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
+import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final UserAuthIdentityRepository userAuthIdentityRepository;
+
+    @Transactional(readOnly = true)
+    public MyProfileResponse getMyProfile(String userPublicId) {
+        User user = findActiveUser(userPublicId);
+        return toMyProfileResponse(user);
+    }
+
+    public MyProfileResponse updateNickname(String userPublicId, NicknameUpdateRequest request) {
+        User user = findActiveUser(userPublicId);
+        user.changeNickname(request.getNickname());
+        return toMyProfileResponse(user);
+    }
+
+    private User findActiveUser(String userPublicId) {
+        return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    private MyProfileResponse toMyProfileResponse(User user) {
+        return MyProfileResponse.of(user, userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/user/entity/User.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/User.java
@@ -85,6 +85,10 @@ public class User extends BaseEntity {
         this.emailVerified = true;
     }
 
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
     public void recordLoginFailure(int maxFailedCount) {
         LocalDateTime now = LocalDateTime.now();
         this.failedLoginCount++;

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -1,0 +1,103 @@
+package com.f1.quiket.domain.mypage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
+import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class MyPageServiceTest {
+
+    private UserRepository userRepository;
+    private UserAuthIdentityRepository userAuthIdentityRepository;
+    private MyPageService myPageService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userAuthIdentityRepository = mock(UserAuthIdentityRepository.class);
+        myPageService = new MyPageService(userRepository, userAuthIdentityRepository);
+    }
+
+    @Test
+    void getMyProfile_returns_profile() {
+        User user = user();
+        UserAuthIdentity localIdentity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        UserAuthIdentity kakaoIdentity = UserAuthIdentity.createOAuth(user, "kakao", "kakao-subject", false);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user))
+                .thenReturn(List.of(localIdentity, kakaoIdentity));
+
+        MyProfileResponse response = myPageService.getMyProfile(user.getPublicId());
+
+        assertThat(response.getId()).isEqualTo(user.getPublicId());
+        assertThat(response.getEmail()).isEqualTo("user@example.com");
+        assertThat(response.getNickname()).isEqualTo("도토리");
+        assertThat(response.getDotoriBalance()).isEqualTo(12);
+        assertThat(response.isEmailVerified()).isTrue();
+        assertThat(response.getStatus()).isEqualTo("active");
+        assertThat(response.getProviders()).containsExactly("local", "kakao");
+        assertThat(response.getXpTotal()).isEqualTo(360);
+        assertThat(response.getCurrentLevel()).isEqualTo(3);
+        assertThat(response.getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 5, 19, 7, 30));
+    }
+
+    @Test
+    void updateNickname_changes_nickname() {
+        User user = user();
+        NicknameUpdateRequest request = nicknameUpdateRequest("새닉네임");
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(identity));
+
+        MyProfileResponse response = myPageService.updateNickname(user.getPublicId(), request);
+
+        assertThat(user.getNickname()).isEqualTo("새닉네임");
+        assertThat(response.getNickname()).isEqualTo("새닉네임");
+        assertThat(response.getProviders()).containsExactly("local");
+    }
+
+    @Test
+    void getMyProfile_throws_not_found_when_user_missing() {
+        String userPublicId = "018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901";
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> myPageService.getMyProfile(userPublicId))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
+    }
+
+    private User user() {
+        User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "emailVerified", true);
+        ReflectionTestUtils.setField(user, "dotoriBalance", 12);
+        ReflectionTestUtils.setField(user, "xpTotal", 360);
+        ReflectionTestUtils.setField(user, "currentLevel", 3);
+        ReflectionTestUtils.setField(user, "createdAt", LocalDateTime.of(2026, 5, 19, 7, 30));
+        return user;
+    }
+
+    private NicknameUpdateRequest nicknameUpdateRequest(String nickname) {
+        NicknameUpdateRequest request = new NicknameUpdateRequest();
+        ReflectionTestUtils.setField(request, "nickname", nickname);
+        return request;
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- MY-001 계정 설정 중 계정 정보 조회와 닉네임 변경 API를 구현했습니다

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- GET /api/v1/my/profile 구현
- PATCH /api/v1/my/profile/nickname 구현
- 마이페이지 프로필 응답 DTO 추가
- 닉네임 변경 요청 검증 추가
- 사용자 닉네임 변경 도메인 메서드 추가
- 마이페이지 서비스 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. ./gradlew test --tests com.f1.quiket.domain.mypage.service.MyPageServiceTest
2. ./gradlew test
3. ./gradlew check

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #61

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 이메일 변경, 비밀번호 변경, 회원 탈퇴는 후속 이슈에서 분리 구현 예정입니다

---

## 🧑‍💻 Assignee

- @imclaremont