### PR TITLE
[Docs] 머지 전략 방향 정정

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,17 +181,17 @@ return ResponseEntity.status(errorCode.getStatus())
 
 ### 머지 전략
 
-- 작업 브랜치(`type/#issue-number-description`, 예: `feat/#123-login-api`) → `develop`: Squash merge 사용
-- `develop` → `main`: Merge commit 사용
-- 작업 브랜치 내부 커밋은 리뷰 편의를 위해 원자적으로 작성
-- `main` 병합 커밋은 릴리즈 단위 추적 목적
+- 작업 브랜치(`type/#issue-number-description`, 예: `feat/#123-login-api`) → `develop`: Merge commit 사용
+- `develop` → `main`: Squash merge 사용
+- `develop`에는 작업 PR 단위 히스토리를 보존해 리뷰·추적 용이성 확보
+- `main`은 릴리즈 단위 1커밋으로 압축해 운영 히스토리를 깔끔히 유지
 
 ### Git 메시지 컨벤션
 
 - 커밋 메시지: `type: 한국어 핵심`
 - PR 제목: `[Type] 한국어 핵심`
-- Squash merge 커밋 메시지: `[Type] 한국어 핵심 (#PR번호)`
-- `develop` → `main` Merge commit 메시지: `[Release] 버전/날짜 배포`
+- 작업 브랜치 → `develop` Merge commit 메시지: `[Type] 한국어 핵심 (#PR번호)` (GitHub 기본 형식)
+- `develop` → `main` Squash merge 커밋 메시지: `[Release] 버전/날짜 배포`
 
 ### 이슈 및 PR 제목
 


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- AGENTS.md PR #59에 정의한 머지 전략이 일반적인 GitFlow와 반대 방향으로 잡혀있어 정정
- `main`은 릴리즈 단위 1커밋으로 깔끔하게, `develop`은 작업 단위 히스토리 보존

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

### 머지 전략 (변경)

| 머지 | 변경 전 | 변경 후 |
|---|---|---|
| 작업 브랜치 → `develop` | Squash merge | **Merge commit** |
| `develop` → `main` | Merge commit | **Squash merge** |

### Git 메시지 컨벤션 (변경)

- 작업 브랜치 → `develop` **Merge commit** 메시지: `[Type] 한국어 핵심 (#PR번호)` (GitHub 기본 형식)
- `develop` → `main` **Squash merge** 커밋 메시지: `[Release] 버전/날짜 배포`

### 의도 설명 보강
- `develop`: 작업 PR 단위 히스토리 보존 → 리뷰·추적 용이성 확보
- `main`: 릴리즈 단위 1커밋으로 압축 → 운영 히스토리 가독성 향상

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. AGENTS.md `머지 전략` / `Git 메시지 컨벤션` 두 섹션이 정석 GitFlow 방향으로 변경됐는지 확인
2. CI `build-and-test` 통과 확인 (문서만 변경이지만 CI는 동작)

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #75

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 문서 변경만 포함 — 코드/스키마 영향 없음
- 진행 중인 운영 배포 PR(#74)도 본 PR 머지 후 머지 방식 안내를 **Squash merge**로 정정해야 함
- 본 PR의 머지 방식은 정정된 컨벤션 기준 **Merge commit** (작업 브랜치 → develop)

---

## 🧑‍💻 Assignee

- @imclaremont