### PR TITLE
[Feat] 마이페이지 회원 탈퇴 구현

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ return ResponseEntity.status(errorCode.getStatus())
 
 - 커밋 메시지: `type: 한국어 핵심`
 - PR 제목: `[Type] 한국어 핵심`
-- Squash merge 커밋 메시지: `type: 한국어 핵심 (#PR번호)`
+- Squash merge 커밋 메시지: `[Type] 한국어 핵심 (#PR번호)`
 - `develop` → `main` Merge commit 메시지: `[Release] 버전/날짜 배포`
 
 ### 이슈 및 PR 제목

--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.mypage.controller;
 
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.mypage.dto.MyAccountDeleteRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
@@ -81,6 +82,15 @@ public class MyPageController {
             @Valid @RequestBody MyPasswordChangeRequest request
     ) {
         myPageService.updatePassword(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
+    }
+
+    @PostMapping("/account/deletion")
+    public ResponseEntity<ApiResponse<Void>> deleteMyAccount(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody MyAccountDeleteRequest request
+    ) {
+        myPageService.deleteAccount(principal.getPublicId(), request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/MyAccountDeleteRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/MyAccountDeleteRequest.java
@@ -1,0 +1,15 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyAccountDeleteRequest {
+
+    private String password;
+
+    @AssertTrue(message = "회원 탈퇴 동의는 필수입니다")
+    private boolean agreedToDelete;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
@@ -5,6 +5,7 @@ import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
 import com.f1.quiket.domain.auth.service.AuthTokenService;
 import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
+import com.f1.quiket.domain.mypage.dto.MyAccountDeleteRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
@@ -15,6 +16,8 @@ import com.f1.quiket.domain.user.entity.User;
 import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -98,6 +101,19 @@ public class MyPageService {
         authTokenService.revokeAllActiveRefreshTokens(user);
     }
 
+    public void deleteAccount(String userPublicId, MyAccountDeleteRequest request) {
+        validateDeleteAgreement(request);
+
+        User user = findActiveUser(userPublicId);
+        List<UserAuthIdentity> identities = userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user);
+        findLocalIdentity(identities).ifPresent(localIdentity ->
+                validateAccountDeletePassword(localIdentity, request.getPassword()));
+
+        authTokenService.revokeAllActiveRefreshTokens(user);
+        identities.forEach(UserAuthIdentity::delete);
+        user.delete();
+    }
+
     private User findActiveUser(String userPublicId) {
         return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
@@ -112,6 +128,12 @@ public class MyPageService {
             throw new CustomException(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND);
         }
         return localIdentity;
+    }
+
+    private Optional<UserAuthIdentity> findLocalIdentity(List<UserAuthIdentity> identities) {
+        return identities.stream()
+                .filter(identity -> PROVIDER_LOCAL.equals(identity.getProvider()))
+                .findFirst();
     }
 
     private void validateEmailNotExists(String email) {
@@ -141,6 +163,21 @@ public class MyPageService {
     private void validateNewPassword(UserAuthIdentity localIdentity, String newPassword) {
         if (passwordEncoder.matches(newPassword, localIdentity.getPasswordHash())) {
             throw new CustomException(ErrorCode.AUTH_PASSWORD_SAME_AS_PREVIOUS);
+        }
+    }
+
+    private void validateDeleteAgreement(MyAccountDeleteRequest request) {
+        if (!request.isAgreedToDelete()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "회원 탈퇴 동의는 필수입니다.");
+        }
+    }
+
+    private void validateAccountDeletePassword(UserAuthIdentity localIdentity, String password) {
+        if (!StringUtils.hasText(localIdentity.getPasswordHash())) {
+            throw new CustomException(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND);
+        }
+        if (!StringUtils.hasText(password) || !passwordEncoder.matches(password, localIdentity.getPasswordHash())) {
+            throw new CustomException(ErrorCode.AUTH_INVALID_CREDENTIALS);
         }
     }
 

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -15,6 +15,7 @@ import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
 import com.f1.quiket.domain.auth.service.AuthTokenService;
 import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
+import com.f1.quiket.domain.mypage.dto.MyAccountDeleteRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
@@ -368,6 +369,101 @@ class MyPageServiceTest {
         verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
     }
 
+    @Test
+    void deleteAccount_deletes_local_account_and_revokes_tokens() {
+        User user = user();
+        UserAuthIdentity localIdentity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        UserAuthIdentity kakaoIdentity = UserAuthIdentity.createOAuth(user, "kakao", "kakao-subject", false);
+        MyAccountDeleteRequest request = accountDeleteRequest("Password123!", true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user))
+                .thenReturn(List.of(localIdentity, kakaoIdentity));
+
+        myPageService.deleteAccount(user.getPublicId(), request);
+
+        assertThat(user.getDeletedAt()).isNotNull();
+        assertThat(localIdentity.getDeletedAt()).isNotNull();
+        assertThat(kakaoIdentity.getDeletedAt()).isNotNull();
+        verify(authTokenService).revokeAllActiveRefreshTokens(user);
+    }
+
+    @Test
+    void deleteAccount_deletes_social_only_account_without_password() {
+        User user = user();
+        UserAuthIdentity kakaoIdentity = UserAuthIdentity.createOAuth(user, "kakao", "kakao-subject", true);
+        MyAccountDeleteRequest request = accountDeleteRequest(null, true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(kakaoIdentity));
+
+        myPageService.deleteAccount(user.getPublicId(), request);
+
+        assertThat(user.getDeletedAt()).isNotNull();
+        assertThat(kakaoIdentity.getDeletedAt()).isNotNull();
+        verify(authTokenService).revokeAllActiveRefreshTokens(user);
+    }
+
+    @Test
+    void deleteAccount_throws_invalid_input_when_agreement_missing() {
+        String userPublicId = "018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901";
+        MyAccountDeleteRequest request = accountDeleteRequest("Password123!", false);
+
+        assertThatThrownBy(() -> myPageService.deleteAccount(userPublicId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+        verify(userRepository, never()).findByPublicIdAndDeletedAtIsNull(userPublicId);
+    }
+
+    @Test
+    void deleteAccount_throws_invalid_credentials_when_local_password_missing() {
+        User user = user();
+        UserAuthIdentity localIdentity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        MyAccountDeleteRequest request = accountDeleteRequest(null, true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(localIdentity));
+
+        assertThatThrownBy(() -> myPageService.deleteAccount(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
+        assertThat(user.getDeletedAt()).isNull();
+        assertThat(localIdentity.getDeletedAt()).isNull();
+    }
+
+    @Test
+    void deleteAccount_throws_invalid_credentials_when_local_password_wrong() {
+        User user = user();
+        UserAuthIdentity localIdentity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        MyAccountDeleteRequest request = accountDeleteRequest("WrongPassword123!", true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(localIdentity));
+
+        assertThatThrownBy(() -> myPageService.deleteAccount(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
+        assertThat(user.getDeletedAt()).isNull();
+        assertThat(localIdentity.getDeletedAt()).isNull();
+    }
+
     private User user() {
         User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
         ReflectionTestUtils.setField(user, "id", 1L);
@@ -407,6 +503,13 @@ class MyPageServiceTest {
         ReflectionTestUtils.setField(request, "currentPassword", currentPassword);
         ReflectionTestUtils.setField(request, "newPassword", newPassword);
         ReflectionTestUtils.setField(request, "newPasswordConfirm", newPasswordConfirm);
+        return request;
+    }
+
+    private MyAccountDeleteRequest accountDeleteRequest(String password, boolean agreedToDelete) {
+        MyAccountDeleteRequest request = new MyAccountDeleteRequest();
+        ReflectionTestUtils.setField(request, "password", password);
+        ReflectionTestUtils.setField(request, "agreedToDelete", agreedToDelete);
         return request;
     }
 }

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -417,7 +417,7 @@ class MyPageServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
-        verify(userRepository, never()).findByPublicIdAndDeletedAtIsNull(userPublicId);
+        verify(userRepository, never()).findByPublicIdAndDeletedAtIsNull(anyString());
     }
 
     @Test


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- MY-001 계정 설정 중 회원 탈퇴 API를 구현했습니다

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- POST /api/v1/my/account/deletion 구현
- 회원 탈퇴 요청 DTO 추가
- 탈퇴 동의 검증 추가
- Local 계정 비밀번호 확인 검증 추가
- 사용자 및 인증 수단 삭제 처리 추가
- 활성 리프레시 토큰 폐기 처리 추가
- 마이페이지 서비스 테스트 확장

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. ./gradlew test --tests com.f1.quiket.domain.mypage.service.MyPageServiceTest
2. ./gradlew clean test
3. ./gradlew check

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #67

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- Local 계정은 확인용 비밀번호를 요구합니다
- 소셜 전용 계정은 비밀번호 없이 탈퇴 동의만 검증합니다
- 현재 구현은 사용자와 인증 수단을 soft delete하고 활성 리프레시 토큰을 폐기합니다
- 학습 기록 상세 삭제 정책은 개인정보 보존 정책 확정 후 별도 확장 대상입니다

---

## 🧑‍💻 Assignee

- @imclaremont