### PR TITLE
[Feat] 피드백 문의 제출 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/mypage/controller/FeedbackController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/FeedbackController.java
@@ -1,0 +1,34 @@
+package com.f1.quiket.domain.mypage.controller;
+
+import com.f1.quiket.domain.mypage.dto.FeedbackCreateRequest;
+import com.f1.quiket.domain.mypage.dto.FeedbackResponse;
+import com.f1.quiket.domain.mypage.service.FeedbackService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/feedbacks")
+public class FeedbackController {
+
+    private final FeedbackService feedbackService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<FeedbackResponse>> createFeedback(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody FeedbackCreateRequest request
+    ) {
+        FeedbackResponse response = feedbackService.createFeedback(principal.getPublicId(), request);
+        return ResponseEntity.status(SuccessCode.CREATED.getStatus())
+                .body(ApiResponse.success(SuccessCode.CREATED, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/FeedbackCreateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/FeedbackCreateRequest.java
@@ -1,0 +1,34 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FeedbackCreateRequest {
+
+    @NotBlank(message = "피드백 카테고리는 필수입니다")
+    @Pattern(regexp = "feature|bug|inquiry|other", message = "피드백 카테고리가 올바르지 않습니다")
+    private String category;
+
+    @NotBlank(message = "피드백 내용은 필수입니다")
+    @Size(max = 1000, message = "피드백 내용은 1000자 이하여야 합니다")
+    private String body;
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @Size(max = 255, message = "회신 이메일은 255자 이하여야 합니다")
+    private String replyEmail;
+
+    @Size(max = 20, message = "앱 버전은 20자 이하여야 합니다")
+    private String appVersion;
+
+    @Size(max = 50, message = "OS 버전은 50자 이하여야 합니다")
+    private String osVersion;
+
+    @Size(max = 100, message = "디바이스 모델은 100자 이하여야 합니다")
+    private String deviceModel;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/FeedbackResponse.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/FeedbackResponse.java
@@ -1,0 +1,33 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import com.f1.quiket.domain.mypage.entity.UserFeedback;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FeedbackResponse {
+
+    private final String id;
+    private final String category;
+    private final String body;
+    private final String replyEmail;
+    private final String appVersion;
+    private final String osVersion;
+    private final String deviceModel;
+    private final LocalDateTime createdAt;
+
+    public static FeedbackResponse from(UserFeedback feedback) {
+        return FeedbackResponse.builder()
+                .id(feedback.getId().toString())
+                .category(feedback.getCategory())
+                .body(feedback.getBody())
+                .replyEmail(feedback.getReplyEmail())
+                .appVersion(feedback.getAppVersion())
+                .osVersion(feedback.getOsVersion())
+                .deviceModel(feedback.getDeviceModel())
+                .createdAt(feedback.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/entity/UserFeedback.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/entity/UserFeedback.java
@@ -36,7 +36,7 @@ public class UserFeedback {
     @Column(name = "id")
     Long id;
 
-    @Column(name = "user_id")
+    @Column(name = "user_id", nullable = false)
     Long userId;
 
     @Column(name = "category", length = 20, nullable = false)

--- a/src/main/java/com/f1/quiket/domain/mypage/entity/UserFeedback.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/entity/UserFeedback.java
@@ -1,0 +1,75 @@
+package com.f1.quiket.domain.mypage.entity;
+
+import com.f1.quiket.domain.mypage.dto.FeedbackCreateRequest;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "user_feedbacks",
+        indexes = {
+                @Index(name = "idx_user_feedbacks_user_id", columnList = "user_id"),
+                @Index(name = "idx_user_feedbacks_category_created_at", columnList = "category, created_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserFeedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "user_id")
+    Long userId;
+
+    @Column(name = "category", length = 20, nullable = false)
+    String category;
+
+    @Column(name = "body", length = 1000, nullable = false)
+    String body;
+
+    @Column(name = "reply_email", length = 255)
+    String replyEmail;
+
+    @Column(name = "app_version", length = 20)
+    String appVersion;
+
+    @Column(name = "os_version", length = 50)
+    String osVersion;
+
+    @Column(name = "device_model", length = 100)
+    String deviceModel;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    LocalDateTime createdAt;
+
+    public static UserFeedback create(Long userId, FeedbackCreateRequest request) {
+        UserFeedback feedback = new UserFeedback();
+        feedback.userId = userId;
+        feedback.category = request.getCategory();
+        feedback.body = request.getBody();
+        feedback.replyEmail = request.getReplyEmail();
+        feedback.appVersion = request.getAppVersion();
+        feedback.osVersion = request.getOsVersion();
+        feedback.deviceModel = request.getDeviceModel();
+        return feedback;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/repository/UserFeedbackRepository.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/repository/UserFeedbackRepository.java
@@ -1,0 +1,9 @@
+package com.f1.quiket.domain.mypage.repository;
+
+import com.f1.quiket.domain.mypage.entity.UserFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserFeedbackRepository extends JpaRepository<UserFeedback, Long> {
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/FeedbackService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/FeedbackService.java
@@ -1,0 +1,33 @@
+package com.f1.quiket.domain.mypage.service;
+
+import com.f1.quiket.domain.mypage.dto.FeedbackCreateRequest;
+import com.f1.quiket.domain.mypage.dto.FeedbackResponse;
+import com.f1.quiket.domain.mypage.entity.UserFeedback;
+import com.f1.quiket.domain.mypage.repository.UserFeedbackRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FeedbackService {
+
+    private final UserRepository userRepository;
+    private final UserFeedbackRepository userFeedbackRepository;
+
+    public FeedbackResponse createFeedback(String userPublicId, FeedbackCreateRequest request) {
+        User user = findActiveUser(userPublicId);
+        UserFeedback feedback = userFeedbackRepository.save(UserFeedback.create(user.getId(), request));
+        return FeedbackResponse.from(feedback);
+    }
+
+    private User findActiveUser(String userPublicId) {
+        return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+}

--- a/src/main/resources/db/migration/V8__create_user_feedbacks.sql
+++ b/src/main/resources/db/migration/V8__create_user_feedbacks.sql
@@ -1,0 +1,22 @@
+CREATE TABLE user_feedbacks (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    user_id BIGINT NULL COMMENT '사용자 ID',
+    category VARCHAR(20) NOT NULL COMMENT '카테고리: feature / bug / inquiry / other',
+    body VARCHAR(1000) NOT NULL COMMENT '본문',
+    reply_email VARCHAR(255) NULL COMMENT '회신 이메일',
+    app_version VARCHAR(20) NULL COMMENT '앱 버전',
+    os_version VARCHAR(50) NULL COMMENT 'OS 버전',
+    device_model VARCHAR(100) NULL COMMENT '디바이스 모델',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '제출 시각',
+
+    PRIMARY KEY (id),
+    KEY idx_user_feedbacks_user_id (user_id),
+    KEY idx_user_feedbacks_category_created_at (category, created_at),
+
+    CONSTRAINT fk_user_feedbacks_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT chk_user_feedbacks_category
+        CHECK (category IN ('feature', 'bug', 'inquiry', 'other')),
+    CONSTRAINT chk_user_feedbacks_body_length
+        CHECK (CHAR_LENGTH(body) BETWEEN 1 AND 1000)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 피드백/문의';

--- a/src/main/resources/db/migration/V8__create_user_feedbacks.sql
+++ b/src/main/resources/db/migration/V8__create_user_feedbacks.sql
@@ -1,6 +1,6 @@
 CREATE TABLE user_feedbacks (
     id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
-    user_id BIGINT NULL COMMENT '사용자 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID (인증 엔드포인트 — 항상 존재)',
     category VARCHAR(20) NOT NULL COMMENT '카테고리: feature / bug / inquiry / other',
     body VARCHAR(1000) NOT NULL COMMENT '본문',
     reply_email VARCHAR(255) NULL COMMENT '회신 이메일',

--- a/src/test/java/com/f1/quiket/domain/mypage/service/FeedbackServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/FeedbackServiceTest.java
@@ -1,0 +1,104 @@
+package com.f1.quiket.domain.mypage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.mypage.dto.FeedbackCreateRequest;
+import com.f1.quiket.domain.mypage.dto.FeedbackResponse;
+import com.f1.quiket.domain.mypage.entity.UserFeedback;
+import com.f1.quiket.domain.mypage.repository.UserFeedbackRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class FeedbackServiceTest {
+
+    private UserRepository userRepository;
+    private UserFeedbackRepository userFeedbackRepository;
+    private FeedbackService feedbackService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userFeedbackRepository = mock(UserFeedbackRepository.class);
+        feedbackService = new FeedbackService(userRepository, userFeedbackRepository);
+    }
+
+    @Test
+    void createFeedback_saves_feedback_and_returns_response() {
+        User user = user();
+        FeedbackCreateRequest request = feedbackCreateRequest();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 5, 25, 9, 30);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userFeedbackRepository.save(any(UserFeedback.class)))
+                .thenAnswer(invocation -> {
+                    UserFeedback feedback = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(feedback, "id", 10L);
+                    ReflectionTestUtils.setField(feedback, "createdAt", createdAt);
+                    return feedback;
+                });
+
+        FeedbackResponse response = feedbackService.createFeedback(user.getPublicId(), request);
+
+        assertThat(response.getId()).isEqualTo("10");
+        assertThat(response.getCategory()).isEqualTo("feature");
+        assertThat(response.getBody()).isEqualTo("퀴즈 결과 화면에서 복습 알림을 받을 수 있으면 좋겠어요.");
+        assertThat(response.getReplyEmail()).isEqualTo("user@example.com");
+        assertThat(response.getAppVersion()).isEqualTo("1.0.0");
+        assertThat(response.getOsVersion()).isEqualTo("Android 15");
+        assertThat(response.getDeviceModel()).isEqualTo("Galaxy S24");
+        assertThat(response.getCreatedAt()).isEqualTo(createdAt);
+
+        ArgumentCaptor<UserFeedback> feedbackCaptor = ArgumentCaptor.forClass(UserFeedback.class);
+        verify(userFeedbackRepository).save(feedbackCaptor.capture());
+        UserFeedback savedFeedback = feedbackCaptor.getValue();
+        assertThat(savedFeedback.getUserId()).isEqualTo(user.getId());
+        assertThat(savedFeedback.getCategory()).isEqualTo("feature");
+        assertThat(savedFeedback.getBody()).isEqualTo("퀴즈 결과 화면에서 복습 알림을 받을 수 있으면 좋겠어요.");
+        assertThat(savedFeedback.getReplyEmail()).isEqualTo("user@example.com");
+        assertThat(savedFeedback.getAppVersion()).isEqualTo("1.0.0");
+        assertThat(savedFeedback.getOsVersion()).isEqualTo("Android 15");
+        assertThat(savedFeedback.getDeviceModel()).isEqualTo("Galaxy S24");
+    }
+
+    @Test
+    void createFeedback_throws_not_found_when_user_missing() {
+        String userPublicId = "018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901";
+        FeedbackCreateRequest request = feedbackCreateRequest();
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> feedbackService.createFeedback(userPublicId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
+    }
+
+    private User user() {
+        User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return user;
+    }
+
+    private FeedbackCreateRequest feedbackCreateRequest() {
+        FeedbackCreateRequest request = new FeedbackCreateRequest();
+        ReflectionTestUtils.setField(request, "category", "feature");
+        ReflectionTestUtils.setField(request, "body", "퀴즈 결과 화면에서 복습 알림을 받을 수 있으면 좋겠어요.");
+        ReflectionTestUtils.setField(request, "replyEmail", "user@example.com");
+        ReflectionTestUtils.setField(request, "appVersion", "1.0.0");
+        ReflectionTestUtils.setField(request, "osVersion", "Android 15");
+        ReflectionTestUtils.setField(request, "deviceModel", "Galaxy S24");
+        return request;
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- MY-003 피드백/문의 제출 API 구현

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `POST /api/v1/feedbacks` 구현
- `user_feedbacks` 엔티티/리포지토리 추가
- `user_feedbacks` Flyway migration 추가
- 피드백 요청 검증 및 응답 DTO 추가
- 피드백 서비스 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.domain.mypage.service.FeedbackServiceTest`
2. `./gradlew test`
3. `./gradlew check`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #71

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 인증 사용자 기준으로 `user_feedbacks.user_id` 저장
- API 명세의 `/api/v1/feedbacks` 경로와 `FeedbackCreateRequest`, `FeedbackResponse` 계약 기준 구현

---

## 🧑‍💻 Assignee

- @imclaremont
