### PR TITLE
[Feat] 마이페이지 알림 설정 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -1,12 +1,16 @@
 package com.f1.quiket.domain.mypage.controller;
 
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.mypage.dto.FcmTokenUpdateRequest;
 import com.f1.quiket.domain.mypage.dto.MyAccountDeleteRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsResponse;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsUpdateRequest;
+import com.f1.quiket.domain.mypage.service.MyNotificationService;
 import com.f1.quiket.domain.mypage.service.MyPageService;
 import com.f1.quiket.global.auth.UserPrincipal;
 import com.f1.quiket.global.response.ApiResponse;
@@ -18,6 +22,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MyPageController {
 
     private final MyPageService myPageService;
+    private final MyNotificationService myNotificationService;
 
     /**
      * 마이페이지 계정 정보 조회
@@ -91,6 +97,35 @@ public class MyPageController {
             @Valid @RequestBody MyAccountDeleteRequest request
     ) {
         myPageService.deleteAccount(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
+    }
+
+    @GetMapping("/notifications")
+    public ResponseEntity<ApiResponse<NotificationSettingsResponse>> getNotificationSettings(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        NotificationSettingsResponse response = myNotificationService.getNotificationSettings(principal.getPublicId());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    @PutMapping("/notifications")
+    public ResponseEntity<ApiResponse<NotificationSettingsResponse>> updateNotificationSettings(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody NotificationSettingsUpdateRequest request
+    ) {
+        NotificationSettingsResponse response = myNotificationService.updateNotificationSettings(
+                principal.getPublicId(),
+                request
+        );
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    @PutMapping("/fcm-token")
+    public ResponseEntity<ApiResponse<Void>> updateFcmToken(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody FcmTokenUpdateRequest request
+    ) {
+        myNotificationService.updateFcmToken(principal.getPublicId(), request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/FcmTokenUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/FcmTokenUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FcmTokenUpdateRequest {
+
+    @NotBlank(message = "FCM 토큰은 필수입니다")
+    @Size(max = 255, message = "FCM 토큰은 255자 이하여야 합니다")
+    private String fcmToken;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/NotificationSettingsResponse.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/NotificationSettingsResponse.java
@@ -22,4 +22,16 @@ public class NotificationSettingsResponse {
                 .reviewEnabled(setting.isReviewEnabled())
                 .build();
     }
+
+    /**
+     * 사용자 알림 설정이 아직 생성되지 않은 경우의 기본값 응답 (기능명세 MY-002 — 모두 ON)
+     */
+    public static NotificationSettingsResponse defaults() {
+        return NotificationSettingsResponse.builder()
+                .fcmTokenRegistered(false)
+                .activityEnabled(true)
+                .updateEnabled(true)
+                .reviewEnabled(true)
+                .build();
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/NotificationSettingsResponse.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/NotificationSettingsResponse.java
@@ -1,0 +1,25 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+@Getter
+@Builder
+public class NotificationSettingsResponse {
+
+    private final boolean fcmTokenRegistered;
+    private final boolean activityEnabled;
+    private final boolean updateEnabled;
+    private final boolean reviewEnabled;
+
+    public static NotificationSettingsResponse from(UserNotificationSetting setting) {
+        return NotificationSettingsResponse.builder()
+                .fcmTokenRegistered(StringUtils.hasText(setting.getFcmToken()))
+                .activityEnabled(setting.isActivityEnabled())
+                .updateEnabled(setting.isUpdateEnabled())
+                .reviewEnabled(setting.isReviewEnabled())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/NotificationSettingsUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/NotificationSettingsUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NotificationSettingsUpdateRequest {
+
+    @NotNull(message = "활동 알림 설정은 필수입니다")
+    private Boolean activityEnabled;
+
+    @NotNull(message = "업데이트 알림 설정은 필수입니다")
+    private Boolean updateEnabled;
+
+    @NotNull(message = "복습 알림 설정은 필수입니다")
+    private Boolean reviewEnabled;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/entity/UserNotificationSetting.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/entity/UserNotificationSetting.java
@@ -1,0 +1,76 @@
+package com.f1.quiket.domain.mypage.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "user_notification_settings",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_user_notification_settings_user_id", columnNames = "user_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserNotificationSetting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "fcm_token", length = 255)
+    String fcmToken;
+
+    @Column(name = "is_activity_enabled", nullable = false)
+    boolean activityEnabled = true;
+
+    @Column(name = "is_update_enabled", nullable = false)
+    boolean updateEnabled = true;
+
+    @Column(name = "is_review_enabled", nullable = false)
+    boolean reviewEnabled = true;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+
+    public static UserNotificationSetting createDefault(Long userId) {
+        UserNotificationSetting setting = new UserNotificationSetting();
+        setting.userId = userId;
+        return setting;
+    }
+
+    public void updateSettings(boolean activityEnabled, boolean updateEnabled, boolean reviewEnabled) {
+        this.activityEnabled = activityEnabled;
+        this.updateEnabled = updateEnabled;
+        this.reviewEnabled = reviewEnabled;
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/repository/UserNotificationSettingRepository.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/repository/UserNotificationSettingRepository.java
@@ -1,0 +1,10 @@
+package com.f1.quiket.domain.mypage.repository;
+
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserNotificationSettingRepository extends JpaRepository<UserNotificationSetting, Long> {
+
+    Optional<UserNotificationSetting> findByUserId(Long userId);
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyNotificationService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyNotificationService.java
@@ -20,6 +20,7 @@ public class MyNotificationService {
 
     private final UserRepository userRepository;
     private final UserNotificationSettingRepository userNotificationSettingRepository;
+    private final UserNotificationSettingCreator userNotificationSettingCreator;
 
     @Transactional(readOnly = true)
     public NotificationSettingsResponse getNotificationSettings(String userPublicId) {
@@ -56,6 +57,6 @@ public class MyNotificationService {
 
     private UserNotificationSetting findOrCreateSetting(Long userId) {
         return userNotificationSettingRepository.findByUserId(userId)
-                .orElseGet(() -> userNotificationSettingRepository.save(UserNotificationSetting.createDefault(userId)));
+                .orElseGet(() -> userNotificationSettingCreator.createIfAbsent(userId));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyNotificationService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyNotificationService.java
@@ -1,0 +1,58 @@
+package com.f1.quiket.domain.mypage.service;
+
+import com.f1.quiket.domain.mypage.dto.FcmTokenUpdateRequest;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsResponse;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsUpdateRequest;
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import com.f1.quiket.domain.mypage.repository.UserNotificationSettingRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MyNotificationService {
+
+    private final UserRepository userRepository;
+    private final UserNotificationSettingRepository userNotificationSettingRepository;
+
+    public NotificationSettingsResponse getNotificationSettings(String userPublicId) {
+        User user = findActiveUser(userPublicId);
+        return NotificationSettingsResponse.from(findOrCreateSetting(user.getId()));
+    }
+
+    public NotificationSettingsResponse updateNotificationSettings(
+            String userPublicId,
+            NotificationSettingsUpdateRequest request
+    ) {
+        User user = findActiveUser(userPublicId);
+        UserNotificationSetting setting = findOrCreateSetting(user.getId());
+        setting.updateSettings(
+                request.getActivityEnabled(),
+                request.getUpdateEnabled(),
+                request.getReviewEnabled()
+        );
+        return NotificationSettingsResponse.from(setting);
+    }
+
+    public void updateFcmToken(String userPublicId, FcmTokenUpdateRequest request) {
+        User user = findActiveUser(userPublicId);
+        UserNotificationSetting setting = findOrCreateSetting(user.getId());
+        setting.updateFcmToken(request.getFcmToken());
+    }
+
+    private User findActiveUser(String userPublicId) {
+        return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    private UserNotificationSetting findOrCreateSetting(Long userId) {
+        return userNotificationSettingRepository.findByUserId(userId)
+                .orElseGet(() -> userNotificationSettingRepository.save(UserNotificationSetting.createDefault(userId)));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyNotificationService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyNotificationService.java
@@ -21,9 +21,12 @@ public class MyNotificationService {
     private final UserRepository userRepository;
     private final UserNotificationSettingRepository userNotificationSettingRepository;
 
+    @Transactional(readOnly = true)
     public NotificationSettingsResponse getNotificationSettings(String userPublicId) {
         User user = findActiveUser(userPublicId);
-        return NotificationSettingsResponse.from(findOrCreateSetting(user.getId()));
+        return userNotificationSettingRepository.findByUserId(user.getId())
+                .map(NotificationSettingsResponse::from)
+                .orElseGet(NotificationSettingsResponse::defaults);
     }
 
     public NotificationSettingsResponse updateNotificationSettings(

--- a/src/main/java/com/f1/quiket/domain/mypage/service/UserNotificationSettingCreator.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/UserNotificationSettingCreator.java
@@ -1,0 +1,34 @@
+package com.f1.quiket.domain.mypage.service;
+
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import com.f1.quiket.domain.mypage.repository.UserNotificationSettingRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 알림 설정 첫 생성 시 동시 요청 race를 방어하는 별도 트랜잭션 컴포넌트
+ *
+ * - {@code user_notification_settings.user_id} UNIQUE 제약 위반(동시 INSERT)을 catch
+ * - REQUIRES_NEW로 격리된 트랜잭션 안에서만 INSERT/재조회가 일어나므로 호출 측 트랜잭션은 rollback-only 마크되지 않음
+ */
+@Component
+@RequiredArgsConstructor
+public class UserNotificationSettingCreator {
+
+    private final UserNotificationSettingRepository userNotificationSettingRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public UserNotificationSetting createIfAbsent(Long userId) {
+        try {
+            return userNotificationSettingRepository.saveAndFlush(UserNotificationSetting.createDefault(userId));
+        } catch (DataIntegrityViolationException e) {
+            return userNotificationSettingRepository.findByUserId(userId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "알림 설정 조회 실패", e));
+        }
+    }
+}

--- a/src/main/resources/db/migration/V7__create_user_notification_settings.sql
+++ b/src/main/resources/db/migration/V7__create_user_notification_settings.sql
@@ -1,0 +1,22 @@
+CREATE TABLE user_notification_settings (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    fcm_token VARCHAR(255) NULL COMMENT 'FCM 푸시 토큰',
+    is_activity_enabled TINYINT(1) NOT NULL DEFAULT 1 COMMENT '활동 알림 여부',
+    is_update_enabled TINYINT(1) NOT NULL DEFAULT 1 COMMENT '업데이트 알림 여부',
+    is_review_enabled TINYINT(1) NOT NULL DEFAULT 1 COMMENT '복습 알림 여부',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_user_notification_settings_user_id (user_id),
+
+    CONSTRAINT fk_user_notification_settings_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT chk_user_notification_settings_activity_enabled
+        CHECK (is_activity_enabled IN (0, 1)),
+    CONSTRAINT chk_user_notification_settings_update_enabled
+        CHECK (is_update_enabled IN (0, 1)),
+    CONSTRAINT chk_user_notification_settings_review_enabled
+        CHECK (is_review_enabled IN (0, 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 알림 설정';

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyNotificationServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyNotificationServiceTest.java
@@ -1,0 +1,165 @@
+package com.f1.quiket.domain.mypage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.mypage.dto.FcmTokenUpdateRequest;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsResponse;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsUpdateRequest;
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import com.f1.quiket.domain.mypage.repository.UserNotificationSettingRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class MyNotificationServiceTest {
+
+    private UserRepository userRepository;
+    private UserNotificationSettingRepository userNotificationSettingRepository;
+    private MyNotificationService myNotificationService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userNotificationSettingRepository = mock(UserNotificationSettingRepository.class);
+        myNotificationService = new MyNotificationService(userRepository, userNotificationSettingRepository);
+    }
+
+    @Test
+    void getNotificationSettings_creates_default_when_missing() {
+        User user = user();
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
+        when(userNotificationSettingRepository.save(any(UserNotificationSetting.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        NotificationSettingsResponse response = myNotificationService.getNotificationSettings(user.getPublicId());
+
+        assertThat(response.isFcmTokenRegistered()).isFalse();
+        assertThat(response.isActivityEnabled()).isTrue();
+        assertThat(response.isUpdateEnabled()).isTrue();
+        assertThat(response.isReviewEnabled()).isTrue();
+
+        ArgumentCaptor<UserNotificationSetting> settingCaptor =
+                ArgumentCaptor.forClass(UserNotificationSetting.class);
+        verify(userNotificationSettingRepository).save(settingCaptor.capture());
+        assertThat(settingCaptor.getValue().getUserId()).isEqualTo(user.getId());
+    }
+
+    @Test
+    void getNotificationSettings_returns_existing_settings() {
+        User user = user();
+        UserNotificationSetting setting = UserNotificationSetting.createDefault(user.getId());
+        setting.updateSettings(false, true, false);
+        setting.updateFcmToken("fcm-token");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.of(setting));
+
+        NotificationSettingsResponse response = myNotificationService.getNotificationSettings(user.getPublicId());
+
+        assertThat(response.isFcmTokenRegistered()).isTrue();
+        assertThat(response.isActivityEnabled()).isFalse();
+        assertThat(response.isUpdateEnabled()).isTrue();
+        assertThat(response.isReviewEnabled()).isFalse();
+    }
+
+    @Test
+    void updateNotificationSettings_updates_existing_settings() {
+        User user = user();
+        UserNotificationSetting setting = UserNotificationSetting.createDefault(user.getId());
+        NotificationSettingsUpdateRequest request = notificationSettingsUpdateRequest(false, false, true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.of(setting));
+
+        NotificationSettingsResponse response = myNotificationService.updateNotificationSettings(
+                user.getPublicId(),
+                request
+        );
+
+        assertThat(setting.isActivityEnabled()).isFalse();
+        assertThat(setting.isUpdateEnabled()).isFalse();
+        assertThat(setting.isReviewEnabled()).isTrue();
+        assertThat(response.isActivityEnabled()).isFalse();
+        assertThat(response.isUpdateEnabled()).isFalse();
+        assertThat(response.isReviewEnabled()).isTrue();
+    }
+
+    @Test
+    void updateFcmToken_updates_existing_token() {
+        User user = user();
+        UserNotificationSetting setting = UserNotificationSetting.createDefault(user.getId());
+        FcmTokenUpdateRequest request = fcmTokenUpdateRequest("new-fcm-token");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.of(setting));
+
+        myNotificationService.updateFcmToken(user.getPublicId(), request);
+
+        assertThat(setting.getFcmToken()).isEqualTo("new-fcm-token");
+    }
+
+    @Test
+    void updateFcmToken_creates_default_when_setting_missing() {
+        User user = user();
+        FcmTokenUpdateRequest request = fcmTokenUpdateRequest("new-fcm-token");
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
+        when(userNotificationSettingRepository.save(any(UserNotificationSetting.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        myNotificationService.updateFcmToken(user.getPublicId(), request);
+
+        ArgumentCaptor<UserNotificationSetting> settingCaptor =
+                ArgumentCaptor.forClass(UserNotificationSetting.class);
+        verify(userNotificationSettingRepository).save(settingCaptor.capture());
+        assertThat(settingCaptor.getValue().getUserId()).isEqualTo(user.getId());
+        assertThat(settingCaptor.getValue().getFcmToken()).isEqualTo("new-fcm-token");
+    }
+
+    @Test
+    void getNotificationSettings_throws_not_found_when_user_missing() {
+        String userPublicId = "018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901";
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> myNotificationService.getNotificationSettings(userPublicId))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
+    }
+
+    private User user() {
+        User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return user;
+    }
+
+    private NotificationSettingsUpdateRequest notificationSettingsUpdateRequest(
+            boolean activityEnabled,
+            boolean updateEnabled,
+            boolean reviewEnabled
+    ) {
+        NotificationSettingsUpdateRequest request = new NotificationSettingsUpdateRequest();
+        ReflectionTestUtils.setField(request, "activityEnabled", activityEnabled);
+        ReflectionTestUtils.setField(request, "updateEnabled", updateEnabled);
+        ReflectionTestUtils.setField(request, "reviewEnabled", reviewEnabled);
+        return request;
+    }
+
+    private FcmTokenUpdateRequest fcmTokenUpdateRequest(String fcmToken) {
+        FcmTokenUpdateRequest request = new FcmTokenUpdateRequest();
+        ReflectionTestUtils.setField(request, "fcmToken", fcmToken);
+        return request;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyNotificationServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyNotificationServiceTest.java
@@ -20,20 +20,25 @@ import com.f1.quiket.global.response.ErrorCode;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class MyNotificationServiceTest {
 
     private UserRepository userRepository;
     private UserNotificationSettingRepository userNotificationSettingRepository;
+    private UserNotificationSettingCreator userNotificationSettingCreator;
     private MyNotificationService myNotificationService;
 
     @BeforeEach
     void setUp() {
         userRepository = mock(UserRepository.class);
         userNotificationSettingRepository = mock(UserNotificationSettingRepository.class);
-        myNotificationService = new MyNotificationService(userRepository, userNotificationSettingRepository);
+        userNotificationSettingCreator = mock(UserNotificationSettingCreator.class);
+        myNotificationService = new MyNotificationService(
+                userRepository,
+                userNotificationSettingRepository,
+                userNotificationSettingCreator
+        );
     }
 
     @Test
@@ -109,19 +114,33 @@ class MyNotificationServiceTest {
     @Test
     void updateFcmToken_creates_default_when_setting_missing() {
         User user = user();
+        UserNotificationSetting createdSetting = UserNotificationSetting.createDefault(user.getId());
         FcmTokenUpdateRequest request = fcmTokenUpdateRequest("new-fcm-token");
+
         when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
         when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
-        when(userNotificationSettingRepository.save(any(UserNotificationSetting.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(userNotificationSettingCreator.createIfAbsent(user.getId())).thenReturn(createdSetting);
 
         myNotificationService.updateFcmToken(user.getPublicId(), request);
 
-        ArgumentCaptor<UserNotificationSetting> settingCaptor =
-                ArgumentCaptor.forClass(UserNotificationSetting.class);
-        verify(userNotificationSettingRepository).save(settingCaptor.capture());
-        assertThat(settingCaptor.getValue().getUserId()).isEqualTo(user.getId());
-        assertThat(settingCaptor.getValue().getFcmToken()).isEqualTo("new-fcm-token");
+        assertThat(createdSetting.getFcmToken()).isEqualTo("new-fcm-token");
+    }
+
+    @Test
+    void updateFcmToken_recovers_when_concurrent_create_conflicts() {
+        // 다른 트랜잭션이 먼저 INSERT한 setting을 creator가 catch & re-fetch로 반환하는 시나리오
+        User user = user();
+        UserNotificationSetting concurrentlyCreatedSetting = UserNotificationSetting.createDefault(user.getId());
+        FcmTokenUpdateRequest request = fcmTokenUpdateRequest("new-fcm-token");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
+        when(userNotificationSettingCreator.createIfAbsent(user.getId())).thenReturn(concurrentlyCreatedSetting);
+
+        myNotificationService.updateFcmToken(user.getPublicId(), request);
+
+        assertThat(concurrentlyCreatedSetting.getFcmToken()).isEqualTo("new-fcm-token");
+        verify(userNotificationSettingCreator).createIfAbsent(user.getId());
     }
 
     @Test

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyNotificationServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyNotificationServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,12 +37,10 @@ class MyNotificationServiceTest {
     }
 
     @Test
-    void getNotificationSettings_creates_default_when_missing() {
+    void getNotificationSettings_returns_default_without_insert_when_missing() {
         User user = user();
         when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
         when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
-        when(userNotificationSettingRepository.save(any(UserNotificationSetting.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
 
         NotificationSettingsResponse response = myNotificationService.getNotificationSettings(user.getPublicId());
 
@@ -49,11 +48,8 @@ class MyNotificationServiceTest {
         assertThat(response.isActivityEnabled()).isTrue();
         assertThat(response.isUpdateEnabled()).isTrue();
         assertThat(response.isReviewEnabled()).isTrue();
-
-        ArgumentCaptor<UserNotificationSetting> settingCaptor =
-                ArgumentCaptor.forClass(UserNotificationSetting.class);
-        verify(userNotificationSettingRepository).save(settingCaptor.capture());
-        assertThat(settingCaptor.getValue().getUserId()).isEqualTo(user.getId());
+        // GET은 read-only — 첫 호출에도 INSERT 발생하지 않아야 함
+        verify(userNotificationSettingRepository, never()).save(any(UserNotificationSetting.class));
     }
 
     @Test

--- a/src/test/java/com/f1/quiket/domain/mypage/service/UserNotificationSettingCreatorTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/UserNotificationSettingCreatorTest.java
@@ -1,0 +1,74 @@
+package com.f1.quiket.domain.mypage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import com.f1.quiket.domain.mypage.repository.UserNotificationSettingRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+class UserNotificationSettingCreatorTest {
+
+    private UserNotificationSettingRepository userNotificationSettingRepository;
+    private UserNotificationSettingCreator userNotificationSettingCreator;
+
+    @BeforeEach
+    void setUp() {
+        userNotificationSettingRepository = mock(UserNotificationSettingRepository.class);
+        userNotificationSettingCreator = new UserNotificationSettingCreator(userNotificationSettingRepository);
+    }
+
+    @Test
+    void createIfAbsent_returns_saved_setting_when_insert_succeeds() {
+        Long userId = 1L;
+        when(userNotificationSettingRepository.saveAndFlush(any(UserNotificationSetting.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserNotificationSetting result = userNotificationSettingCreator.createIfAbsent(userId);
+
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.isActivityEnabled()).isTrue();
+        assertThat(result.isUpdateEnabled()).isTrue();
+        assertThat(result.isReviewEnabled()).isTrue();
+    }
+
+    @Test
+    void createIfAbsent_recovers_via_refetch_when_unique_constraint_violated() {
+        // 다른 트랜잭션이 먼저 INSERT한 상태를 시뮬레이션
+        Long userId = 1L;
+        UserNotificationSetting concurrentlyCreatedSetting = UserNotificationSetting.createDefault(userId);
+
+        when(userNotificationSettingRepository.saveAndFlush(any(UserNotificationSetting.class)))
+                .thenThrow(new DataIntegrityViolationException("uq_user_notification_settings_user_id"));
+        when(userNotificationSettingRepository.findByUserId(userId))
+                .thenReturn(Optional.of(concurrentlyCreatedSetting));
+
+        UserNotificationSetting result = userNotificationSettingCreator.createIfAbsent(userId);
+
+        assertThat(result).isSameAs(concurrentlyCreatedSetting);
+        verify(userNotificationSettingRepository).findByUserId(userId);
+    }
+
+    @Test
+    void createIfAbsent_throws_internal_error_when_refetch_returns_empty() {
+        // 매우 드문 케이스 — INSERT 실패 후 재조회도 비어있으면 일관성 깨진 상태
+        Long userId = 1L;
+        when(userNotificationSettingRepository.saveAndFlush(any(UserNotificationSetting.class)))
+                .thenThrow(new DataIntegrityViolationException("uq_user_notification_settings_user_id"));
+        when(userNotificationSettingRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userNotificationSettingCreator.createIfAbsent(userId))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- MY-002 마이페이지 알림 설정 조회/수정과 FCM 토큰 등록 API를 구현했습니다

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- GET /api/v1/my/notifications 구현
- PUT /api/v1/my/notifications 구현
- PUT /api/v1/my/fcm-token 구현
- user_notification_settings 엔티티 및 리포지토리 추가
- user_notification_settings Flyway 마이그레이션 추가
- 알림 설정 요청/응답 DTO 추가
- 알림 설정 서비스 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. ./gradlew test --tests com.f1.quiket.domain.mypage.service.MyNotificationServiceTest
2. ./gradlew test
3. ./gradlew check

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #69

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 설정 레코드가 없으면 기본 ON 상태로 생성합니다
- FCM 토큰은 사용자별 최신 토큰 1개를 저장합니다

---

## 🧑‍💻 Assignee

- @imclaremont