### PR TITLE
[Chore] 두 번째 운영 배포

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,20 @@ return ResponseEntity.status(errorCode.getStatus())
 - 서로 다른 목적의 변경은 논리 단위별로 커밋 분리
 - 리뷰와 롤백이 쉬운 단위로 커밋 작성
 
+### 머지 전략
+
+- 작업 브랜치(`type/#issue-number-description`, 예: `feat/#123-login-api`) → `develop`: Squash merge 사용
+- `develop` → `main`: Merge commit 사용
+- 작업 브랜치 내부 커밋은 리뷰 편의를 위해 원자적으로 작성
+- `main` 병합 커밋은 릴리즈 단위 추적 목적
+
+### Git 메시지 컨벤션
+
+- 커밋 메시지: `type: 한국어 핵심`
+- PR 제목: `[Type] 한국어 핵심`
+- Squash merge 커밋 메시지: `type: 한국어 핵심 (#PR번호)`
+- `develop` → `main` Merge commit 메시지: `[Release] 버전/날짜 배포`
+
 ### 이슈 및 PR 제목
 
 - 형식: `[Type] 제목`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,7 +190,7 @@ return ResponseEntity.status(errorCode.getStatus())
 
 - 커밋 메시지: `type: 한국어 핵심`
 - PR 제목: `[Type] 한국어 핵심`
-- Squash merge 커밋 메시지: `type: 한국어 핵심 (#PR번호)`
+- Squash merge 커밋 메시지: `[Type] 한국어 핵심 (#PR번호)`
 - `develop` → `main` Merge commit 메시지: `[Release] 버전/날짜 배포`
 
 ### 이슈 및 PR 제목

--- a/src/main/java/com/f1/quiket/domain/mypage/controller/FeedbackController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/FeedbackController.java
@@ -1,0 +1,34 @@
+package com.f1.quiket.domain.mypage.controller;
+
+import com.f1.quiket.domain.mypage.dto.FeedbackCreateRequest;
+import com.f1.quiket.domain.mypage.dto.FeedbackResponse;
+import com.f1.quiket.domain.mypage.service.FeedbackService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/feedbacks")
+public class FeedbackController {
+
+    private final FeedbackService feedbackService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<FeedbackResponse>> createFeedback(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody FeedbackCreateRequest request
+    ) {
+        FeedbackResponse response = feedbackService.createFeedback(principal.getPublicId(), request);
+        return ResponseEntity.status(SuccessCode.CREATED.getStatus())
+                .body(ApiResponse.success(SuccessCode.CREATED, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -1,0 +1,51 @@
+package com.f1.quiket.domain.mypage.controller;
+
+import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
+import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.mypage.service.MyPageService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 마이페이지 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/my")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    /**
+     * 마이페이지 계정 정보 조회
+     */
+    @GetMapping("/profile")
+    public ResponseEntity<ApiResponse<MyProfileResponse>> getMyProfile(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        MyProfileResponse response = myPageService.getMyProfile(principal.getPublicId());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 닉네임 변경
+     */
+    @PatchMapping("/profile/nickname")
+    public ResponseEntity<ApiResponse<MyProfileResponse>> updateNickname(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody NicknameUpdateRequest request
+    ) {
+        MyProfileResponse response = myPageService.updateNickname(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -1,12 +1,16 @@
 package com.f1.quiket.domain.mypage.controller;
 
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.mypage.dto.FcmTokenUpdateRequest;
 import com.f1.quiket.domain.mypage.dto.MyAccountDeleteRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsResponse;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsUpdateRequest;
+import com.f1.quiket.domain.mypage.service.MyNotificationService;
 import com.f1.quiket.domain.mypage.service.MyPageService;
 import com.f1.quiket.global.auth.UserPrincipal;
 import com.f1.quiket.global.response.ApiResponse;
@@ -18,6 +22,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MyPageController {
 
     private final MyPageService myPageService;
+    private final MyNotificationService myNotificationService;
 
     /**
      * 마이페이지 계정 정보 조회
@@ -91,6 +97,35 @@ public class MyPageController {
             @Valid @RequestBody MyAccountDeleteRequest request
     ) {
         myPageService.deleteAccount(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
+    }
+
+    @GetMapping("/notifications")
+    public ResponseEntity<ApiResponse<NotificationSettingsResponse>> getNotificationSettings(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        NotificationSettingsResponse response = myNotificationService.getNotificationSettings(principal.getPublicId());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    @PutMapping("/notifications")
+    public ResponseEntity<ApiResponse<NotificationSettingsResponse>> updateNotificationSettings(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody NotificationSettingsUpdateRequest request
+    ) {
+        NotificationSettingsResponse response = myNotificationService.updateNotificationSettings(
+                principal.getPublicId(),
+                request
+        );
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    @PutMapping("/fcm-token")
+    public ResponseEntity<ApiResponse<Void>> updateFcmToken(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody FcmTokenUpdateRequest request
+    ) {
+        myNotificationService.updateFcmToken(principal.getPublicId(), request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.mypage.controller;
 
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.mypage.dto.MyAccountDeleteRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
@@ -81,6 +82,15 @@ public class MyPageController {
             @Valid @RequestBody MyPasswordChangeRequest request
     ) {
         myPageService.updatePassword(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
+    }
+
+    @PostMapping("/account/deletion")
+    public ResponseEntity<ApiResponse<Void>> deleteMyAccount(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody MyAccountDeleteRequest request
+    ) {
+        myPageService.deleteAccount(principal.getPublicId(), request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -3,6 +3,7 @@ package com.f1.quiket.domain.mypage.controller;
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
+import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
 import com.f1.quiket.domain.mypage.service.MyPageService;
@@ -69,5 +70,17 @@ public class MyPageController {
     ) {
         MyProfileResponse response = myPageService.confirmEmailChange(principal.getPublicId(), request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 비밀번호 변경
+     */
+    @PatchMapping("/password")
+    public ResponseEntity<ApiResponse<Void>> updatePassword(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody MyPasswordChangeRequest request
+    ) {
+        myPageService.updatePassword(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/controller/MyPageController.java
@@ -1,5 +1,8 @@
 package com.f1.quiket.domain.mypage.controller;
 
+import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
 import com.f1.quiket.domain.mypage.service.MyPageService;
@@ -12,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -46,6 +50,24 @@ public class MyPageController {
             @Valid @RequestBody NicknameUpdateRequest request
     ) {
         MyProfileResponse response = myPageService.updateNickname(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    @PostMapping("/email/change-requests")
+    public ResponseEntity<ApiResponse<EmailVerificationSentResponse>> requestEmailChange(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody MyEmailChangeRequest request
+    ) {
+        EmailVerificationSentResponse response = myPageService.requestEmailChange(principal.getPublicId(), request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    @PostMapping("/email/change-confirm")
+    public ResponseEntity<ApiResponse<MyProfileResponse>> confirmEmailChange(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody MyEmailChangeConfirmRequest request
+    ) {
+        MyProfileResponse response = myPageService.confirmEmailChange(principal.getPublicId(), request);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/FcmTokenUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/FcmTokenUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FcmTokenUpdateRequest {
+
+    @NotBlank(message = "FCM 토큰은 필수입니다")
+    @Size(max = 255, message = "FCM 토큰은 255자 이하여야 합니다")
+    private String fcmToken;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/FeedbackCreateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/FeedbackCreateRequest.java
@@ -1,0 +1,34 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class FeedbackCreateRequest {
+
+    @NotBlank(message = "피드백 카테고리는 필수입니다")
+    @Pattern(regexp = "feature|bug|inquiry|other", message = "피드백 카테고리가 올바르지 않습니다")
+    private String category;
+
+    @NotBlank(message = "피드백 내용은 필수입니다")
+    @Size(max = 1000, message = "피드백 내용은 1000자 이하여야 합니다")
+    private String body;
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @Size(max = 255, message = "회신 이메일은 255자 이하여야 합니다")
+    private String replyEmail;
+
+    @Size(max = 20, message = "앱 버전은 20자 이하여야 합니다")
+    private String appVersion;
+
+    @Size(max = 50, message = "OS 버전은 50자 이하여야 합니다")
+    private String osVersion;
+
+    @Size(max = 100, message = "디바이스 모델은 100자 이하여야 합니다")
+    private String deviceModel;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/FeedbackResponse.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/FeedbackResponse.java
@@ -1,0 +1,33 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import com.f1.quiket.domain.mypage.entity.UserFeedback;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FeedbackResponse {
+
+    private final String id;
+    private final String category;
+    private final String body;
+    private final String replyEmail;
+    private final String appVersion;
+    private final String osVersion;
+    private final String deviceModel;
+    private final LocalDateTime createdAt;
+
+    public static FeedbackResponse from(UserFeedback feedback) {
+        return FeedbackResponse.builder()
+                .id(feedback.getId().toString())
+                .category(feedback.getCategory())
+                .body(feedback.getBody())
+                .replyEmail(feedback.getReplyEmail())
+                .appVersion(feedback.getAppVersion())
+                .osVersion(feedback.getOsVersion())
+                .deviceModel(feedback.getDeviceModel())
+                .createdAt(feedback.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/MyAccountDeleteRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/MyAccountDeleteRequest.java
@@ -1,0 +1,15 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyAccountDeleteRequest {
+
+    private String password;
+
+    @AssertTrue(message = "회원 탈퇴 동의는 필수입니다")
+    private boolean agreedToDelete;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/MyEmailChangeConfirmRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/MyEmailChangeConfirmRequest.java
@@ -1,0 +1,22 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyEmailChangeConfirmRequest {
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수입니다")
+    @Size(max = 255, message = "이메일은 255자 이하여야 합니다")
+    private String newEmail;
+
+    @NotBlank(message = "인증 코드는 필수입니다")
+    @Pattern(regexp = "^\\d{6}$", message = "인증 코드는 6자리 숫자여야 합니다")
+    private String verificationCode;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/MyEmailChangeRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/MyEmailChangeRequest.java
@@ -1,0 +1,17 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyEmailChangeRequest {
+
+    @Email(message = "올바른 이메일 형식이 아닙니다")
+    @NotBlank(message = "이메일은 필수입니다")
+    @Size(max = 255, message = "이메일은 255자 이하여야 합니다")
+    private String newEmail;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/MyPasswordChangeRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/MyPasswordChangeRequest.java
@@ -1,0 +1,26 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MyPasswordChangeRequest {
+
+    @NotBlank(message = "현재 비밀번호는 필수입니다")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호는 필수입니다")
+    @Size(min = 8, max = 32, message = "새 비밀번호는 8자 이상 32자 이하여야 합니다")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z0-9~!@#$%^&*()_+=\\[\\]{}.,?-]{8,32}$",
+            message = "새 비밀번호는 영문과 숫자를 포함하고 공백 없이 허용된 문자만 사용할 수 있습니다")
+    private String newPassword;
+
+    @NotBlank(message = "새 비밀번호 확인은 필수입니다")
+    @Size(min = 8, max = 32, message = "새 비밀번호 확인은 8자 이상 32자 이하여야 합니다")
+    private String newPasswordConfirm;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/MyProfileResponse.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/MyProfileResponse.java
@@ -1,0 +1,51 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.user.entity.User;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 마이페이지 계정 정보 응답 DTO (기능명세 MY-001)
+ */
+@Getter
+@Builder
+public class MyProfileResponse {
+
+    // primary 인증 수단 우선, 그 다음 provider명 알파벳순 — 응답 순서 결정성 보장
+    private static final Comparator<UserAuthIdentity> PROVIDER_ORDER =
+            Comparator.comparing(UserAuthIdentity::isPrimary).reversed()
+                    .thenComparing(UserAuthIdentity::getProvider);
+
+    private final String id;
+    private final String email;
+    private final String nickname;
+    private final Integer dotoriBalance;
+    private final boolean emailVerified;
+    private final String status;
+    private final List<String> providers;
+    private final Integer xpTotal;
+    private final Integer currentLevel;
+    private final LocalDateTime createdAt;
+
+    public static MyProfileResponse of(User user, List<UserAuthIdentity> identities) {
+        return MyProfileResponse.builder()
+                .id(user.getPublicId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .dotoriBalance(user.getDotoriBalance())
+                .emailVerified(user.isEmailVerified())
+                .status(user.getStatus())
+                .providers(identities.stream()
+                        .sorted(PROVIDER_ORDER)
+                        .map(UserAuthIdentity::getProvider)
+                        .toList())
+                .xpTotal(user.getXpTotal())
+                .currentLevel(user.getCurrentLevel())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/NicknameUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/NicknameUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NicknameUpdateRequest {
+
+    @NotBlank(message = "닉네임은 필수입니다")
+    @Size(min = 2, max = 12, message = "닉네임은 2자 이상 12자 이하여야 합니다")
+    @Pattern(regexp = "^[가-힣A-Za-z]{2,12}$", message = "닉네임은 한글 또는 영문만 사용할 수 있습니다")
+    private String nickname;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/NotificationSettingsResponse.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/NotificationSettingsResponse.java
@@ -1,0 +1,37 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+@Getter
+@Builder
+public class NotificationSettingsResponse {
+
+    private final boolean fcmTokenRegistered;
+    private final boolean activityEnabled;
+    private final boolean updateEnabled;
+    private final boolean reviewEnabled;
+
+    public static NotificationSettingsResponse from(UserNotificationSetting setting) {
+        return NotificationSettingsResponse.builder()
+                .fcmTokenRegistered(StringUtils.hasText(setting.getFcmToken()))
+                .activityEnabled(setting.isActivityEnabled())
+                .updateEnabled(setting.isUpdateEnabled())
+                .reviewEnabled(setting.isReviewEnabled())
+                .build();
+    }
+
+    /**
+     * 사용자 알림 설정이 아직 생성되지 않은 경우의 기본값 응답 (기능명세 MY-002 — 모두 ON)
+     */
+    public static NotificationSettingsResponse defaults() {
+        return NotificationSettingsResponse.builder()
+                .fcmTokenRegistered(false)
+                .activityEnabled(true)
+                .updateEnabled(true)
+                .reviewEnabled(true)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/dto/NotificationSettingsUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/dto/NotificationSettingsUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.mypage.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NotificationSettingsUpdateRequest {
+
+    @NotNull(message = "활동 알림 설정은 필수입니다")
+    private Boolean activityEnabled;
+
+    @NotNull(message = "업데이트 알림 설정은 필수입니다")
+    private Boolean updateEnabled;
+
+    @NotNull(message = "복습 알림 설정은 필수입니다")
+    private Boolean reviewEnabled;
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/entity/UserFeedback.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/entity/UserFeedback.java
@@ -1,0 +1,75 @@
+package com.f1.quiket.domain.mypage.entity;
+
+import com.f1.quiket.domain.mypage.dto.FeedbackCreateRequest;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "user_feedbacks",
+        indexes = {
+                @Index(name = "idx_user_feedbacks_user_id", columnList = "user_id"),
+                @Index(name = "idx_user_feedbacks_category_created_at", columnList = "category, created_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserFeedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "category", length = 20, nullable = false)
+    String category;
+
+    @Column(name = "body", length = 1000, nullable = false)
+    String body;
+
+    @Column(name = "reply_email", length = 255)
+    String replyEmail;
+
+    @Column(name = "app_version", length = 20)
+    String appVersion;
+
+    @Column(name = "os_version", length = 50)
+    String osVersion;
+
+    @Column(name = "device_model", length = 100)
+    String deviceModel;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    LocalDateTime createdAt;
+
+    public static UserFeedback create(Long userId, FeedbackCreateRequest request) {
+        UserFeedback feedback = new UserFeedback();
+        feedback.userId = userId;
+        feedback.category = request.getCategory();
+        feedback.body = request.getBody();
+        feedback.replyEmail = request.getReplyEmail();
+        feedback.appVersion = request.getAppVersion();
+        feedback.osVersion = request.getOsVersion();
+        feedback.deviceModel = request.getDeviceModel();
+        return feedback;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/entity/UserNotificationSetting.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/entity/UserNotificationSetting.java
@@ -1,0 +1,76 @@
+package com.f1.quiket.domain.mypage.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "user_notification_settings",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_user_notification_settings_user_id", columnNames = "user_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserNotificationSetting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "fcm_token", length = 255)
+    String fcmToken;
+
+    @Column(name = "is_activity_enabled", nullable = false)
+    boolean activityEnabled = true;
+
+    @Column(name = "is_update_enabled", nullable = false)
+    boolean updateEnabled = true;
+
+    @Column(name = "is_review_enabled", nullable = false)
+    boolean reviewEnabled = true;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+
+    public static UserNotificationSetting createDefault(Long userId) {
+        UserNotificationSetting setting = new UserNotificationSetting();
+        setting.userId = userId;
+        return setting;
+    }
+
+    public void updateSettings(boolean activityEnabled, boolean updateEnabled, boolean reviewEnabled) {
+        this.activityEnabled = activityEnabled;
+        this.updateEnabled = updateEnabled;
+        this.reviewEnabled = reviewEnabled;
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/event/MyEmailChangeMailRequestedEvent.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/event/MyEmailChangeMailRequestedEvent.java
@@ -1,0 +1,7 @@
+package com.f1.quiket.domain.mypage.event;
+
+public record MyEmailChangeMailRequestedEvent(
+        String email,
+        String verificationCode
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/repository/UserFeedbackRepository.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/repository/UserFeedbackRepository.java
@@ -1,0 +1,9 @@
+package com.f1.quiket.domain.mypage.repository;
+
+import com.f1.quiket.domain.mypage.entity.UserFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserFeedbackRepository extends JpaRepository<UserFeedback, Long> {
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/repository/UserNotificationSettingRepository.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/repository/UserNotificationSettingRepository.java
@@ -1,0 +1,10 @@
+package com.f1.quiket.domain.mypage.repository;
+
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserNotificationSettingRepository extends JpaRepository<UserNotificationSetting, Long> {
+
+    Optional<UserNotificationSetting> findByUserId(Long userId);
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/FeedbackService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/FeedbackService.java
@@ -1,0 +1,33 @@
+package com.f1.quiket.domain.mypage.service;
+
+import com.f1.quiket.domain.mypage.dto.FeedbackCreateRequest;
+import com.f1.quiket.domain.mypage.dto.FeedbackResponse;
+import com.f1.quiket.domain.mypage.entity.UserFeedback;
+import com.f1.quiket.domain.mypage.repository.UserFeedbackRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FeedbackService {
+
+    private final UserRepository userRepository;
+    private final UserFeedbackRepository userFeedbackRepository;
+
+    public FeedbackResponse createFeedback(String userPublicId, FeedbackCreateRequest request) {
+        User user = findActiveUser(userPublicId);
+        UserFeedback feedback = userFeedbackRepository.save(UserFeedback.create(user.getId(), request));
+        return FeedbackResponse.from(feedback);
+    }
+
+    private User findActiveUser(String userPublicId) {
+        return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyEmailChangeVerificationPayload.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyEmailChangeVerificationPayload.java
@@ -1,0 +1,7 @@
+package com.f1.quiket.domain.mypage.service;
+
+public record MyEmailChangeVerificationPayload(
+        String newEmail,
+        String verificationCode
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyEmailChangeVerificationStore.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyEmailChangeVerificationStore.java
@@ -1,0 +1,89 @@
+package com.f1.quiket.domain.mypage.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@RequiredArgsConstructor
+public class MyEmailChangeVerificationStore {
+
+    private static final String KEY_PREFIX = "my:email-change:";
+    private static final String COOLDOWN_KEY_PREFIX = "my:email-change:cooldown:";
+    private static final String COOLDOWN_VALUE = "1";
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public void save(String userPublicId, MyEmailChangeVerificationPayload payload, long ttlSeconds) {
+        try {
+            stringRedisTemplate.opsForValue()
+                    .set(
+                            buildKey(userPublicId),
+                            objectMapper.writeValueAsString(payload),
+                            Duration.ofSeconds(ttlSeconds)
+                    );
+        } catch (DataAccessException | JsonProcessingException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    public Optional<MyEmailChangeVerificationPayload> find(String userPublicId) {
+        try {
+            String payload = stringRedisTemplate.opsForValue().get(buildKey(userPublicId));
+            if (!StringUtils.hasText(payload)) {
+                return Optional.empty();
+            }
+            return Optional.of(objectMapper.readValue(payload, MyEmailChangeVerificationPayload.class));
+        } catch (DataAccessException | JsonProcessingException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    public void delete(String userPublicId) {
+        try {
+            stringRedisTemplate.delete(buildKey(userPublicId));
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    /**
+     * 이메일 변경 성공 시 하루(24h) cool-down 시작 (기능명세 MY-001 정책)
+     */
+    public void markCooldown(String userPublicId, long cooldownSeconds) {
+        try {
+            stringRedisTemplate.opsForValue()
+                    .set(buildCooldownKey(userPublicId), COOLDOWN_VALUE, Duration.ofSeconds(cooldownSeconds));
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    /**
+     * 이메일 변경 cool-down 여부
+     */
+    public boolean isInCooldown(String userPublicId) {
+        try {
+            return Boolean.TRUE.equals(stringRedisTemplate.hasKey(buildCooldownKey(userPublicId)));
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    private String buildKey(String userPublicId) {
+        return KEY_PREFIX + userPublicId;
+    }
+
+    private String buildCooldownKey(String userPublicId) {
+        return COOLDOWN_KEY_PREFIX + userPublicId;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyNotificationService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyNotificationService.java
@@ -1,0 +1,62 @@
+package com.f1.quiket.domain.mypage.service;
+
+import com.f1.quiket.domain.mypage.dto.FcmTokenUpdateRequest;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsResponse;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsUpdateRequest;
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import com.f1.quiket.domain.mypage.repository.UserNotificationSettingRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MyNotificationService {
+
+    private final UserRepository userRepository;
+    private final UserNotificationSettingRepository userNotificationSettingRepository;
+    private final UserNotificationSettingCreator userNotificationSettingCreator;
+
+    @Transactional(readOnly = true)
+    public NotificationSettingsResponse getNotificationSettings(String userPublicId) {
+        User user = findActiveUser(userPublicId);
+        return userNotificationSettingRepository.findByUserId(user.getId())
+                .map(NotificationSettingsResponse::from)
+                .orElseGet(NotificationSettingsResponse::defaults);
+    }
+
+    public NotificationSettingsResponse updateNotificationSettings(
+            String userPublicId,
+            NotificationSettingsUpdateRequest request
+    ) {
+        User user = findActiveUser(userPublicId);
+        UserNotificationSetting setting = findOrCreateSetting(user.getId());
+        setting.updateSettings(
+                request.getActivityEnabled(),
+                request.getUpdateEnabled(),
+                request.getReviewEnabled()
+        );
+        return NotificationSettingsResponse.from(setting);
+    }
+
+    public void updateFcmToken(String userPublicId, FcmTokenUpdateRequest request) {
+        User user = findActiveUser(userPublicId);
+        UserNotificationSetting setting = findOrCreateSetting(user.getId());
+        setting.updateFcmToken(request.getFcmToken());
+    }
+
+    private User findActiveUser(String userPublicId) {
+        return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    private UserNotificationSetting findOrCreateSetting(Long userId) {
+        return userNotificationSettingRepository.findByUserId(userId)
+                .orElseGet(() -> userNotificationSettingCreator.createIfAbsent(userId));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
@@ -1,0 +1,42 @@
+package com.f1.quiket.domain.mypage.service;
+
+import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
+import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final UserAuthIdentityRepository userAuthIdentityRepository;
+
+    @Transactional(readOnly = true)
+    public MyProfileResponse getMyProfile(String userPublicId) {
+        User user = findActiveUser(userPublicId);
+        return toMyProfileResponse(user);
+    }
+
+    public MyProfileResponse updateNickname(String userPublicId, NicknameUpdateRequest request) {
+        User user = findActiveUser(userPublicId);
+        user.changeNickname(request.getNickname());
+        return toMyProfileResponse(user);
+    }
+
+    private User findActiveUser(String userPublicId) {
+        return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    private MyProfileResponse toMyProfileResponse(User user) {
+        return MyProfileResponse.of(user, userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
@@ -3,9 +3,11 @@ package com.f1.quiket.domain.mypage.service;
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
 import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.auth.service.AuthTokenService;
 import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
+import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
 import com.f1.quiket.domain.mypage.event.MyEmailChangeMailRequestedEvent;
@@ -15,6 +17,7 @@ import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -33,6 +36,8 @@ public class MyPageService {
     private final EmailVerificationCodeGenerator verificationCodeGenerator;
     private final MyEmailChangeVerificationStore emailChangeVerificationStore;
     private final ApplicationEventPublisher eventPublisher;
+    private final PasswordEncoder passwordEncoder;
+    private final AuthTokenService authTokenService;
 
     @Transactional(readOnly = true)
     public MyProfileResponse getMyProfile(String userPublicId) {
@@ -81,6 +86,18 @@ public class MyPageService {
         return toMyProfileResponse(user);
     }
 
+    public void updatePassword(String userPublicId, MyPasswordChangeRequest request) {
+        validatePasswordConfirm(request.getNewPassword(), request.getNewPasswordConfirm());
+
+        User user = findActiveUser(userPublicId);
+        UserAuthIdentity localIdentity = findLocalIdentity(user);
+        validateCurrentPassword(localIdentity, request.getCurrentPassword());
+        validateNewPassword(localIdentity, request.getNewPassword());
+
+        localIdentity.changePassword(passwordEncoder.encode(request.getNewPassword()));
+        authTokenService.revokeAllActiveRefreshTokens(user);
+    }
+
     private User findActiveUser(String userPublicId) {
         return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
@@ -106,6 +123,24 @@ public class MyPageService {
     private void validateNotInCooldown(String userPublicId) {
         if (emailChangeVerificationStore.isInCooldown(userPublicId)) {
             throw new CustomException(ErrorCode.MY_EMAIL_CHANGE_TOO_FREQUENT);
+        }
+    }
+
+    private void validatePasswordConfirm(String password, String passwordConfirm) {
+        if (!password.equals(passwordConfirm)) {
+            throw new CustomException(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
+        }
+    }
+
+    private void validateCurrentPassword(UserAuthIdentity localIdentity, String currentPassword) {
+        if (!passwordEncoder.matches(currentPassword, localIdentity.getPasswordHash())) {
+            throw new CustomException(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        }
+    }
+
+    private void validateNewPassword(UserAuthIdentity localIdentity, String newPassword) {
+        if (passwordEncoder.matches(newPassword, localIdentity.getPasswordHash())) {
+            throw new CustomException(ErrorCode.AUTH_PASSWORD_SAME_AS_PREVIOUS);
         }
     }
 

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
@@ -1,23 +1,38 @@
 package com.f1.quiket.domain.mypage.service;
 
+import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.mypage.event.MyEmailChangeMailRequestedEvent;
 import com.f1.quiket.domain.user.entity.User;
 import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class MyPageService {
 
+    private static final String PROVIDER_LOCAL = "local";
+    private static final long EMAIL_CHANGE_TTL_SECONDS = 600L;
+    private static final long EMAIL_CHANGE_COOLDOWN_SECONDS = 86_400L;
+
     private final UserRepository userRepository;
     private final UserAuthIdentityRepository userAuthIdentityRepository;
+    private final EmailVerificationCodeGenerator verificationCodeGenerator;
+    private final MyEmailChangeVerificationStore emailChangeVerificationStore;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public MyProfileResponse getMyProfile(String userPublicId) {
@@ -31,9 +46,67 @@ public class MyPageService {
         return toMyProfileResponse(user);
     }
 
+    public EmailVerificationSentResponse requestEmailChange(String userPublicId, MyEmailChangeRequest request) {
+        User user = findActiveUser(userPublicId);
+        findLocalIdentity(user);
+        validateNotInCooldown(userPublicId);
+        validateEmailNotExists(request.getNewEmail());
+
+        String verificationCode = verificationCodeGenerator.generate();
+        emailChangeVerificationStore.save(
+                userPublicId,
+                new MyEmailChangeVerificationPayload(request.getNewEmail(), verificationCode),
+                EMAIL_CHANGE_TTL_SECONDS
+        );
+        eventPublisher.publishEvent(new MyEmailChangeMailRequestedEvent(request.getNewEmail(), verificationCode));
+        return EmailVerificationSentResponse.of(request.getNewEmail(), EMAIL_CHANGE_TTL_SECONDS);
+    }
+
+    public MyProfileResponse confirmEmailChange(String userPublicId, MyEmailChangeConfirmRequest request) {
+        User user = findActiveUser(userPublicId);
+        findLocalIdentity(user);
+        validateEmailNotExists(request.getNewEmail());
+
+        MyEmailChangeVerificationPayload payload = emailChangeVerificationStore.find(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_EMAIL_VERIFICATION_EXPIRED));
+        if (!payload.newEmail().equals(request.getNewEmail())
+                || !payload.verificationCode().equals(request.getVerificationCode())) {
+            throw new CustomException(ErrorCode.AUTH_INVALID_EMAIL_VERIFICATION);
+        }
+
+        user.changeEmail(request.getNewEmail());
+        emailChangeVerificationStore.delete(userPublicId);
+        // 기능명세 MY-001 정책 — 이메일 변경 성공 시 하루 cool-down 시작
+        emailChangeVerificationStore.markCooldown(userPublicId, EMAIL_CHANGE_COOLDOWN_SECONDS);
+        return toMyProfileResponse(user);
+    }
+
     private User findActiveUser(String userPublicId) {
         return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    private UserAuthIdentity findLocalIdentity(User user) {
+        UserAuthIdentity localIdentity = userAuthIdentityRepository
+                .findByUserAndProviderAndDeletedAtIsNull(user, PROVIDER_LOCAL)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND));
+
+        if (!StringUtils.hasText(localIdentity.getPasswordHash())) {
+            throw new CustomException(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND);
+        }
+        return localIdentity;
+    }
+
+    private void validateEmailNotExists(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new CustomException(ErrorCode.AUTH_EMAIL_ALREADY_EXISTS);
+        }
+    }
+
+    private void validateNotInCooldown(String userPublicId) {
+        if (emailChangeVerificationStore.isInCooldown(userPublicId)) {
+            throw new CustomException(ErrorCode.MY_EMAIL_CHANGE_TOO_FREQUENT);
+        }
     }
 
     private MyProfileResponse toMyProfileResponse(User user) {

--- a/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/MyPageService.java
@@ -5,6 +5,7 @@ import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
 import com.f1.quiket.domain.auth.service.AuthTokenService;
 import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
+import com.f1.quiket.domain.mypage.dto.MyAccountDeleteRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
@@ -15,6 +16,8 @@ import com.f1.quiket.domain.user.entity.User;
 import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -98,6 +101,19 @@ public class MyPageService {
         authTokenService.revokeAllActiveRefreshTokens(user);
     }
 
+    public void deleteAccount(String userPublicId, MyAccountDeleteRequest request) {
+        validateDeleteAgreement(request);
+
+        User user = findActiveUser(userPublicId);
+        List<UserAuthIdentity> identities = userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user);
+        findLocalIdentity(identities).ifPresent(localIdentity ->
+                validateAccountDeletePassword(localIdentity, request.getPassword()));
+
+        authTokenService.revokeAllActiveRefreshTokens(user);
+        identities.forEach(UserAuthIdentity::delete);
+        user.delete();
+    }
+
     private User findActiveUser(String userPublicId) {
         return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
@@ -112,6 +128,12 @@ public class MyPageService {
             throw new CustomException(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND);
         }
         return localIdentity;
+    }
+
+    private Optional<UserAuthIdentity> findLocalIdentity(List<UserAuthIdentity> identities) {
+        return identities.stream()
+                .filter(identity -> PROVIDER_LOCAL.equals(identity.getProvider()))
+                .findFirst();
     }
 
     private void validateEmailNotExists(String email) {
@@ -141,6 +163,21 @@ public class MyPageService {
     private void validateNewPassword(UserAuthIdentity localIdentity, String newPassword) {
         if (passwordEncoder.matches(newPassword, localIdentity.getPasswordHash())) {
             throw new CustomException(ErrorCode.AUTH_PASSWORD_SAME_AS_PREVIOUS);
+        }
+    }
+
+    private void validateDeleteAgreement(MyAccountDeleteRequest request) {
+        if (!request.isAgreedToDelete()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "회원 탈퇴 동의는 필수입니다.");
+        }
+    }
+
+    private void validateAccountDeletePassword(UserAuthIdentity localIdentity, String password) {
+        if (!StringUtils.hasText(localIdentity.getPasswordHash())) {
+            throw new CustomException(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND);
+        }
+        if (!StringUtils.hasText(password) || !passwordEncoder.matches(password, localIdentity.getPasswordHash())) {
+            throw new CustomException(ErrorCode.AUTH_INVALID_CREDENTIALS);
         }
     }
 

--- a/src/main/java/com/f1/quiket/domain/mypage/service/UserNotificationSettingCreator.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/service/UserNotificationSettingCreator.java
@@ -1,0 +1,34 @@
+package com.f1.quiket.domain.mypage.service;
+
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import com.f1.quiket.domain.mypage.repository.UserNotificationSettingRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 알림 설정 첫 생성 시 동시 요청 race를 방어하는 별도 트랜잭션 컴포넌트
+ *
+ * - {@code user_notification_settings.user_id} UNIQUE 제약 위반(동시 INSERT)을 catch
+ * - REQUIRES_NEW로 격리된 트랜잭션 안에서만 INSERT/재조회가 일어나므로 호출 측 트랜잭션은 rollback-only 마크되지 않음
+ */
+@Component
+@RequiredArgsConstructor
+public class UserNotificationSettingCreator {
+
+    private final UserNotificationSettingRepository userNotificationSettingRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public UserNotificationSetting createIfAbsent(Long userId) {
+        try {
+            return userNotificationSettingRepository.saveAndFlush(UserNotificationSetting.createDefault(userId));
+        } catch (DataIntegrityViolationException e) {
+            return userNotificationSettingRepository.findByUserId(userId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "알림 설정 조회 실패", e));
+        }
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/user/entity/User.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/User.java
@@ -85,6 +85,10 @@ public class User extends BaseEntity {
         this.emailVerified = true;
     }
 
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
     public void recordLoginFailure(int maxFailedCount) {
         LocalDateTime now = LocalDateTime.now();
         this.failedLoginCount++;

--- a/src/main/java/com/f1/quiket/domain/user/entity/User.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/User.java
@@ -85,6 +85,10 @@ public class User extends BaseEntity {
         this.emailVerified = true;
     }
 
+    public void changeEmail(String email) {
+        this.email = email;
+    }
+
     public void changeNickname(String nickname) {
         this.nickname = nickname;
     }

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -57,6 +57,9 @@ public enum ErrorCode {
     QUIZ_SESSION_NOT_FOUND(404, "QUIZ_SESSION_NOT_FOUND", "퀴즈 세션을 찾을 수 없습니다."),
     QUIZ_SESSION_NOT_COMPLETED(409, "QUIZ_SESSION_NOT_COMPLETED", "아직 생성 완료 전인 퀴즈입니다."),
 
+    // MyPage Errors
+    MY_EMAIL_CHANGE_TOO_FREQUENT(429, "MY_EMAIL_CHANGE_TOO_FREQUENT", "이메일 변경은 하루에 1회만 가능합니다."),
+
     // 5xx Server Errors
     INTERNAL_SERVER_ERROR(500, "C002", "서버 내부 오류가 발생했습니다."),
     SERVICE_UNAVAILABLE(503, "C009", "일시적으로 서비스를 이용할 수 없습니다."),

--- a/src/main/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListener.java
+++ b/src/main/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListener.java
@@ -2,6 +2,7 @@ package com.f1.quiket.infra.mail.listener;
 
 import com.f1.quiket.domain.auth.event.EmailVerificationMailRequestedEvent;
 import com.f1.quiket.domain.auth.event.PasswordResetMailRequestedEvent;
+import com.f1.quiket.domain.mypage.event.MyEmailChangeMailRequestedEvent;
 import com.f1.quiket.infra.mail.dto.MailSendRequest;
 import com.f1.quiket.infra.mail.service.SesMailSender;
 import com.f1.quiket.infra.mail.template.MailTemplateFactory;
@@ -29,6 +30,15 @@ public class EmailVerificationMailEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void sendPasswordResetMail(PasswordResetMailRequestedEvent event) {
         MailSendRequest mailRequest = mailTemplateFactory.createPasswordResetMail(
+                event.email(),
+                event.verificationCode()
+        );
+        sesMailSender.sendMail(mailRequest);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void sendMyEmailChangeMail(MyEmailChangeMailRequestedEvent event) {
+        MailSendRequest mailRequest = mailTemplateFactory.createEmailChangeMail(
                 event.email(),
                 event.verificationCode()
         );

--- a/src/main/java/com/f1/quiket/infra/mail/template/MailTemplateFactory.java
+++ b/src/main/java/com/f1/quiket/infra/mail/template/MailTemplateFactory.java
@@ -33,6 +33,12 @@ public class MailTemplateFactory {
         return MailSendRequest.html(toEmail, subject, body);
     }
 
+    public MailSendRequest createEmailChangeMail(String toEmail, String verificationCode) {
+        String subject = "[Quiket] 이메일 변경 인증";
+        String body = createVerificationCodeBody(verificationCode);
+        return MailSendRequest.html(toEmail, subject, body);
+    }
+
     private String createVerificationCodeBody(String verificationCode) {
         return loadTemplate(VERIFICATION_TEMPLATE_PATH)
                 .replace(VERIFICATION_CODE_PLACEHOLDER, verificationCode);

--- a/src/main/resources/db/migration/V7__create_user_notification_settings.sql
+++ b/src/main/resources/db/migration/V7__create_user_notification_settings.sql
@@ -1,0 +1,22 @@
+CREATE TABLE user_notification_settings (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    fcm_token VARCHAR(255) NULL COMMENT 'FCM 푸시 토큰',
+    is_activity_enabled TINYINT(1) NOT NULL DEFAULT 1 COMMENT '활동 알림 여부',
+    is_update_enabled TINYINT(1) NOT NULL DEFAULT 1 COMMENT '업데이트 알림 여부',
+    is_review_enabled TINYINT(1) NOT NULL DEFAULT 1 COMMENT '복습 알림 여부',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_user_notification_settings_user_id (user_id),
+
+    CONSTRAINT fk_user_notification_settings_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT chk_user_notification_settings_activity_enabled
+        CHECK (is_activity_enabled IN (0, 1)),
+    CONSTRAINT chk_user_notification_settings_update_enabled
+        CHECK (is_update_enabled IN (0, 1)),
+    CONSTRAINT chk_user_notification_settings_review_enabled
+        CHECK (is_review_enabled IN (0, 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 알림 설정';

--- a/src/main/resources/db/migration/V8__create_user_feedbacks.sql
+++ b/src/main/resources/db/migration/V8__create_user_feedbacks.sql
@@ -1,0 +1,22 @@
+CREATE TABLE user_feedbacks (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID (인증 엔드포인트 — 항상 존재)',
+    category VARCHAR(20) NOT NULL COMMENT '카테고리: feature / bug / inquiry / other',
+    body VARCHAR(1000) NOT NULL COMMENT '본문',
+    reply_email VARCHAR(255) NULL COMMENT '회신 이메일',
+    app_version VARCHAR(20) NULL COMMENT '앱 버전',
+    os_version VARCHAR(50) NULL COMMENT 'OS 버전',
+    device_model VARCHAR(100) NULL COMMENT '디바이스 모델',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '제출 시각',
+
+    PRIMARY KEY (id),
+    KEY idx_user_feedbacks_user_id (user_id),
+    KEY idx_user_feedbacks_category_created_at (category, created_at),
+
+    CONSTRAINT fk_user_feedbacks_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT chk_user_feedbacks_category
+        CHECK (category IN ('feature', 'bug', 'inquiry', 'other')),
+    CONSTRAINT chk_user_feedbacks_body_length
+        CHECK (CHAR_LENGTH(body) BETWEEN 1 AND 1000)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 피드백/문의';

--- a/src/test/java/com/f1/quiket/domain/mypage/service/FeedbackServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/FeedbackServiceTest.java
@@ -1,0 +1,104 @@
+package com.f1.quiket.domain.mypage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.mypage.dto.FeedbackCreateRequest;
+import com.f1.quiket.domain.mypage.dto.FeedbackResponse;
+import com.f1.quiket.domain.mypage.entity.UserFeedback;
+import com.f1.quiket.domain.mypage.repository.UserFeedbackRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class FeedbackServiceTest {
+
+    private UserRepository userRepository;
+    private UserFeedbackRepository userFeedbackRepository;
+    private FeedbackService feedbackService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userFeedbackRepository = mock(UserFeedbackRepository.class);
+        feedbackService = new FeedbackService(userRepository, userFeedbackRepository);
+    }
+
+    @Test
+    void createFeedback_saves_feedback_and_returns_response() {
+        User user = user();
+        FeedbackCreateRequest request = feedbackCreateRequest();
+        LocalDateTime createdAt = LocalDateTime.of(2026, 5, 25, 9, 30);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userFeedbackRepository.save(any(UserFeedback.class)))
+                .thenAnswer(invocation -> {
+                    UserFeedback feedback = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(feedback, "id", 10L);
+                    ReflectionTestUtils.setField(feedback, "createdAt", createdAt);
+                    return feedback;
+                });
+
+        FeedbackResponse response = feedbackService.createFeedback(user.getPublicId(), request);
+
+        assertThat(response.getId()).isEqualTo("10");
+        assertThat(response.getCategory()).isEqualTo("feature");
+        assertThat(response.getBody()).isEqualTo("퀴즈 결과 화면에서 복습 알림을 받을 수 있으면 좋겠어요.");
+        assertThat(response.getReplyEmail()).isEqualTo("user@example.com");
+        assertThat(response.getAppVersion()).isEqualTo("1.0.0");
+        assertThat(response.getOsVersion()).isEqualTo("Android 15");
+        assertThat(response.getDeviceModel()).isEqualTo("Galaxy S24");
+        assertThat(response.getCreatedAt()).isEqualTo(createdAt);
+
+        ArgumentCaptor<UserFeedback> feedbackCaptor = ArgumentCaptor.forClass(UserFeedback.class);
+        verify(userFeedbackRepository).save(feedbackCaptor.capture());
+        UserFeedback savedFeedback = feedbackCaptor.getValue();
+        assertThat(savedFeedback.getUserId()).isEqualTo(user.getId());
+        assertThat(savedFeedback.getCategory()).isEqualTo("feature");
+        assertThat(savedFeedback.getBody()).isEqualTo("퀴즈 결과 화면에서 복습 알림을 받을 수 있으면 좋겠어요.");
+        assertThat(savedFeedback.getReplyEmail()).isEqualTo("user@example.com");
+        assertThat(savedFeedback.getAppVersion()).isEqualTo("1.0.0");
+        assertThat(savedFeedback.getOsVersion()).isEqualTo("Android 15");
+        assertThat(savedFeedback.getDeviceModel()).isEqualTo("Galaxy S24");
+    }
+
+    @Test
+    void createFeedback_throws_not_found_when_user_missing() {
+        String userPublicId = "018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901";
+        FeedbackCreateRequest request = feedbackCreateRequest();
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> feedbackService.createFeedback(userPublicId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
+    }
+
+    private User user() {
+        User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return user;
+    }
+
+    private FeedbackCreateRequest feedbackCreateRequest() {
+        FeedbackCreateRequest request = new FeedbackCreateRequest();
+        ReflectionTestUtils.setField(request, "category", "feature");
+        ReflectionTestUtils.setField(request, "body", "퀴즈 결과 화면에서 복습 알림을 받을 수 있으면 좋겠어요.");
+        ReflectionTestUtils.setField(request, "replyEmail", "user@example.com");
+        ReflectionTestUtils.setField(request, "appVersion", "1.0.0");
+        ReflectionTestUtils.setField(request, "osVersion", "Android 15");
+        ReflectionTestUtils.setField(request, "deviceModel", "Galaxy S24");
+        return request;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyNotificationServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyNotificationServiceTest.java
@@ -1,0 +1,180 @@
+package com.f1.quiket.domain.mypage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.mypage.dto.FcmTokenUpdateRequest;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsResponse;
+import com.f1.quiket.domain.mypage.dto.NotificationSettingsUpdateRequest;
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import com.f1.quiket.domain.mypage.repository.UserNotificationSettingRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class MyNotificationServiceTest {
+
+    private UserRepository userRepository;
+    private UserNotificationSettingRepository userNotificationSettingRepository;
+    private UserNotificationSettingCreator userNotificationSettingCreator;
+    private MyNotificationService myNotificationService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userNotificationSettingRepository = mock(UserNotificationSettingRepository.class);
+        userNotificationSettingCreator = mock(UserNotificationSettingCreator.class);
+        myNotificationService = new MyNotificationService(
+                userRepository,
+                userNotificationSettingRepository,
+                userNotificationSettingCreator
+        );
+    }
+
+    @Test
+    void getNotificationSettings_returns_default_without_insert_when_missing() {
+        User user = user();
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
+
+        NotificationSettingsResponse response = myNotificationService.getNotificationSettings(user.getPublicId());
+
+        assertThat(response.isFcmTokenRegistered()).isFalse();
+        assertThat(response.isActivityEnabled()).isTrue();
+        assertThat(response.isUpdateEnabled()).isTrue();
+        assertThat(response.isReviewEnabled()).isTrue();
+        // GET은 read-only — 첫 호출에도 INSERT 발생하지 않아야 함
+        verify(userNotificationSettingRepository, never()).save(any(UserNotificationSetting.class));
+    }
+
+    @Test
+    void getNotificationSettings_returns_existing_settings() {
+        User user = user();
+        UserNotificationSetting setting = UserNotificationSetting.createDefault(user.getId());
+        setting.updateSettings(false, true, false);
+        setting.updateFcmToken("fcm-token");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.of(setting));
+
+        NotificationSettingsResponse response = myNotificationService.getNotificationSettings(user.getPublicId());
+
+        assertThat(response.isFcmTokenRegistered()).isTrue();
+        assertThat(response.isActivityEnabled()).isFalse();
+        assertThat(response.isUpdateEnabled()).isTrue();
+        assertThat(response.isReviewEnabled()).isFalse();
+    }
+
+    @Test
+    void updateNotificationSettings_updates_existing_settings() {
+        User user = user();
+        UserNotificationSetting setting = UserNotificationSetting.createDefault(user.getId());
+        NotificationSettingsUpdateRequest request = notificationSettingsUpdateRequest(false, false, true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.of(setting));
+
+        NotificationSettingsResponse response = myNotificationService.updateNotificationSettings(
+                user.getPublicId(),
+                request
+        );
+
+        assertThat(setting.isActivityEnabled()).isFalse();
+        assertThat(setting.isUpdateEnabled()).isFalse();
+        assertThat(setting.isReviewEnabled()).isTrue();
+        assertThat(response.isActivityEnabled()).isFalse();
+        assertThat(response.isUpdateEnabled()).isFalse();
+        assertThat(response.isReviewEnabled()).isTrue();
+    }
+
+    @Test
+    void updateFcmToken_updates_existing_token() {
+        User user = user();
+        UserNotificationSetting setting = UserNotificationSetting.createDefault(user.getId());
+        FcmTokenUpdateRequest request = fcmTokenUpdateRequest("new-fcm-token");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.of(setting));
+
+        myNotificationService.updateFcmToken(user.getPublicId(), request);
+
+        assertThat(setting.getFcmToken()).isEqualTo("new-fcm-token");
+    }
+
+    @Test
+    void updateFcmToken_creates_default_when_setting_missing() {
+        User user = user();
+        UserNotificationSetting createdSetting = UserNotificationSetting.createDefault(user.getId());
+        FcmTokenUpdateRequest request = fcmTokenUpdateRequest("new-fcm-token");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
+        when(userNotificationSettingCreator.createIfAbsent(user.getId())).thenReturn(createdSetting);
+
+        myNotificationService.updateFcmToken(user.getPublicId(), request);
+
+        assertThat(createdSetting.getFcmToken()).isEqualTo("new-fcm-token");
+    }
+
+    @Test
+    void updateFcmToken_recovers_when_concurrent_create_conflicts() {
+        // 다른 트랜잭션이 먼저 INSERT한 setting을 creator가 catch & re-fetch로 반환하는 시나리오
+        User user = user();
+        UserNotificationSetting concurrentlyCreatedSetting = UserNotificationSetting.createDefault(user.getId());
+        FcmTokenUpdateRequest request = fcmTokenUpdateRequest("new-fcm-token");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userNotificationSettingRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
+        when(userNotificationSettingCreator.createIfAbsent(user.getId())).thenReturn(concurrentlyCreatedSetting);
+
+        myNotificationService.updateFcmToken(user.getPublicId(), request);
+
+        assertThat(concurrentlyCreatedSetting.getFcmToken()).isEqualTo("new-fcm-token");
+        verify(userNotificationSettingCreator).createIfAbsent(user.getId());
+    }
+
+    @Test
+    void getNotificationSettings_throws_not_found_when_user_missing() {
+        String userPublicId = "018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901";
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> myNotificationService.getNotificationSettings(userPublicId))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
+    }
+
+    private User user() {
+        User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return user;
+    }
+
+    private NotificationSettingsUpdateRequest notificationSettingsUpdateRequest(
+            boolean activityEnabled,
+            boolean updateEnabled,
+            boolean reviewEnabled
+    ) {
+        NotificationSettingsUpdateRequest request = new NotificationSettingsUpdateRequest();
+        ReflectionTestUtils.setField(request, "activityEnabled", activityEnabled);
+        ReflectionTestUtils.setField(request, "updateEnabled", updateEnabled);
+        ReflectionTestUtils.setField(request, "reviewEnabled", reviewEnabled);
+        return request;
+    }
+
+    private FcmTokenUpdateRequest fcmTokenUpdateRequest(String fcmToken) {
+        FcmTokenUpdateRequest request = new FcmTokenUpdateRequest();
+        ReflectionTestUtils.setField(request, "fcmToken", fcmToken);
+        return request;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -2,13 +2,23 @@ package com.f1.quiket.domain.mypage.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
 import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
+import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.mypage.event.MyEmailChangeMailRequestedEvent;
 import com.f1.quiket.domain.user.entity.User;
 import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
@@ -18,19 +28,32 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class MyPageServiceTest {
 
     private UserRepository userRepository;
     private UserAuthIdentityRepository userAuthIdentityRepository;
+    private EmailVerificationCodeGenerator verificationCodeGenerator;
+    private MyEmailChangeVerificationStore emailChangeVerificationStore;
+    private ApplicationEventPublisher eventPublisher;
     private MyPageService myPageService;
 
     @BeforeEach
     void setUp() {
         userRepository = mock(UserRepository.class);
         userAuthIdentityRepository = mock(UserAuthIdentityRepository.class);
-        myPageService = new MyPageService(userRepository, userAuthIdentityRepository);
+        verificationCodeGenerator = mock(EmailVerificationCodeGenerator.class);
+        emailChangeVerificationStore = mock(MyEmailChangeVerificationStore.class);
+        eventPublisher = mock(ApplicationEventPublisher.class);
+        myPageService = new MyPageService(
+                userRepository,
+                userAuthIdentityRepository,
+                verificationCodeGenerator,
+                emailChangeVerificationStore,
+                eventPublisher
+        );
     }
 
     @Test
@@ -84,6 +107,146 @@ class MyPageServiceTest {
                 .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
     }
 
+    @Test
+    void requestEmailChange_saves_code_and_publishes_mail() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeRequest request = emailChangeRequest("new.user@example.com");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(userRepository.existsByEmail(request.getNewEmail())).thenReturn(false);
+        when(verificationCodeGenerator.generate()).thenReturn("123456");
+
+        EmailVerificationSentResponse response = myPageService.requestEmailChange(user.getPublicId(), request);
+
+        assertThat(response.getEmail()).isEqualTo("new.user@example.com");
+        assertThat(response.getExpiresInSeconds()).isEqualTo(600L);
+        verify(emailChangeVerificationStore).isInCooldown(user.getPublicId());
+        verify(emailChangeVerificationStore).save(
+                user.getPublicId(),
+                new MyEmailChangeVerificationPayload("new.user@example.com", "123456"),
+                600L
+        );
+        verify(eventPublisher).publishEvent(
+                new MyEmailChangeMailRequestedEvent("new.user@example.com", "123456")
+        );
+    }
+
+    @Test
+    void requestEmailChange_throws_too_frequent_when_in_cooldown() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeRequest request = emailChangeRequest("new.user@example.com");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(emailChangeVerificationStore.isInCooldown(user.getPublicId())).thenReturn(true);
+
+        assertThatThrownBy(() -> myPageService.requestEmailChange(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.MY_EMAIL_CHANGE_TOO_FREQUENT);
+        verify(emailChangeVerificationStore, never())
+                .save(anyString(), any(MyEmailChangeVerificationPayload.class), anyLong());
+    }
+
+    @Test
+    void requestEmailChange_throws_conflict_when_email_exists() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeRequest request = emailChangeRequest("new.user@example.com");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(userRepository.existsByEmail(request.getNewEmail())).thenReturn(true);
+
+        assertThatThrownBy(() -> myPageService.requestEmailChange(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_EMAIL_ALREADY_EXISTS);
+        verify(emailChangeVerificationStore, never())
+                .save(anyString(), any(MyEmailChangeVerificationPayload.class), anyLong());
+    }
+
+    @Test
+    void requestEmailChange_throws_conflict_when_local_identity_missing() {
+        User user = user();
+        MyEmailChangeRequest request = emailChangeRequest("new.user@example.com");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> myPageService.requestEmailChange(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void confirmEmailChange_updates_email_and_deletes_code() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeConfirmRequest request = emailChangeConfirmRequest("new.user@example.com", "123456");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(userRepository.existsByEmail(request.getNewEmail())).thenReturn(false);
+        when(emailChangeVerificationStore.find(user.getPublicId()))
+                .thenReturn(Optional.of(new MyEmailChangeVerificationPayload("new.user@example.com", "123456")));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(identity));
+
+        MyProfileResponse response = myPageService.confirmEmailChange(user.getPublicId(), request);
+
+        assertThat(user.getEmail()).isEqualTo("new.user@example.com");
+        assertThat(response.getEmail()).isEqualTo("new.user@example.com");
+        verify(emailChangeVerificationStore).delete(user.getPublicId());
+        verify(emailChangeVerificationStore).markCooldown(user.getPublicId(), 86_400L);
+    }
+
+    @Test
+    void confirmEmailChange_throws_expired_when_code_missing() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeConfirmRequest request = emailChangeConfirmRequest("new.user@example.com", "123456");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(userRepository.existsByEmail(request.getNewEmail())).thenReturn(false);
+        when(emailChangeVerificationStore.find(user.getPublicId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> myPageService.confirmEmailChange(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_EMAIL_VERIFICATION_EXPIRED);
+    }
+
+    @Test
+    void confirmEmailChange_throws_invalid_when_code_mismatched() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        MyEmailChangeConfirmRequest request = emailChangeConfirmRequest("new.user@example.com", "000000");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+        when(userRepository.existsByEmail(request.getNewEmail())).thenReturn(false);
+        when(emailChangeVerificationStore.find(user.getPublicId()))
+                .thenReturn(Optional.of(new MyEmailChangeVerificationPayload("new.user@example.com", "123456")));
+
+        assertThatThrownBy(() -> myPageService.confirmEmailChange(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_INVALID_EMAIL_VERIFICATION);
+        verify(emailChangeVerificationStore, never()).delete(user.getPublicId());
+    }
+
     private User user() {
         User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
         ReflectionTestUtils.setField(user, "id", 1L);
@@ -98,6 +261,19 @@ class MyPageServiceTest {
     private NicknameUpdateRequest nicknameUpdateRequest(String nickname) {
         NicknameUpdateRequest request = new NicknameUpdateRequest();
         ReflectionTestUtils.setField(request, "nickname", nickname);
+        return request;
+    }
+
+    private MyEmailChangeRequest emailChangeRequest(String newEmail) {
+        MyEmailChangeRequest request = new MyEmailChangeRequest();
+        ReflectionTestUtils.setField(request, "newEmail", newEmail);
+        return request;
+    }
+
+    private MyEmailChangeConfirmRequest emailChangeConfirmRequest(String newEmail, String verificationCode) {
+        MyEmailChangeConfirmRequest request = new MyEmailChangeConfirmRequest();
+        ReflectionTestUtils.setField(request, "newEmail", newEmail);
+        ReflectionTestUtils.setField(request, "verificationCode", verificationCode);
         return request;
     }
 }

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -1,0 +1,103 @@
+package com.f1.quiket.domain.mypage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
+import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
+import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class MyPageServiceTest {
+
+    private UserRepository userRepository;
+    private UserAuthIdentityRepository userAuthIdentityRepository;
+    private MyPageService myPageService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userAuthIdentityRepository = mock(UserAuthIdentityRepository.class);
+        myPageService = new MyPageService(userRepository, userAuthIdentityRepository);
+    }
+
+    @Test
+    void getMyProfile_returns_profile() {
+        User user = user();
+        UserAuthIdentity localIdentity = UserAuthIdentity.createLocal(user, "password-hash", true);
+        UserAuthIdentity kakaoIdentity = UserAuthIdentity.createOAuth(user, "kakao", "kakao-subject", false);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user))
+                .thenReturn(List.of(localIdentity, kakaoIdentity));
+
+        MyProfileResponse response = myPageService.getMyProfile(user.getPublicId());
+
+        assertThat(response.getId()).isEqualTo(user.getPublicId());
+        assertThat(response.getEmail()).isEqualTo("user@example.com");
+        assertThat(response.getNickname()).isEqualTo("도토리");
+        assertThat(response.getDotoriBalance()).isEqualTo(12);
+        assertThat(response.isEmailVerified()).isTrue();
+        assertThat(response.getStatus()).isEqualTo("active");
+        assertThat(response.getProviders()).containsExactly("local", "kakao");
+        assertThat(response.getXpTotal()).isEqualTo(360);
+        assertThat(response.getCurrentLevel()).isEqualTo(3);
+        assertThat(response.getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 5, 19, 7, 30));
+    }
+
+    @Test
+    void updateNickname_changes_nickname() {
+        User user = user();
+        NicknameUpdateRequest request = nicknameUpdateRequest("새닉네임");
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(user, "password-hash", true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(identity));
+
+        MyProfileResponse response = myPageService.updateNickname(user.getPublicId(), request);
+
+        assertThat(user.getNickname()).isEqualTo("새닉네임");
+        assertThat(response.getNickname()).isEqualTo("새닉네임");
+        assertThat(response.getProviders()).containsExactly("local");
+    }
+
+    @Test
+    void getMyProfile_throws_not_found_when_user_missing() {
+        String userPublicId = "018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901";
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> myPageService.getMyProfile(userPublicId))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
+    }
+
+    private User user() {
+        User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "emailVerified", true);
+        ReflectionTestUtils.setField(user, "dotoriBalance", 12);
+        ReflectionTestUtils.setField(user, "xpTotal", 360);
+        ReflectionTestUtils.setField(user, "currentLevel", 3);
+        ReflectionTestUtils.setField(user, "createdAt", LocalDateTime.of(2026, 5, 19, 7, 30));
+        return user;
+    }
+
+    private NicknameUpdateRequest nicknameUpdateRequest(String nickname) {
+        NicknameUpdateRequest request = new NicknameUpdateRequest();
+        ReflectionTestUtils.setField(request, "nickname", nickname);
+        return request;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -15,6 +15,7 @@ import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
 import com.f1.quiket.domain.auth.service.AuthTokenService;
 import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
+import com.f1.quiket.domain.mypage.dto.MyAccountDeleteRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
@@ -368,6 +369,101 @@ class MyPageServiceTest {
         verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
     }
 
+    @Test
+    void deleteAccount_deletes_local_account_and_revokes_tokens() {
+        User user = user();
+        UserAuthIdentity localIdentity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        UserAuthIdentity kakaoIdentity = UserAuthIdentity.createOAuth(user, "kakao", "kakao-subject", false);
+        MyAccountDeleteRequest request = accountDeleteRequest("Password123!", true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user))
+                .thenReturn(List.of(localIdentity, kakaoIdentity));
+
+        myPageService.deleteAccount(user.getPublicId(), request);
+
+        assertThat(user.getDeletedAt()).isNotNull();
+        assertThat(localIdentity.getDeletedAt()).isNotNull();
+        assertThat(kakaoIdentity.getDeletedAt()).isNotNull();
+        verify(authTokenService).revokeAllActiveRefreshTokens(user);
+    }
+
+    @Test
+    void deleteAccount_deletes_social_only_account_without_password() {
+        User user = user();
+        UserAuthIdentity kakaoIdentity = UserAuthIdentity.createOAuth(user, "kakao", "kakao-subject", true);
+        MyAccountDeleteRequest request = accountDeleteRequest(null, true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(kakaoIdentity));
+
+        myPageService.deleteAccount(user.getPublicId(), request);
+
+        assertThat(user.getDeletedAt()).isNotNull();
+        assertThat(kakaoIdentity.getDeletedAt()).isNotNull();
+        verify(authTokenService).revokeAllActiveRefreshTokens(user);
+    }
+
+    @Test
+    void deleteAccount_throws_invalid_input_when_agreement_missing() {
+        String userPublicId = "018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901";
+        MyAccountDeleteRequest request = accountDeleteRequest("Password123!", false);
+
+        assertThatThrownBy(() -> myPageService.deleteAccount(userPublicId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+        verify(userRepository, never()).findByPublicIdAndDeletedAtIsNull(anyString());
+    }
+
+    @Test
+    void deleteAccount_throws_invalid_credentials_when_local_password_missing() {
+        User user = user();
+        UserAuthIdentity localIdentity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        MyAccountDeleteRequest request = accountDeleteRequest(null, true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(localIdentity));
+
+        assertThatThrownBy(() -> myPageService.deleteAccount(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
+        assertThat(user.getDeletedAt()).isNull();
+        assertThat(localIdentity.getDeletedAt()).isNull();
+    }
+
+    @Test
+    void deleteAccount_throws_invalid_credentials_when_local_password_wrong() {
+        User user = user();
+        UserAuthIdentity localIdentity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        MyAccountDeleteRequest request = accountDeleteRequest("WrongPassword123!", true);
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findAllByUserAndDeletedAtIsNull(user)).thenReturn(List.of(localIdentity));
+
+        assertThatThrownBy(() -> myPageService.deleteAccount(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
+        assertThat(user.getDeletedAt()).isNull();
+        assertThat(localIdentity.getDeletedAt()).isNull();
+    }
+
     private User user() {
         User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
         ReflectionTestUtils.setField(user, "id", 1L);
@@ -407,6 +503,13 @@ class MyPageServiceTest {
         ReflectionTestUtils.setField(request, "currentPassword", currentPassword);
         ReflectionTestUtils.setField(request, "newPassword", newPassword);
         ReflectionTestUtils.setField(request, "newPasswordConfirm", newPasswordConfirm);
+        return request;
+    }
+
+    private MyAccountDeleteRequest accountDeleteRequest(String password, boolean agreedToDelete) {
+        MyAccountDeleteRequest request = new MyAccountDeleteRequest();
+        ReflectionTestUtils.setField(request, "password", password);
+        ReflectionTestUtils.setField(request, "agreedToDelete", agreedToDelete);
         return request;
     }
 }

--- a/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/MyPageServiceTest.java
@@ -13,9 +13,11 @@ import static org.mockito.Mockito.when;
 import com.f1.quiket.domain.auth.dto.EmailVerificationSentResponse;
 import com.f1.quiket.domain.auth.entity.UserAuthIdentity;
 import com.f1.quiket.domain.auth.repository.UserAuthIdentityRepository;
+import com.f1.quiket.domain.auth.service.AuthTokenService;
 import com.f1.quiket.domain.auth.service.EmailVerificationCodeGenerator;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeConfirmRequest;
 import com.f1.quiket.domain.mypage.dto.MyEmailChangeRequest;
+import com.f1.quiket.domain.mypage.dto.MyPasswordChangeRequest;
 import com.f1.quiket.domain.mypage.dto.MyProfileResponse;
 import com.f1.quiket.domain.mypage.dto.NicknameUpdateRequest;
 import com.f1.quiket.domain.mypage.event.MyEmailChangeMailRequestedEvent;
@@ -29,6 +31,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class MyPageServiceTest {
@@ -38,6 +42,8 @@ class MyPageServiceTest {
     private EmailVerificationCodeGenerator verificationCodeGenerator;
     private MyEmailChangeVerificationStore emailChangeVerificationStore;
     private ApplicationEventPublisher eventPublisher;
+    private PasswordEncoder passwordEncoder;
+    private AuthTokenService authTokenService;
     private MyPageService myPageService;
 
     @BeforeEach
@@ -47,12 +53,16 @@ class MyPageServiceTest {
         verificationCodeGenerator = mock(EmailVerificationCodeGenerator.class);
         emailChangeVerificationStore = mock(MyEmailChangeVerificationStore.class);
         eventPublisher = mock(ApplicationEventPublisher.class);
+        passwordEncoder = new BCryptPasswordEncoder();
+        authTokenService = mock(AuthTokenService.class);
         myPageService = new MyPageService(
                 userRepository,
                 userAuthIdentityRepository,
                 verificationCodeGenerator,
                 emailChangeVerificationStore,
-                eventPublisher
+                eventPublisher,
+                passwordEncoder,
+                authTokenService
         );
     }
 
@@ -247,6 +257,117 @@ class MyPageServiceTest {
         verify(emailChangeVerificationStore, never()).delete(user.getPublicId());
     }
 
+    @Test
+    void updatePassword_changes_password_and_revokes_tokens() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        MyPasswordChangeRequest request = passwordChangeRequest(
+                "Password123!",
+                "NewPassword123!",
+                "NewPassword123!"
+        );
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+
+        myPageService.updatePassword(user.getPublicId(), request);
+
+        assertThat(passwordEncoder.matches("NewPassword123!", identity.getPasswordHash())).isTrue();
+        assertThat(passwordEncoder.matches("Password123!", identity.getPasswordHash())).isFalse();
+        verify(authTokenService).revokeAllActiveRefreshTokens(user);
+    }
+
+    @Test
+    void updatePassword_throws_mismatch_when_password_confirm_differs() {
+        String userPublicId = "018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901";
+        MyPasswordChangeRequest request = passwordChangeRequest(
+                "Password123!",
+                "NewPassword123!",
+                "OtherPassword123!"
+        );
+
+        assertThatThrownBy(() -> myPageService.updatePassword(userPublicId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_PASSWORD_CONFIRM_MISMATCH);
+        verify(userRepository, never()).findByPublicIdAndDeletedAtIsNull(anyString());
+    }
+
+    @Test
+    void updatePassword_throws_invalid_credentials_when_current_password_wrong() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        MyPasswordChangeRequest request = passwordChangeRequest(
+                "WrongPassword123!",
+                "NewPassword123!",
+                "NewPassword123!"
+        );
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+
+        assertThatThrownBy(() -> myPageService.updatePassword(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_INVALID_CREDENTIALS);
+        verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
+    }
+
+    @Test
+    void updatePassword_throws_same_as_previous_when_new_password_same() {
+        User user = user();
+        UserAuthIdentity identity = UserAuthIdentity.createLocal(
+                user,
+                passwordEncoder.encode("Password123!"),
+                true
+        );
+        MyPasswordChangeRequest request = passwordChangeRequest(
+                "Password123!",
+                "Password123!",
+                "Password123!"
+        );
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.of(identity));
+
+        assertThatThrownBy(() -> myPageService.updatePassword(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_PASSWORD_SAME_AS_PREVIOUS);
+        verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
+    }
+
+    @Test
+    void updatePassword_throws_conflict_when_local_identity_missing() {
+        User user = user();
+        MyPasswordChangeRequest request = passwordChangeRequest(
+                "Password123!",
+                "NewPassword123!",
+                "NewPassword123!"
+        );
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(userAuthIdentityRepository.findByUserAndProviderAndDeletedAtIsNull(user, "local"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> myPageService.updatePassword(user.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_LOCAL_IDENTITY_NOT_FOUND);
+        verify(authTokenService, never()).revokeAllActiveRefreshTokens(user);
+    }
+
     private User user() {
         User user = User.create("018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901", "user@example.com", "도토리");
         ReflectionTestUtils.setField(user, "id", 1L);
@@ -274,6 +395,18 @@ class MyPageServiceTest {
         MyEmailChangeConfirmRequest request = new MyEmailChangeConfirmRequest();
         ReflectionTestUtils.setField(request, "newEmail", newEmail);
         ReflectionTestUtils.setField(request, "verificationCode", verificationCode);
+        return request;
+    }
+
+    private MyPasswordChangeRequest passwordChangeRequest(
+            String currentPassword,
+            String newPassword,
+            String newPasswordConfirm
+    ) {
+        MyPasswordChangeRequest request = new MyPasswordChangeRequest();
+        ReflectionTestUtils.setField(request, "currentPassword", currentPassword);
+        ReflectionTestUtils.setField(request, "newPassword", newPassword);
+        ReflectionTestUtils.setField(request, "newPasswordConfirm", newPasswordConfirm);
         return request;
     }
 }

--- a/src/test/java/com/f1/quiket/domain/mypage/service/UserNotificationSettingCreatorTest.java
+++ b/src/test/java/com/f1/quiket/domain/mypage/service/UserNotificationSettingCreatorTest.java
@@ -1,0 +1,74 @@
+package com.f1.quiket.domain.mypage.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.mypage.entity.UserNotificationSetting;
+import com.f1.quiket.domain.mypage.repository.UserNotificationSettingRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+
+class UserNotificationSettingCreatorTest {
+
+    private UserNotificationSettingRepository userNotificationSettingRepository;
+    private UserNotificationSettingCreator userNotificationSettingCreator;
+
+    @BeforeEach
+    void setUp() {
+        userNotificationSettingRepository = mock(UserNotificationSettingRepository.class);
+        userNotificationSettingCreator = new UserNotificationSettingCreator(userNotificationSettingRepository);
+    }
+
+    @Test
+    void createIfAbsent_returns_saved_setting_when_insert_succeeds() {
+        Long userId = 1L;
+        when(userNotificationSettingRepository.saveAndFlush(any(UserNotificationSetting.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        UserNotificationSetting result = userNotificationSettingCreator.createIfAbsent(userId);
+
+        assertThat(result.getUserId()).isEqualTo(userId);
+        assertThat(result.isActivityEnabled()).isTrue();
+        assertThat(result.isUpdateEnabled()).isTrue();
+        assertThat(result.isReviewEnabled()).isTrue();
+    }
+
+    @Test
+    void createIfAbsent_recovers_via_refetch_when_unique_constraint_violated() {
+        // 다른 트랜잭션이 먼저 INSERT한 상태를 시뮬레이션
+        Long userId = 1L;
+        UserNotificationSetting concurrentlyCreatedSetting = UserNotificationSetting.createDefault(userId);
+
+        when(userNotificationSettingRepository.saveAndFlush(any(UserNotificationSetting.class)))
+                .thenThrow(new DataIntegrityViolationException("uq_user_notification_settings_user_id"));
+        when(userNotificationSettingRepository.findByUserId(userId))
+                .thenReturn(Optional.of(concurrentlyCreatedSetting));
+
+        UserNotificationSetting result = userNotificationSettingCreator.createIfAbsent(userId);
+
+        assertThat(result).isSameAs(concurrentlyCreatedSetting);
+        verify(userNotificationSettingRepository).findByUserId(userId);
+    }
+
+    @Test
+    void createIfAbsent_throws_internal_error_when_refetch_returns_empty() {
+        // 매우 드문 케이스 — INSERT 실패 후 재조회도 비어있으면 일관성 깨진 상태
+        Long userId = 1L;
+        when(userNotificationSettingRepository.saveAndFlush(any(UserNotificationSetting.class)))
+                .thenThrow(new DataIntegrityViolationException("uq_user_notification_settings_user_id"));
+        when(userNotificationSettingRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userNotificationSettingCreator.createIfAbsent(userId))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 마이페이지(MY-001 / MY-002 / MY-003) 도메인 1차 운영 배포
- 머지 즉시 `deploy.yml` 트리거 → GHCR 이미지 빌드 → EC2 docker compose 재기동

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

### MyPage 도메인 (MY-001 / MY-002 / MY-003)
- **계정 정보 조회 + 닉네임 변경** (#61)
  - GET `/my/profile`, PATCH `/my/profile/nickname`
  - providers 응답 순서 결정성 보장 (primary 우선 + 알파벳순)
- **이메일 변경 인증** (#63)
  - POST `/my/email/change-requests`, POST `/my/email/change-confirm`
  - Redis 인증 코드 TTL 10분, 재요청 시 이전 코드 자동 무효화
  - **하루 1회 변경 제한** cool-down (`my:email-change:cooldown:` TTL 24h)
- **비밀번호 변경** (#65)
  - PATCH `/my/password`
  - 변경 성공 시 모든 활성 Refresh 토큰 폐기
  - 새 비번 = 이전 비번 거절, 소셜 전용 계정 거절
- **회원 탈퇴** (#67)
  - POST `/my/account/deletion`
  - 동의 검증 + local 비번 확인 + user/identity soft delete + Refresh 폐기
  - 소셜 전용 계정은 비밀번호 없이 동의만으로 탈퇴
- **알림 설정 + FCM 토큰** (#69)
  - GET/PUT `/my/notifications`, PUT `/my/fcm-token`
  - GET은 read-only로 동작 (첫 호출에도 INSERT 안 함, RESTful 회복)
  - PUT은 REQUIRES_NEW 별도 트랜잭션으로 동시 INSERT race 방어
- **피드백/문의 제출** (#71)
  - POST `/feedbacks`
  - 4 카테고리(`feature`/`bug`/`inquiry`/`other`), 본문 1~1000자
  - 앱/OS/디바이스 메타 자동 수집

### 인프라 / 문서
- Flyway V7: `user_notification_settings` 신규
- Flyway V8: `user_feedbacks` 신규 (user_id NOT NULL)
- ErrorCode 신설: `MY_EMAIL_CHANGE_TOO_FREQUENT(429)`
- User 엔티티 도메인 메서드 추가: `changeNickname`, `changeEmail`
- AGENTS.md 머지 전략 + Squash/Merge 커밋 메시지 형식 컨벤션 추가 (#59)

> Auth/Quiz/Home 등 기존 도메인은 이전 배포(#57)에서 이미 반영 완료. 본 PR diff에 포함되지 않습니다.

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. CI `build-and-test` 통과 확인
2. 머지 후 Actions `Deploy` 워크플로우 성공 확인
3. 운영 DB `flyway_schema_history`에 V7 / V8 적용 확인
4. 신규 엔드포인트 스모크 테스트
   - GET `/api/v1/my/profile`
   - PATCH `/api/v1/my/profile/nickname`
   - POST `/api/v1/my/email/change-requests` → POST `/api/v1/my/email/change-confirm`
   - PATCH `/api/v1/my/password`
   - POST `/api/v1/my/account/deletion`
   - GET/PUT `/api/v1/my/notifications`
   - PUT `/api/v1/my/fcm-token`
   - POST `/api/v1/feedbacks`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #73

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- **머지 방식 — Merge commit**
  - 이후 머지 전략 정정(#75 / PR #76)에 따라 `develop` → `main`은 **Squash merge**가 정답이지만, 본 PR은 그 정책 결정 *이전*에 머지된 작업이라 당시 컨벤션(Merge commit)을 그대로 적용함
  - 다음 운영 배포 PR부터는 Squash merge + 커밋 메시지 `[Release] 버전/날짜 배포` 적용 예정
- 운영 DB는 Flyway `baseline-on-migrate=false`. V1~V6가 적용된 상태에 V7 / V8만 신규 적용됨
- 운영 환경변수(`PROD_ENV_FILE`)는 변경 없음. 기존 운영 배포 시점 값 그대로 사용
- 신규 Redis 키 prefix: `my:email-change:`, `my:email-change:cooldown:` (TTL 자동 만료, 별도 정리 불필요)
- `MY_EMAIL_CHANGE_TOO_FREQUENT(429)`는 신규 도메인 응답 전용이라 기존 클라이언트 호환성에 영향 없음

---

## 🧑‍💻 Assignee

- @imclaremont