### PR TITLE
[Feat] 마이페이지 비밀번호 변경 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -3,6 +3,7 @@ package com.f1.quiket.domain.mypage.controller;
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
+import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
 import com.f1.quiket.domain.mypage.service.MyPageService;
@@ -69,5 +70,14 @@ public class MyPageController {
     ) {
         MyProfileResponse response = myPageService.confirmEmailChange(principal.getPublicId(), request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<ApiResponse<Void>> updatePassword(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody MyPasswordChangeRequest request
+    ) {
+        myPageService.updatePassword(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -72,6 +72,9 @@ public class MyPageController {
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
     }
 
+    /**
+     * 비밀번호 변경
+     */
     @PatchMapping("/password")
     public ResponseEntity<ApiResponse<Void>> updatePassword(
             @AuthenticationPrincipal UserPrincipal principal,

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/MyPasswordChangeRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/MyPasswordChangeRequest.java
@@ -1,0 +1,26 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyPasswordChangeRequest {
+
+    @NotBlank(message = "현재 비밀번호는 필수입니다")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호는 필수입니다")
+    @Size(min = 8, max = 32, message = "새 비밀번호는 8자 이상 32자 이하여야 합니다")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z0-9~!@#$%^&*()_+=\\[\\]{}.,?-]{8,32}$",
+            message = "새 비밀번호는 영문과 숫자를 포함하고 공백 없이 허용된 문자만 사용할 수 있습니다")
+    private String newPassword;
+
+    @NotBlank(message = "새 비밀번호 확인은 필수입니다")
+    @Size(min = 8, max = 32, message = "새 비밀번호 확인은 8자 이상 32자 이하여야 합니다")
+    private String newPasswordConfirm;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
@@ -3,9 +3,11 @@ package com.f1.quiket.domain.mypage.service;
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
 import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.auth.service.AuthTokenService;
 import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
+import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
 import com.f1.quiket.domain.mypage.event.MyEmailChangeMailRequestedEvent;
@@ -15,6 +17,7 @@ import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -33,6 +36,8 @@ public class MyPageService {
     private final EmailVerificationCodeGenerator verificationCodeGenerator;
     private final MyEmailChangeVerificationStore emailChangeVerificationStore;
     private final ApplicationEventPublisher eventPublisher;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthTokenService authTokenService;
 
     @Transactional(readOnly = true)
     public MyProfileResponse getMyProfile(String userPublicId) {
@@ -81,6 +86,18 @@ public class MyPageService {
         return toMyProfileResponse(user);
     }
 
+    public void updatePassword(String userPublicId, MyPasswordChangeRequest request) {
+        validatePasswordConfirm(request.getNewPassword(), request.getNewPasswordConfirm());
+
+        User user = findActiveUser(userPublicId);
+        UserAuthIdentity localIdentity = findLocalIdentity(user);
+        validateCurrentPassword(localIdentity, request.getCurrentPassword());
+        validateNewPassword(localIdentity, request.getNewPassword());
+
+        localIdentity.changePassword(passwordEncoder.encode(request.getNewPassword()));
+        authTokenService.revokeAllActiveRefreshTokens(user);
+    }
+
     private User findActiveUser(String userPublicId) {
         return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
@@ -106,6 +123,24 @@ public class MyPageService {
     private void validateNotInCooldown(String userPublicId) {
         if (emailChangeVerificationStore.isInCooldown(userPublicId)) {
             throw new CustomException(ErrorCode.MY_EMAIL_CHANGE_TOO_FREQUENT);
+        }
+    }
+
+    private void validatePasswordConfirm(String password, String passwordConfirm) {
+        if (!password.equals(passwordConfirm)) {
+            throw new CustomException(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
+        }
+    }
+
+    private void validateCurrentPassword(UserAuthIdentity localIdentity, String currentPassword) {
+        if (!passwordEncoder.matches(currentPassword, localIdentity.getPasswordHash())) {
+            throw new CustomException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        }
+    }
+
+    private void validateNewPassword(UserAuthIdentity localIdentity, String newPassword) {
+        if (passwordEncoder.matches(newPassword, localIdentity.getPasswordHash())) {
+            throw new CustomException(ErrorCode.AUTH_PASSWORD_SAME_AS_PREVIOUS);
         }
     }
 

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -13,9 +13,11 @@ import static org.mockito.Mockito.when;
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
 import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.auth.service.AuthTokenService;
 import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
+import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
 import com.f1.quiket.domain.mypage.event.MyEmailChangeMailRequestedEvent;
@@ -29,6 +31,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class MyPageServiceTest {
@@ -38,6 +42,8 @@ class MyPageServiceTest {
     private EmailVerificationCodeGenerator verificationCodeGenerator;
     private MyEmailChangeVerificationStore emailChangeVerificationStore;
     private ApplicationEventPublisher eventPublisher;
+    private PasswordEncoder passwordEncoder;
+    private AuthTokenService authTokenService;
     private MyPageService myPageService;
 
     @BeforeEach
@@ -47,12 +53,16 @@ class MyPageServiceTest {
         verificationCodeGenerator = mock(EmailVerificationCodeGenerator.class);
         emailChangeVerificationStore = mock(MyEmailChangeVerificationStore.class);
         eventPublisher = mock(ApplicationEventPublisher.class);
+        passwordEncoder = new BCryptPasswordEncoder();
+        authTokenService = mock(AuthTokenService.class);
         myPageService = new MyPageService(
                 userRepository,
                 userAuthIdentityRepository,
                 verificationCodeGenerator,
                 emailChangeVerificationStore,
-                eventPublisher
+                eventPublisher,
+                passwordEncoder,
+                authTokenService
         );
     }
 
@@ -247,6 +257,117 @@ class MyPageServiceTest {
         verify(emailChangeVerificationStore, never()).delete(user.getPublicId());
     }
 
+    @Test
+    void updatePassword_changes_password_and_revokes_tokens() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        MyPasswordChangeRequest request = passwordChangeRequest(
+                "Password123!",
+                "NewPassword123!",
+                "NewPassword123!"
+        );
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+
+        myPageService.updatePassword(user.getPublicId(), request);
+
+        assertThat(passwordEncoder.matches("NewPassword123!", identity.getPasswordHash())).isTrue();
+        assertThat(passwordEncoder.matches("Password123!", identity.getPasswordHash())).isFalse();
+        verify(authTokenService).revokeAllActiveRefreshTokens(user);
+    }
+
+    @Test
+    void updatePassword_throws_mismatch_when_password_confirm_differs() {
+        String userPublicId = "018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901";
+        MyPasswordChangeRequest request = passwordChangeRequest(
+                "Password123!",
+                "NewPassword123!",
+                "OtherPassword123!"
+        );
+
+        assertThatThrownBy(() -> myPageService.updatePassword(userPublicId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
+        verify(userRepository, never()).findByPublicIdAndDeletedAtIsNull(userPublicId);
+    }
+
+    @Test
+    void updatePassword_throws_invalid_credentials_when_current_password_wrong() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        MyPasswordChangeRequest request = passwordChangeRequest(
+                "WrongPassword123!",
+                "NewPassword123!",
+                "NewPassword123!"
+        );
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+
+        assertThatThrownBy(() -> myPageService.updatePassword(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
+    }
+
+    @Test
+    void updatePassword_throws_same_as_previous_when_new_password_same() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        MyPasswordChangeRequest request = passwordChangeRequest(
+                "Password123!",
+                "Password123!",
+                "Password123!"
+        );
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+
+        assertThatThrownBy(() -> myPageService.updatePassword(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_PASSWORD_SAME_AS_PREVIOUS);
+        verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
+    }
+
+    @Test
+    void updatePassword_throws_conflict_when_local_identity_missing() {
+        User user = user();
+        MyPasswordChangeRequest request = passwordChangeRequest(
+                "Password123!",
+                "NewPassword123!",
+                "NewPassword123!"
+        );
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> myPageService.updatePassword(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND);
+        verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
+    }
+
     private User user() {
         User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
         ReflectionTestUtils.setField(user, "id", 1L);
@@ -274,6 +395,18 @@ class MyPageServiceTest {
         MyEmailChangeConfirmRequest request = new MyEmailChangeConfirmRequest();
         ReflectionTestUtils.setField(request, "newEmail", newEmail);
         ReflectionTestUtils.setField(request, "verificationCode", verificationCode);
+        return request;
+    }
+
+    private MyPasswordChangeRequest passwordChangeRequest(
+            String currentPassword,
+            String newPassword,
+            String newPasswordConfirm
+    ) {
+        MyPasswordChangeRequest request = new MyPasswordChangeRequest();
+        ReflectionTestUtils.setField(request, "currentPassword", currentPassword);
+        ReflectionTestUtils.setField(request, "newPassword", newPassword);
+        ReflectionTestUtils.setField(request, "newPasswordConfirm", newPasswordConfirm);
         return request;
     }
 }

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -295,7 +295,7 @@ class MyPageServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
-        verify(userRepository, never()).findByPublicIdAndDeletedAtIsNull(userPublicId);
+        verify(userRepository, never()).findByPublicIdAndDeletedAtIsNull(anyString());
     }
 
     @Test


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- MY-001 계정 설정 중 비밀번호 변경 API를 구현했습니다

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- PATCH /api/v1/my/password 구현
- 비밀번호 변경 요청 DTO 추가
- 현재 비밀번호 검증 추가
- 새 비밀번호 확인 및 이전 비밀번호 동일 여부 검증 추가
- 변경 성공 시 활성 리프레시 토큰 폐기 처리 추가
- 마이페이지 서비스 테스트 확장

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. ./gradlew test --tests com.f1.quiket.domain.mypage.service.MyPageServiceTest
2. ./gradlew test
3. ./gradlew check

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #65

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 소셜 전용 계정은 기존 AUTH_LOCAL_IDENTITY_NOT_FOUND 계약으로 제한합니다
- 비밀번호 변경 성공 시 보안상 기존 리프레시 토큰을 모두 폐기합니다

---

## 🧑‍💻 Assignee

- @imclaremont