### PR TITLE
[Feat] 마이페이지 이메일 변경 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -1,5 +1,8 @@
 package com.f1.quiket.domain.mypage.controller;
 
+import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
 import com.f1.quiket.domain.mypage.service.MyPageService;
@@ -12,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,6 +50,24 @@ public class MyPageController {
             @Valid @RequestBody NicknameUpdateRequest request
     ) {
         MyProfileResponse response = myPageService.updateNickname(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    @PostMapping("/email/change-requests")
+    public ResponseEntity<ApiResponse<EmailVerificationSentResponse>> requestEmailChange(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody MyEmailChangeRequest request
+    ) {
+        EmailVerificationSentResponse response = myPageService.requestEmailChange(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    @PostMapping("/email/change-confirm")
+    public ResponseEntity<ApiResponse<MyProfileResponse>> confirmEmailChange(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody MyEmailChangeConfirmRequest request
+    ) {
+        MyProfileResponse response = myPageService.confirmEmailChange(principal.getPublicId(), request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/MyEmailChangeConfirmRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/MyEmailChangeConfirmRequest.java
@@ -1,0 +1,22 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyEmailChangeConfirmRequest {
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수입니다")
+    @Size(max = 255, message = "이메일은 255자 이하여야 합니다")
+    private String newEmail;
+
+    @NotBlank(message = "인증 코드는 필수입니다")
+    @Pattern(regexp = "^\\d{6}$", message = "인증 코드는 6자리 숫자여야 합니다")
+    private String verificationCode;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/MyEmailChangeRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/MyEmailChangeRequest.java
@@ -1,0 +1,17 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyEmailChangeRequest {
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수입니다")
+    @Size(max = 255, message = "이메일은 255자 이하여야 합니다")
+    private String newEmail;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/event/MyEmailChangeMailRequestedEvent.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/event/MyEmailChangeMailRequestedEvent.java
@@ -1,0 +1,7 @@
+package com.f1.quiket.domain.mypage.event;
+
+public record MyEmailChangeMailRequestedEvent(
+        String email,
+        String verificationCode
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyEmailChangeVerificationPayload.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyEmailChangeVerificationPayload.java
@@ -1,0 +1,7 @@
+package com.f1.quiket.domain.mypage.service;
+
+public record MyEmailChangeVerificationPayload(
+        String newEmail,
+        String verificationCode
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyEmailChangeVerificationStore.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyEmailChangeVerificationStore.java
@@ -1,0 +1,60 @@
+package com.f1.quiket.domain.mypage.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class MyEmailChangeVerificationStore {
+
+    private static final String KEY_PREFIX = "my:email-change:";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public void save(String userPublicId, MyEmailChangeVerificationPayload payload, long ttlSeconds) {
+        try {
+            stringRedisTemplate.opsForValue()
+                    .set(
+                            buildKey(userPublicId),
+                            objectMapper.writeValueAsString(payload),
+                            Duration.ofSeconds(ttlSeconds)
+                    );
+        } catch (DataAccessException | JsonProcessingException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    public Optional<MyEmailChangeVerificationPayload> find(String userPublicId) {
+        try {
+            String payload = stringRedisTemplate.opsForValue().get(buildKey(userPublicId));
+            if (!StringUtils.hasText(payload)) {
+                return Optional.empty();
+            }
+            return Optional.of(objectMapper.readValue(payload, MyEmailChangeVerificationPayload.class));
+        } catch (DataAccessException | JsonProcessingException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    public void delete(String userPublicId) {
+        try {
+            stringRedisTemplate.delete(buildKey(userPublicId));
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    private String buildKey(String userPublicId) {
+        return KEY_PREFIX + userPublicId;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyEmailChangeVerificationStore.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyEmailChangeVerificationStore.java
@@ -17,6 +17,8 @@ import org.springframework.util.StringUtils;
 public class MyEmailChangeVerificationStore {
 
     private static final String KEY_PREFIX = "my:email-change:";
+    private static final String COOLDOWN_KEY_PREFIX = "my:email-change:cooldown:";
+    private static final String COOLDOWN_VALUE = "1";
 
     private final StringRedisTemplate stringRedisTemplate;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -54,7 +56,34 @@ public class MyEmailChangeVerificationStore {
         }
     }
 
+    /**
+     * 이메일 변경 성공 시 하루(24h) cool-down 시작 (기능명세 MY-001 정책)
+     */
+    public void markCooldown(String userPublicId, long cooldownSeconds) {
+        try {
+            stringRedisTemplate.opsForValue()
+                    .set(buildCooldownKey(userPublicId), COOLDOWN_VALUE, Duration.ofSeconds(cooldownSeconds));
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    /**
+     * 이메일 변경 cool-down 여부
+     */
+    public boolean isInCooldown(String userPublicId) {
+        try {
+            return Boolean.TRUE.equals(stringRedisTemplate.hasKey(buildCooldownKey(userPublicId)));
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
     private String buildKey(String userPublicId) {
         return KEY_PREFIX + userPublicId;
+    }
+
+    private String buildCooldownKey(String userPublicId) {
+        return COOLDOWN_KEY_PREFIX + userPublicId;
     }
 }

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
@@ -1,23 +1,37 @@
 package com.f1.quiket.domain.mypage.service;
 
+import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.mypage.event.MyEmailChangeMailRequestedEvent;
 import com.f1.quiket.domain.user.entity.User;
 import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class MyPageService {
 
+    private static final String PROVIDER_LOCAL = "local";
+    private static final long EMAIL_CHANGE_TTL_SECONDS = 600L;
+
     private final UserRepository userRepository;
     private final UserAuthIdentityRepository userAuthIdentityRepository;
+    private final EmailVerificationCodeGenerator verificationCodeGenerator;
+    private final MyEmailChangeVerificationStore emailChangeVerificationStore;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public MyProfileResponse getMyProfile(String userPublicId) {
@@ -31,9 +45,58 @@ public class MyPageService {
         return toMyProfileResponse(user);
     }
 
+    public EmailVerificationSentResponse requestEmailChange(String userPublicId, MyEmailChangeRequest request) {
+        User user = findActiveUser(userPublicId);
+        findLocalIdentity(user);
+        validateEmailNotExists(request.getNewEmail());
+
+        String verificationCode = verificationCodeGenerator.generate();
+        emailChangeVerificationStore.save(
+                userPublicId,
+                new MyEmailChangeVerificationPayload(request.getNewEmail(), verificationCode),
+                EMAIL_CHANGE_TTL_SECONDS
+        );
+        eventPublisher.publishEvent(new MyEmailChangeMailRequestedEvent(request.getNewEmail(), verificationCode));
+        return EmailVerificationSentResponse.of(request.getNewEmail(), EMAIL_CHANGE_TTL_SECONDS);
+    }
+
+    public MyProfileResponse confirmEmailChange(String userPublicId, MyEmailChangeConfirmRequest request) {
+        User user = findActiveUser(userPublicId);
+        findLocalIdentity(user);
+        validateEmailNotExists(request.getNewEmail());
+
+        MyEmailChangeVerificationPayload payload = emailChangeVerificationStore.find(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_EMAIL_VERIFICATION_EXPIRED));
+        if (!payload.newEmail().equals(request.getNewEmail())
+                || !payload.verificationCode().equals(request.getVerificationCode())) {
+            throw new CustomException(ErrorCode.AUTH_INVALID_EMAIL_VERIFICATION);
+        }
+
+        user.changeEmail(request.getNewEmail());
+        emailChangeVerificationStore.delete(userPublicId);
+        return toMyProfileResponse(user);
+    }
+
     private User findActiveUser(String userPublicId) {
         return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    private UserAuthIdentity findLocalIdentity(User user) {
+        UserAuthIdentity localIdentity = userAuthIdentityRepository
+                .findByUserAndProviderAndDeletedAtIsNull(user, PROVIDER_LOCAL)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND));
+
+        if (!StringUtils.hasText(localIdentity.getPasswordHash())) {
+            throw new CustomException(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND);
+        }
+        return localIdentity;
+    }
+
+    private void validateEmailNotExists(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException(ErrorCode.AUTH_EMAIL_ALREADY_EXISTS);
+        }
     }
 
     private MyProfileResponse toMyProfileResponse(User user) {

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
@@ -26,6 +26,7 @@ public class MyPageService {
 
     private static final String PROVIDER_LOCAL = "local";
     private static final long EMAIL_CHANGE_TTL_SECONDS = 600L;
+    private static final long EMAIL_CHANGE_COOLDOWN_SECONDS = 86_400L;
 
     private final UserRepository userRepository;
     private final UserAuthIdentityRepository userAuthIdentityRepository;
@@ -48,6 +49,7 @@ public class MyPageService {
     public EmailVerificationSentResponse requestEmailChange(String userPublicId, MyEmailChangeRequest request) {
         User user = findActiveUser(userPublicId);
         findLocalIdentity(user);
+        validateNotInCooldown(userPublicId);
         validateEmailNotExists(request.getNewEmail());
 
         String verificationCode = verificationCodeGenerator.generate();
@@ -74,6 +76,8 @@ public class MyPageService {
 
         user.changeEmail(request.getNewEmail());
         emailChangeVerificationStore.delete(userPublicId);
+        // 기능명세 MY-001 정책 — 이메일 변경 성공 시 하루 cool-down 시작
+        emailChangeVerificationStore.markCooldown(userPublicId, EMAIL_CHANGE_COOLDOWN_SECONDS);
         return toMyProfileResponse(user);
     }
 
@@ -96,6 +100,12 @@ public class MyPageService {
     private void validateEmailNotExists(String email) {
         if (userRepository.existsByEmail(email)) {
             throw new CustomException(ErrorCode.AUTH_EMAIL_ALREADY_EXISTS);
+        }
+    }
+
+    private void validateNotInCooldown(String userPublicId) {
+        if (emailChangeVerificationStore.isInCooldown(userPublicId)) {
+            throw new CustomException(ErrorCode.MY_EMAIL_CHANGE_TOO_FREQUENT);
         }
     }
 

--- a/src/main/java/com/f1/quiket/domain/user/entity/User.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/User.java
@@ -85,6 +85,10 @@ public class User extends BaseEntity {
         this.emailVerified = true;
     }
 
+    public void changeEmail(String email) {
+        this.email = email;
+    }
+
     public void changeNickname(String nickname) {
         this.nickname = nickname;
     }

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -57,6 +57,9 @@ public enum ErrorCode {
     QUIZ_SESSION_NOT_FOUND(404, "QUIZ_SESSION_NOT_FOUND", "퀴즈 세션을 찾을 수 없습니다."),
     QUIZ_SESSION_NOT_COMPLETED(409, "QUIZ_SESSION_NOT_COMPLETED", "아직 생성 완료 전인 퀴즈입니다."),
 
+    // MyPage Errors
+    MY_EMAIL_CHANGE_TOO_FREQUENT(429, "MY_EMAIL_CHANGE_TOO_FREQUENT", "이메일 변경은 하루에 1회만 가능합니다."),
+
     // 5xx Server Errors
     INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다."),
     SERVICE_UNAVAILABLE(503, "C009", "일시적으로 서비스를 이용할 수 없습니다."),

--- a/src/main/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListener.java
+++ b/src/main/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListener.java
@@ -2,6 +2,7 @@ package com.f1.quiket.infra.mail.listener;
 
 import com.f1.quiket.domain.auth.event.EmailVerificationMailRequestedEvent;
 import com.f1.quiket.domain.auth.event.PasswordResetMailRequestedEvent;
+import com.f1.quiket.domain.mypage.event.MyEmailChangeMailRequestedEvent;
 import com.f1.quiket.infra.mail.dto.MailSendRequest;
 import com.f1.quiket.infra.mail.service.SesMailSender;
 import com.f1.quiket.infra.mail.template.MailTemplateFactory;
@@ -29,6 +30,15 @@ public class EmailVerificationMailEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void sendPasswordResetMail(PasswordResetMailRequestedEvent event) {
         MailSendRequest mailRequest = mailTemplateFactory.createPasswordResetMail(
+                event.email(),
+                event.verificationCode()
+        );
+        sesMailSender.sendMail(mailRequest);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void sendMyEmailChangeMail(MyEmailChangeMailRequestedEvent event) {
+        MailSendRequest mailRequest = mailTemplateFactory.createEmailChangeMail(
                 event.email(),
                 event.verificationCode()
         );

--- a/src/main/java/com/f1/quiket/infra/mail/template/MailTemplateFactory.java
+++ b/src/main/java/com/f1/quiket/infra/mail/template/MailTemplateFactory.java
@@ -33,6 +33,12 @@ public class MailTemplateFactory {
         return MailSendRequest.html(toEmail, subject, body);
     }
 
+    public MailSendRequest createEmailChangeMail(String toEmail, String verificationCode) {
+        String subject = "[Quiket] 이메일 변경 인증";
+        String body = createVerificationCodeBody(verificationCode);
+        return MailSendRequest.html(toEmail, subject, body);
+    }
+
     private String createVerificationCodeBody(String verificationCode) {
         return loadTemplate(VERIFICATION_TEMPLATE_PATH)
                 .replace(VERIFICATION_CODE_PLACEHOLDER, verificationCode);

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -2,6 +2,9 @@ package com.f1.quiket.domain.mypage.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -146,11 +149,8 @@ class MyPageServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(ErrorCode.MY_EMAIL_CHANGE_TOO_FREQUENT);
-        verify(emailChangeVerificationStore, never()).save(
-                user.getPublicId(),
-                new MyEmailChangeVerificationPayload("new.user@example.com", "123456"),
-                600L
-        );
+        verify(emailChangeVerificationStore, never())
+                .save(anyString(), any(MyEmailChangeVerificationPayload.class), anyLong());
     }
 
     @Test
@@ -168,11 +168,8 @@ class MyPageServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(ErrorCode.AUTH_EMAIL_ALREADY_EXISTS);
-        verify(emailChangeVerificationStore, never()).save(
-                user.getPublicId(),
-                new MyEmailChangeVerificationPayload("new.user@example.com", "123456"),
-                600L
-        );
+        verify(emailChangeVerificationStore, never())
+                .save(anyString(), any(MyEmailChangeVerificationPayload.class), anyLong());
     }
 
     @Test

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -3,12 +3,19 @@ package com.f1.quiket.domain.mypage.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
 import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.mypage.event.MyEmailChangeMailRequestedEvent;
 import com.f1.quiket.domain.user.entity.User;
 import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
@@ -18,19 +25,32 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class MyPageServiceTest {
 
     private UserRepository userRepository;
     private UserAuthIdentityRepository userAuthIdentityRepository;
+    private EmailVerificationCodeGenerator verificationCodeGenerator;
+    private MyEmailChangeVerificationStore emailChangeVerificationStore;
+    private ApplicationEventPublisher eventPublisher;
     private MyPageService myPageService;
 
     @BeforeEach
     void setUp() {
         userRepository = mock(UserRepository.class);
         userAuthIdentityRepository = mock(UserAuthIdentityRepository.class);
-        myPageService = new MyPageService(userRepository, userAuthIdentityRepository);
+        verificationCodeGenerator = mock(EmailVerificationCodeGenerator.class);
+        emailChangeVerificationStore = mock(MyEmailChangeVerificationStore.class);
+        eventPublisher = mock(ApplicationEventPublisher.class);
+        myPageService = new MyPageService(
+                userRepository,
+                userAuthIdentityRepository,
+                verificationCodeGenerator,
+                emailChangeVerificationStore,
+                eventPublisher
+        );
     }
 
     @Test
@@ -84,6 +104,128 @@ class MyPageServiceTest {
                 .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
     }
 
+    @Test
+    void requestEmailChange_saves_code_and_publishes_mail() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeRequest request = emailChangeRequest("new.user@example.com");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(userRepository.existsByEmail(request.getNewEmail())).thenReturn(false);
+        when(verificationCodeGenerator.generate()).thenReturn("123456");
+
+        EmailVerificationSentResponse response = myPageService.requestEmailChange(user.getPublicId(), request);
+
+        assertThat(response.getEmail()).isEqualTo("new.user@example.com");
+        assertThat(response.getExpiresInSeconds()).isEqualTo(600L);
+        verify(emailChangeVerificationStore).save(
+                user.getPublicId(),
+                new MyEmailChangeVerificationPayload("new.user@example.com", "123456"),
+                600L
+        );
+        verify(eventPublisher).publishEvent(
+                new MyEmailChangeMailRequestedEvent("new.user@example.com", "123456")
+        );
+    }
+
+    @Test
+    void requestEmailChange_throws_conflict_when_email_exists() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeRequest request = emailChangeRequest("new.user@example.com");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(userRepository.existsByEmail(request.getNewEmail())).thenReturn(true);
+
+        assertThatThrownBy(() -> myPageService.requestEmailChange(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_EMAIL_ALREADY_EXISTS);
+        verify(emailChangeVerificationStore, never()).save(
+                user.getPublicId(),
+                new MyEmailChangeVerificationPayload("new.user@example.com", "123456"),
+                600L
+        );
+    }
+
+    @Test
+    void requestEmailChange_throws_conflict_when_local_identity_missing() {
+        User user = user();
+        MyEmailChangeRequest request = emailChangeRequest("new.user@example.com");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> myPageService.requestEmailChange(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void confirmEmailChange_updates_email_and_deletes_code() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeConfirmRequest request = emailChangeConfirmRequest("new.user@example.com", "123456");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(userRepository.existsByEmail(request.getNewEmail())).thenReturn(false);
+        when(emailChangeVerificationStore.find(user.getPublicId()))
+                .thenReturn(Optional.of(new MyEmailChangeVerificationPayload("new.user@example.com", "123456")));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(identity));
+
+        MyProfileResponse response = myPageService.confirmEmailChange(user.getPublicId(), request);
+
+        assertThat(user.getEmail()).isEqualTo("new.user@example.com");
+        assertThat(response.getEmail()).isEqualTo("new.user@example.com");
+        verify(emailChangeVerificationStore).delete(user.getPublicId());
+    }
+
+    @Test
+    void confirmEmailChange_throws_expired_when_code_missing() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeConfirmRequest request = emailChangeConfirmRequest("new.user@example.com", "123456");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(userRepository.existsByEmail(request.getNewEmail())).thenReturn(false);
+        when(emailChangeVerificationStore.find(user.getPublicId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> myPageService.confirmEmailChange(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_EMAIL_VERIFICATION_EXPIRED);
+    }
+
+    @Test
+    void confirmEmailChange_throws_invalid_when_code_mismatched() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeConfirmRequest request = emailChangeConfirmRequest("new.user@example.com", "000000");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(userRepository.existsByEmail(request.getNewEmail())).thenReturn(false);
+        when(emailChangeVerificationStore.find(user.getPublicId()))
+                .thenReturn(Optional.of(new MyEmailChangeVerificationPayload("new.user@example.com", "123456")));
+
+        assertThatThrownBy(() -> myPageService.confirmEmailChange(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_INVALID_EMAIL_VERIFICATION);
+        verify(emailChangeVerificationStore, never()).delete(user.getPublicId());
+    }
+
     private User user() {
         User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
         ReflectionTestUtils.setField(user, "id", 1L);
@@ -98,6 +240,19 @@ class MyPageServiceTest {
     private NicknameUpdateRequest nicknameUpdateRequest(String nickname) {
         NicknameUpdateRequest request = new NicknameUpdateRequest();
         ReflectionTestUtils.setField(request, "nickname", nickname);
+        return request;
+    }
+
+    private MyEmailChangeRequest emailChangeRequest(String newEmail) {
+        MyEmailChangeRequest request = new MyEmailChangeRequest();
+        ReflectionTestUtils.setField(request, "newEmail", newEmail);
+        return request;
+    }
+
+    private MyEmailChangeConfirmRequest emailChangeConfirmRequest(String newEmail, String verificationCode) {
+        MyEmailChangeConfirmRequest request = new MyEmailChangeConfirmRequest();
+        ReflectionTestUtils.setField(request, "newEmail", newEmail);
+        ReflectionTestUtils.setField(request, "verificationCode", verificationCode);
         return request;
     }
 }

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -120,6 +120,7 @@ class MyPageServiceTest {
 
         assertThat(response.getEmail()).isEqualTo("new.user@example.com");
         assertThat(response.getExpiresInSeconds()).isEqualTo(600L);
+        verify(emailChangeVerificationStore).isInCooldown(user.getPublicId());
         verify(emailChangeVerificationStore).save(
                 user.getPublicId(),
                 new MyEmailChangeVerificationPayload("new.user@example.com", "123456"),
@@ -127,6 +128,28 @@ class MyPageServiceTest {
         );
         verify(eventPublisher).publishEvent(
                 new MyEmailChangeMailRequestedEvent("new.user@example.com", "123456")
+        );
+    }
+
+    @Test
+    void requestEmailChange_throws_too_frequent_when_in_cooldown() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeRequest request = emailChangeRequest("new.user@example.com");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(emailChangeVerificationStore.isInCooldown(user.getPublicId())).thenReturn(true);
+
+        assertThatThrownBy(() -> myPageService.requestEmailChange(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.MY_EMAIL_CHANGE_TOO_FREQUENT);
+        verify(emailChangeVerificationStore, never()).save(
+                user.getPublicId(),
+                new MyEmailChangeVerificationPayload("new.user@example.com", "123456"),
+                600L
         );
     }
 
@@ -186,6 +209,7 @@ class MyPageServiceTest {
         assertThat(user.getEmail()).isEqualTo("new.user@example.com");
         assertThat(response.getEmail()).isEqualTo("new.user@example.com");
         verify(emailChangeVerificationStore).delete(user.getPublicId());
+        verify(emailChangeVerificationStore).markCooldown(user.getPublicId(), 86_400L);
     }
 
     @Test


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- MY-001 계정 설정 중 이메일 변경 인증 요청과 인증 확인 API를 구현했습니다

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- POST /api/v1/my/email/change-requests 구현
- POST /api/v1/my/email/change-confirm 구현
- Redis 기반 이메일 변경 인증 코드 저장소 추가
- 이메일 변경 인증 메일 이벤트 및 템플릿 팩토리 메서드 추가
- 로컬 계정 여부와 이메일 중복 검증 추가
- 마이페이지 서비스 테스트 확장

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. ./gradlew test --tests com.f1.quiket.domain.mypage.service.MyPageServiceTest
2. ./gradlew test
3. ./gradlew check

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #63

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 인증 코드는 Redis에 사용자 단위 키로 저장하며 재요청 시 이전 코드가 덮어써집니다
- 소셜 전용 계정은 기존 AUTH_LOCAL_IDENTITY_NOT_FOUND 계약으로 제한합니다

---

## 🧑‍💻 Assignee

- @imclaremont