### PR TITLE
[Feat] 퀴즈 생성 작업 이력 및 Redis 기반 비동기 큐 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationAcceptedResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationAcceptedResponse.java
@@ -1,5 +1,6 @@
 package com.f1.quiket.domain.quiz.dto;
 
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,12 +18,20 @@ public class QuizGenerationAcceptedResponse {
     private final Integer estimatedSeconds;
 
     public static QuizGenerationAcceptedResponse from(QuizSession quizSession) {
-        // TODO: estimatedSeconds — AI 생성 도입 후 출제 범위/문제수 기반 추정값 산출 후속 이슈에서 대체
         return QuizGenerationAcceptedResponse.builder()
                 .quizSessionId(quizSession.getPublicId())
                 .jobId(quizSession.getJobId())
                 .status(quizSession.getStatus())
                 .estimatedSeconds(null)
+                .build();
+    }
+
+    public static QuizGenerationAcceptedResponse from(QuizSession quizSession, QuizGenerationJob generationJob) {
+        return QuizGenerationAcceptedResponse.builder()
+                .quizSessionId(quizSession.getPublicId())
+                .jobId(quizSession.getJobId())
+                .status(generationJob.getStatus())
+                .estimatedSeconds(generationJob.getEstimatedSeconds())
                 .build();
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationStatusResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationStatusResponse.java
@@ -1,8 +1,10 @@
 package com.f1.quiket.domain.quiz.dto;
 
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.util.StringUtils;
 
 /**
  * 퀴즈 생성 상태 응답 DTO
@@ -25,7 +27,6 @@ public class QuizGenerationStatusResponse {
     private final String failReason;
 
     public static QuizGenerationStatusResponse from(QuizSession quizSession) {
-        // TODO: AI 생성 도입 후 estimatedSeconds 산출
         return QuizGenerationStatusResponse.builder()
                 .quizSessionId(quizSession.getPublicId())
                 .jobId(quizSession.getJobId())
@@ -37,7 +38,26 @@ public class QuizGenerationStatusResponse {
                 .build();
     }
 
-    // TODO: progressPct — AI 생성 도입 후 quiz_generation_jobs.progress_pct 실제 진행률 사용. 현재는 상태별 placeholder
+    public static QuizGenerationStatusResponse from(QuizSession quizSession, QuizGenerationJob generationJob) {
+        return QuizGenerationStatusResponse.builder()
+                .quizSessionId(quizSession.getPublicId())
+                .jobId(quizSession.getJobId())
+                .status(generationJob.getStatus())
+                .estimatedSeconds(generationJob.getEstimatedSeconds())
+                .progressPct(generationJob.getProgressPct())
+                .generatedCount(quizSession.getGeneratedCount())
+                .failReason(resolveFailReason(quizSession, generationJob))
+                .build();
+    }
+
+    private static String resolveFailReason(QuizSession quizSession, QuizGenerationJob generationJob) {
+        if (StringUtils.hasText(generationJob.getFailReason())) {
+            return generationJob.getFailReason();
+        }
+        return quizSession.getFailReason();
+    }
+
+    // TODO: 이전 생성 세션 호환용 fallback
     private static Integer resolveProgressPct(String status) {
         return switch (status) {
             case STATUS_PENDING -> 0;

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizGenerationJob.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizGenerationJob.java
@@ -1,0 +1,156 @@
+package com.f1.quiket.domain.quiz.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "quiz_generation_jobs",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_quiz_generation_jobs_session_id", columnNames = "quiz_session_id")
+        },
+        indexes = {
+                @Index(name = "idx_quiz_generation_jobs_user_id_status", columnList = "user_id, status"),
+                @Index(name = "idx_quiz_generation_jobs_timeout_at", columnList = "timeout_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuizGenerationJob {
+
+    private static final String STATUS_PENDING = "pending";
+    private static final String STATUS_IN_PROGRESS = "in_progress";
+    private static final String STATUS_COMPLETED = "completed";
+    private static final String STATUS_FAILED = "failed";
+    private static final String STATUS_TIMEOUT = "timeout";
+    private static final int PROGRESS_PENDING = 0;
+    private static final int PROGRESS_STARTED = 10;
+    private static final int PROGRESS_DONE = 100;
+    private static final long TIMEOUT_MINUTES = 10L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "quiz_session_id", nullable = false)
+    Long quizSessionId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "status", length = 20, nullable = false)
+    String status = STATUS_PENDING;
+
+    @Column(name = "progress_pct", nullable = false)
+    Integer progressPct = PROGRESS_PENDING;
+
+    @Column(name = "estimated_seconds")
+    Integer estimatedSeconds;
+
+    @Column(name = "estimated_finish_at")
+    LocalDateTime estimatedFinishAt;
+
+    @Column(name = "started_at")
+    LocalDateTime startedAt;
+
+    @Column(name = "completed_at")
+    LocalDateTime completedAt;
+
+    @Column(name = "timeout_at")
+    LocalDateTime timeoutAt;
+
+    @Column(name = "retry_count", nullable = false)
+    Integer retryCount = 0;
+
+    @Column(name = "is_retryable", nullable = false)
+    boolean retryable = true;
+
+    @Column(name = "fail_code", length = 50)
+    String failCode;
+
+    @Column(name = "fail_reason", length = 500)
+    String failReason;
+
+    @Column(name = "mq_message_id", length = 100)
+    String mqMessageId;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+
+    public static QuizGenerationJob create(Long quizSessionId, Long userId, Integer estimatedSeconds) {
+        QuizGenerationJob job = new QuizGenerationJob();
+        job.quizSessionId = quizSessionId;
+        job.userId = userId;
+        job.estimatedSeconds = estimatedSeconds;
+        return job;
+    }
+
+    public void assignMqMessageId(String mqMessageId) {
+        this.mqMessageId = mqMessageId;
+    }
+
+    public void markInProgress() {
+        LocalDateTime now = LocalDateTime.now();
+        this.status = STATUS_IN_PROGRESS;
+        this.progressPct = PROGRESS_STARTED;
+        this.startedAt = now;
+        this.timeoutAt = now.plusMinutes(TIMEOUT_MINUTES);
+        if (this.estimatedSeconds != null) {
+            this.estimatedFinishAt = now.plusSeconds(this.estimatedSeconds);
+        }
+    }
+
+    public void markCompleted() {
+        this.status = STATUS_COMPLETED;
+        this.progressPct = PROGRESS_DONE;
+        this.completedAt = LocalDateTime.now();
+        this.failCode = null;
+        this.failReason = null;
+        this.retryable = false;
+    }
+
+    public void markFailed(String failCode, String failReason, boolean retryable) {
+        this.status = STATUS_FAILED;
+        this.progressPct = PROGRESS_DONE;
+        this.completedAt = LocalDateTime.now();
+        this.failCode = failCode;
+        this.failReason = failReason;
+        this.retryable = retryable;
+    }
+
+    public void markTimeout(String failReason) {
+        this.status = STATUS_TIMEOUT;
+        this.progressPct = PROGRESS_DONE;
+        this.completedAt = LocalDateTime.now();
+        this.failCode = "timeout";
+        this.failReason = failReason;
+        this.retryable = true;
+    }
+
+    public void increaseRetryCount() {
+        this.retryCount++;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/event/QuizGenerationEnqueueRequestedEvent.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/event/QuizGenerationEnqueueRequestedEvent.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.quiz.event;
+
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.service.QuizGenerationQueueMessage;
+
+/**
+ * 퀴즈 생성 작업이 DB에 안전하게 적재된 후 Redis 큐 발행을 요청하는 이벤트.
+ *
+ * - 발행 시점: 퀴즈 세션 생성 트랜잭션 *안*
+ * - 처리 시점: 트랜잭션 commit *이후* ({@code AFTER_COMMIT})
+ * - 목적: DB rollback 시 Redis Stream에 orphan 메시지가 남지 않도록 정합성 보장
+ */
+public record QuizGenerationEnqueueRequestedEvent(QuizGenerationQueueMessage message) {
+
+    public static QuizGenerationEnqueueRequestedEvent of(QuizGenerationJob generationJob, QuizSession quizSession) {
+        return new QuizGenerationEnqueueRequestedEvent(QuizGenerationQueueMessage.of(generationJob, quizSession));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizGenerationJobRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizGenerationJobRepository.java
@@ -1,0 +1,12 @@
+package com.f1.quiket.domain.quiz.repository;
+
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuizGenerationJobRepository extends JpaRepository<QuizGenerationJob, Long> {
+
+    Optional<QuizGenerationJob> findByQuizSessionId(Long quizSessionId);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationEnqueueListener.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationEnqueueListener.java
@@ -1,0 +1,49 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.event.QuizGenerationEnqueueRequestedEvent;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
+import com.f1.quiket.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 퀴즈 생성 큐 발행 이벤트 리스너.
+ *
+ * - 호출 측 트랜잭션 commit 이후 별도 트랜잭션(REQUIRES_NEW)에서 Redis 큐 발행
+ * - enqueue 실패 시 generation_job을 failed 상태로 마킹해 사용자 status 조회로 노출
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QuizGenerationEnqueueListener {
+
+    private static final String FAIL_CODE_ENQUEUE = "enqueue_failed";
+
+    private final QuizGenerationQueue quizGenerationQueue;
+    private final QuizGenerationJobRepository quizGenerationJobRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(QuizGenerationEnqueueRequestedEvent event) {
+        Long generationJobId = event.message().generationJobId();
+        try {
+            String messageId = quizGenerationQueue.enqueue(event.message());
+            quizGenerationJobRepository.findById(generationJobId)
+                    .ifPresent(job -> job.assignMqMessageId(messageId));
+        } catch (CustomException e) {
+            log.error("퀴즈 생성 큐 발행 실패 — generation_job을 failed로 마킹. generationJobId={}", generationJobId, e);
+            quizGenerationJobRepository.findById(generationJobId)
+                    .ifPresent(this::markEnqueueFailed);
+        }
+    }
+
+    private void markEnqueueFailed(QuizGenerationJob job) {
+        job.markFailed(FAIL_CODE_ENQUEUE, "퀴즈 생성 큐 발행에 실패했습니다.", true);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueue.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueue.java
@@ -1,0 +1,6 @@
+package com.f1.quiket.domain.quiz.service;
+
+public interface QuizGenerationQueue {
+
+    String enqueue(QuizGenerationQueueMessage message);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueueMessage.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueueMessage.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+
+public record QuizGenerationQueueMessage(
+        Long generationJobId,
+        Long quizSessionId,
+        String quizSessionPublicId,
+        String jobId,
+        Long userId
+) {
+
+    public static QuizGenerationQueueMessage of(QuizGenerationJob generationJob, QuizSession quizSession) {
+        return new QuizGenerationQueueMessage(
+                generationJob.getId(),
+                quizSession.getId(),
+                quizSession.getPublicId(),
+                quizSession.getJobId(),
+                quizSession.getUserId()
+        );
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusService.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.quiz.service;
 
 import com.f1.quiket.domain.quiz.dto.QuizGenerationStatusResponse;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuizGenerationStatusService {
 
     private final QuizSessionRepository quizSessionRepository;
+    private final QuizGenerationJobRepository quizGenerationJobRepository;
 
     /**
      * 퀴즈 생성 상태 조회
@@ -27,6 +29,8 @@ public class QuizGenerationStatusService {
                 .findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionPublicId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
 
-        return QuizGenerationStatusResponse.from(quizSession);
+        return quizGenerationJobRepository.findByQuizSessionId(quizSession.getId())
+                .map(generationJob -> QuizGenerationStatusResponse.from(quizSession, generationJob))
+                .orElseGet(() -> QuizGenerationStatusResponse.from(quizSession));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
@@ -7,6 +7,7 @@ import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
 import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.event.QuizGenerationEnqueueRequestedEvent;
 import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -47,8 +49,8 @@ public class QuizSessionCreateService {
     private final QuizSessionRepository quizSessionRepository;
     private final QuizSessionScopeRepository quizSessionScopeRepository;
     private final QuizGenerationJobRepository quizGenerationJobRepository;
-    private final QuizGenerationQueue quizGenerationQueue;
     private final QuizGenerationLockStore quizGenerationLockStore;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 퀴즈 세션 생성
@@ -92,8 +94,8 @@ public class QuizSessionCreateService {
         QuizGenerationJob generationJob = quizGenerationJobRepository.save(
                 QuizGenerationJob.create(savedQuizSession.getId(), userId, null)
         );
-        String messageId = quizGenerationQueue.enqueue(QuizGenerationQueueMessage.of(generationJob, savedQuizSession));
-        generationJob.assignMqMessageId(messageId);
+        // 실제 Redis 큐 발행은 AFTER_COMMIT 리스너에서 처리 (DB rollback 시 orphan 메시지 방지)
+        eventPublisher.publishEvent(QuizGenerationEnqueueRequestedEvent.of(generationJob, savedQuizSession));
 
         return QuizGenerationAcceptedResponse.from(savedQuizSession, generationJob);
     }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
@@ -4,8 +4,10 @@ import com.f1.quiket.domain.part.entity.Part;
 import com.f1.quiket.domain.part.repository.PartRepository;
 import com.f1.quiket.domain.quiz.dto.QuizCreateRequest;
 import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
 import com.f1.quiket.domain.subject.entity.Subject;
@@ -44,6 +46,8 @@ public class QuizSessionCreateService {
     private final PartRepository partRepository;
     private final QuizSessionRepository quizSessionRepository;
     private final QuizSessionScopeRepository quizSessionScopeRepository;
+    private final QuizGenerationJobRepository quizGenerationJobRepository;
+    private final QuizGenerationQueue quizGenerationQueue;
     private final QuizGenerationLockStore quizGenerationLockStore;
 
     /**
@@ -85,8 +89,13 @@ public class QuizSessionCreateService {
 
         QuizSession savedQuizSession = quizSessionRepository.save(quizSession);
         quizSessionScopeRepository.saveAll(createScopes(savedQuizSession.getId(), parts));
+        QuizGenerationJob generationJob = quizGenerationJobRepository.save(
+                QuizGenerationJob.create(savedQuizSession.getId(), userId, null)
+        );
+        String messageId = quizGenerationQueue.enqueue(QuizGenerationQueueMessage.of(generationJob, savedQuizSession));
+        generationJob.assignMqMessageId(messageId);
 
-        return QuizGenerationAcceptedResponse.from(savedQuizSession);
+        return QuizGenerationAcceptedResponse.from(savedQuizSession, generationJob);
     }
 
     /**

--- a/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
@@ -1,0 +1,43 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisQuizGenerationQueue implements QuizGenerationQueue {
+
+    private static final String STREAM_KEY = "quiz:generation:jobs";
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public String enqueue(QuizGenerationQueueMessage message) {
+        try {
+            RecordId recordId = stringRedisTemplate.opsForStream()
+                    .add(STREAM_KEY, toRecord(message));
+            if (recordId == null) {
+                throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE);
+            }
+            return recordId.getValue();
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    private Map<String, String> toRecord(QuizGenerationQueueMessage message) {
+        return Map.of(
+                "generationJobId", String.valueOf(message.generationJobId()),
+                "quizSessionId", String.valueOf(message.quizSessionId()),
+                "quizSessionPublicId", message.quizSessionPublicId(),
+                "jobId", message.jobId(),
+                "userId", String.valueOf(message.userId())
+        );
+    }
+}

--- a/src/main/resources/db/migration/V9__create_quiz_generation_jobs.sql
+++ b/src/main/resources/db/migration/V9__create_quiz_generation_jobs.sql
@@ -1,0 +1,33 @@
+CREATE TABLE quiz_generation_jobs (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    quiz_session_id BIGINT NOT NULL COMMENT '퀴즈 세션 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    status VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT '작업 상태',
+    progress_pct TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '진행률',
+    estimated_seconds SMALLINT NULL COMMENT '예상 소요 시간',
+    estimated_finish_at DATETIME(3) NULL COMMENT '예상 완료 시각',
+    started_at DATETIME(3) NULL COMMENT '처리 시작 시각',
+    completed_at DATETIME(3) NULL COMMENT '완료 시각',
+    timeout_at DATETIME(3) NULL COMMENT '타임아웃 기준 시각',
+    retry_count TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '재시도 횟수',
+    is_retryable TINYINT(1) NOT NULL DEFAULT 1 COMMENT '재시도 가능 여부',
+    fail_code VARCHAR(50) NULL COMMENT '실패 코드',
+    fail_reason VARCHAR(500) NULL COMMENT '실패 상세 사유',
+    mq_message_id VARCHAR(100) NULL COMMENT 'Redis Stream message-id',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_quiz_generation_jobs_session_id (quiz_session_id),
+    KEY idx_quiz_generation_jobs_user_id_status (user_id, status),
+    KEY idx_quiz_generation_jobs_timeout_at (timeout_at),
+
+    CONSTRAINT fk_quiz_generation_jobs_session_id
+        FOREIGN KEY (quiz_session_id) REFERENCES quiz_sessions(id),
+    CONSTRAINT chk_quiz_generation_jobs_status
+        CHECK (status IN ('pending', 'in_progress', 'completed', 'failed', 'timeout')),
+    CONSTRAINT chk_quiz_generation_jobs_progress_pct
+        CHECK (progress_pct BETWEEN 0 AND 100),
+    CONSTRAINT chk_quiz_generation_jobs_retryable
+        CHECK (is_retryable IN (0, 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='퀴즈 AI 생성 작업 이력';

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationEnqueueListenerTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationEnqueueListenerTest.java
@@ -1,0 +1,99 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.event.QuizGenerationEnqueueRequestedEvent;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizGenerationEnqueueListenerTest {
+
+    private QuizGenerationQueue quizGenerationQueue;
+    private QuizGenerationJobRepository quizGenerationJobRepository;
+    private QuizGenerationEnqueueListener quizGenerationEnqueueListener;
+
+    @BeforeEach
+    void setUp() {
+        quizGenerationQueue = mock(QuizGenerationQueue.class);
+        quizGenerationJobRepository = mock(QuizGenerationJobRepository.class);
+        quizGenerationEnqueueListener = new QuizGenerationEnqueueListener(
+                quizGenerationQueue,
+                quizGenerationJobRepository
+        );
+    }
+
+    @Test
+    void handle_enqueues_and_assigns_message_id_on_success() {
+        QuizGenerationJob generationJob = job(900L);
+        QuizGenerationEnqueueRequestedEvent event = new QuizGenerationEnqueueRequestedEvent(message());
+
+        when(quizGenerationQueue.enqueue(any(QuizGenerationQueueMessage.class)))
+                .thenReturn("1748130000000-0");
+        when(quizGenerationJobRepository.findById(900L)).thenReturn(Optional.of(generationJob));
+
+        quizGenerationEnqueueListener.handle(event);
+
+        assertThat(generationJob.getMqMessageId()).isEqualTo("1748130000000-0");
+        assertThat(generationJob.getStatus()).isEqualTo("pending");
+    }
+
+    @Test
+    void handle_marks_job_failed_when_enqueue_throws() {
+        QuizGenerationJob generationJob = job(900L);
+        QuizGenerationEnqueueRequestedEvent event = new QuizGenerationEnqueueRequestedEvent(message());
+
+        when(quizGenerationQueue.enqueue(any(QuizGenerationQueueMessage.class)))
+                .thenThrow(new CustomException(ErrorCode.SERVICE_UNAVAILABLE));
+        when(quizGenerationJobRepository.findById(900L)).thenReturn(Optional.of(generationJob));
+
+        quizGenerationEnqueueListener.handle(event);
+
+        assertThat(generationJob.getStatus()).isEqualTo("failed");
+        assertThat(generationJob.getFailCode()).isEqualTo("enqueue_failed");
+        assertThat(generationJob.getFailReason()).isEqualTo("퀴즈 생성 큐 발행에 실패했습니다.");
+        assertThat(generationJob.isRetryable()).isTrue();
+        assertThat(generationJob.getMqMessageId()).isNull();
+    }
+
+    @Test
+    void handle_skips_silently_when_job_missing_on_enqueue_success() {
+        QuizGenerationEnqueueRequestedEvent event = new QuizGenerationEnqueueRequestedEvent(message());
+
+        when(quizGenerationQueue.enqueue(any(QuizGenerationQueueMessage.class)))
+                .thenReturn("1748130000000-0");
+        when(quizGenerationJobRepository.findById(900L)).thenReturn(Optional.empty());
+
+        // 매우 드문 케이스 — job이 사라진 상태로 listener 도달. 예외 던지지 않고 정상 종료
+        quizGenerationEnqueueListener.handle(event);
+
+        verify(quizGenerationJobRepository).findById(900L);
+        verify(quizGenerationJobRepository, never()).save(any());
+    }
+
+    private QuizGenerationJob job(Long id) {
+        QuizGenerationJob job = QuizGenerationJob.create(500L, 1L, null);
+        ReflectionTestUtils.setField(job, "id", id);
+        return job;
+    }
+
+    private QuizGenerationQueueMessage message() {
+        return new QuizGenerationQueueMessage(
+                900L,
+                500L,
+                "quiz-session-public-id",
+                "quiz-job-public-id",
+                1L
+        );
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusServiceTest.java
@@ -6,7 +6,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.f1.quiket.domain.quiz.dto.QuizGenerationStatusResponse;
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
@@ -18,20 +20,28 @@ import org.springframework.test.util.ReflectionTestUtils;
 class QuizGenerationStatusServiceTest {
 
     private QuizSessionRepository quizSessionRepository;
+    private QuizGenerationJobRepository quizGenerationJobRepository;
     private QuizGenerationStatusService quizGenerationStatusService;
 
     @BeforeEach
     void setUp() {
         quizSessionRepository = mock(QuizSessionRepository.class);
-        quizGenerationStatusService = new QuizGenerationStatusService(quizSessionRepository);
+        quizGenerationJobRepository = mock(QuizGenerationJobRepository.class);
+        quizGenerationStatusService = new QuizGenerationStatusService(
+                quizSessionRepository,
+                quizGenerationJobRepository
+        );
     }
 
     @Test
     void getGenerationStatus_returns_pending_status() {
         Long userId = 1L;
-        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "pending", "quiz-job-1", null, null);
+        QuizSession quizSession = quizSession(100L, "quiz-session-public-id", userId, "pending", "quiz-job-1", null, null);
+        QuizGenerationJob generationJob = generationJob(900L, quizSession.getId(), userId, "pending", 0, null, null);
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(quizGenerationJobRepository.findByQuizSessionId(quizSession.getId()))
+                .thenReturn(Optional.of(generationJob));
 
         QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
                 userId,
@@ -50,9 +60,12 @@ class QuizGenerationStatusServiceTest {
     @Test
     void getGenerationStatus_returns_in_progress_status() {
         Long userId = 1L;
-        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "in_progress", "quiz-job-1", null, null);
+        QuizSession quizSession = quizSession(100L, "quiz-session-public-id", userId, "pending", "quiz-job-1", null, null);
+        QuizGenerationJob generationJob = generationJob(900L, quizSession.getId(), userId, "in_progress", 10, null, null);
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(quizGenerationJobRepository.findByQuizSessionId(quizSession.getId()))
+                .thenReturn(Optional.of(generationJob));
 
         QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
                 userId,
@@ -60,7 +73,7 @@ class QuizGenerationStatusServiceTest {
         );
 
         assertThat(response.getStatus()).isEqualTo("in_progress");
-        assertThat(response.getProgressPct()).isEqualTo(50);
+        assertThat(response.getProgressPct()).isEqualTo(10);
         assertThat(response.getGeneratedCount()).isNull();
         assertThat(response.getFailReason()).isNull();
     }
@@ -68,9 +81,12 @@ class QuizGenerationStatusServiceTest {
     @Test
     void getGenerationStatus_returns_completed_status() {
         Long userId = 1L;
-        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "completed", "quiz-job-1", 8, null);
+        QuizSession quizSession = quizSession(100L, "quiz-session-public-id", userId, "completed", "quiz-job-1", 8, null);
+        QuizGenerationJob generationJob = generationJob(900L, quizSession.getId(), userId, "completed", 100, null, null);
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(quizGenerationJobRepository.findByQuizSessionId(quizSession.getId()))
+                .thenReturn(Optional.of(generationJob));
 
         QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
                 userId,
@@ -86,9 +102,20 @@ class QuizGenerationStatusServiceTest {
     @Test
     void getGenerationStatus_returns_failed_status() {
         Long userId = 1L;
-        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "failed", "quiz-job-1", null, "텍스트 길이 부족");
+        QuizSession quizSession = quizSession(100L, "quiz-session-public-id", userId, "failed", "quiz-job-1", null, null);
+        QuizGenerationJob generationJob = generationJob(
+                900L,
+                quizSession.getId(),
+                userId,
+                "failed",
+                100,
+                null,
+                "AI 응답 검증 실패"
+        );
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(quizGenerationJobRepository.findByQuizSessionId(quizSession.getId()))
+                .thenReturn(Optional.of(generationJob));
 
         QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
                 userId,
@@ -98,7 +125,7 @@ class QuizGenerationStatusServiceTest {
         assertThat(response.getStatus()).isEqualTo("failed");
         assertThat(response.getProgressPct()).isEqualTo(100);
         assertThat(response.getGeneratedCount()).isNull();
-        assertThat(response.getFailReason()).isEqualTo("텍스트 길이 부족");
+        assertThat(response.getFailReason()).isEqualTo("AI 응답 검증 실패");
     }
 
     @Test
@@ -115,6 +142,7 @@ class QuizGenerationStatusServiceTest {
     }
 
     private QuizSession quizSession(
+            Long id,
             String publicId,
             Long userId,
             String status,
@@ -123,6 +151,7 @@ class QuizGenerationStatusServiceTest {
             String failReason
     ) {
         QuizSession quizSession = org.springframework.beans.BeanUtils.instantiateClass(QuizSession.class);
+        ReflectionTestUtils.setField(quizSession, "id", id);
         ReflectionTestUtils.setField(quizSession, "publicId", publicId);
         ReflectionTestUtils.setField(quizSession, "userId", userId);
         ReflectionTestUtils.setField(quizSession, "status", status);
@@ -130,5 +159,25 @@ class QuizGenerationStatusServiceTest {
         ReflectionTestUtils.setField(quizSession, "generatedCount", generatedCount);
         ReflectionTestUtils.setField(quizSession, "failReason", failReason);
         return quizSession;
+    }
+
+    private QuizGenerationJob generationJob(
+            Long id,
+            Long quizSessionId,
+            Long userId,
+            String status,
+            Integer progressPct,
+            Integer estimatedSeconds,
+            String failReason
+    ) {
+        QuizGenerationJob generationJob = org.springframework.beans.BeanUtils.instantiateClass(QuizGenerationJob.class);
+        ReflectionTestUtils.setField(generationJob, "id", id);
+        ReflectionTestUtils.setField(generationJob, "quizSessionId", quizSessionId);
+        ReflectionTestUtils.setField(generationJob, "userId", userId);
+        ReflectionTestUtils.setField(generationJob, "status", status);
+        ReflectionTestUtils.setField(generationJob, "progressPct", progressPct);
+        ReflectionTestUtils.setField(generationJob, "estimatedSeconds", estimatedSeconds);
+        ReflectionTestUtils.setField(generationJob, "failReason", failReason);
+        return generationJob;
     }
 }

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
@@ -16,6 +16,7 @@ import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
 import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.event.QuizGenerationEnqueueRequestedEvent;
 import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
@@ -28,6 +29,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class QuizSessionCreateServiceTest {
@@ -37,8 +39,8 @@ class QuizSessionCreateServiceTest {
     private QuizSessionRepository quizSessionRepository;
     private QuizSessionScopeRepository quizSessionScopeRepository;
     private QuizGenerationJobRepository quizGenerationJobRepository;
-    private QuizGenerationQueue quizGenerationQueue;
     private QuizGenerationLockStore quizGenerationLockStore;
+    private ApplicationEventPublisher eventPublisher;
     private QuizSessionCreateService quizSessionCreateService;
 
     @BeforeEach
@@ -48,16 +50,16 @@ class QuizSessionCreateServiceTest {
         quizSessionRepository = mock(QuizSessionRepository.class);
         quizSessionScopeRepository = mock(QuizSessionScopeRepository.class);
         quizGenerationJobRepository = mock(QuizGenerationJobRepository.class);
-        quizGenerationQueue = mock(QuizGenerationQueue.class);
         quizGenerationLockStore = mock(QuizGenerationLockStore.class);
+        eventPublisher = mock(ApplicationEventPublisher.class);
         quizSessionCreateService = new QuizSessionCreateService(
                 subjectRepository,
                 partRepository,
                 quizSessionRepository,
                 quizSessionScopeRepository,
                 quizGenerationJobRepository,
-                quizGenerationQueue,
-                quizGenerationLockStore
+                quizGenerationLockStore,
+                eventPublisher
         );
     }
 
@@ -98,7 +100,7 @@ class QuizSessionCreateServiceTest {
                     ReflectionTestUtils.setField(quizSession, "id", 500L);
                     return quizSession;
                 });
-        stubGenerationJobSaveAndQueue(900L, "1748130000000-0");
+        stubGenerationJobSave(900L);
 
         QuizGenerationAcceptedResponse response = quizSessionCreateService.createQuizSession(userId, request);
 
@@ -141,12 +143,13 @@ class QuizSessionCreateServiceTest {
         assertThat(savedJob.getUserId()).isEqualTo(userId);
         assertThat(savedJob.getStatus()).isEqualTo("pending");
         assertThat(savedJob.getProgressPct()).isZero();
-        assertThat(savedJob.getMqMessageId()).isEqualTo("1748130000000-0");
+        // mqMessageId는 AFTER_COMMIT 리스너가 채움 — service 단위 테스트 범위 외
 
-        ArgumentCaptor<QuizGenerationQueueMessage> messageCaptor =
-                ArgumentCaptor.forClass(QuizGenerationQueueMessage.class);
-        verify(quizGenerationQueue).enqueue(messageCaptor.capture());
-        QuizGenerationQueueMessage queueMessage = messageCaptor.getValue();
+        // 실제 Redis 큐 발행은 리스너에서 수행 — service는 이벤트 발행만 검증
+        ArgumentCaptor<QuizGenerationEnqueueRequestedEvent> eventCaptor =
+                ArgumentCaptor.forClass(QuizGenerationEnqueueRequestedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        QuizGenerationQueueMessage queueMessage = eventCaptor.getValue().message();
         assertThat(queueMessage.generationJobId()).isEqualTo(900L);
         assertThat(queueMessage.quizSessionId()).isEqualTo(500L);
         assertThat(queueMessage.quizSessionPublicId()).isEqualTo(savedSession.getPublicId());
@@ -183,7 +186,7 @@ class QuizSessionCreateServiceTest {
                 .isEqualTo(ErrorCode.QUIZ_GENERATION_IN_PROGRESS);
 
         verifyNoInteractions(subjectRepository, partRepository, quizSessionScopeRepository,
-                quizGenerationJobRepository, quizGenerationQueue);
+                quizGenerationJobRepository, eventPublisher);
     }
 
     @Test
@@ -412,7 +415,7 @@ class QuizSessionCreateServiceTest {
                     ReflectionTestUtils.setField(quizSession, "id", 501L);
                     return quizSession;
                 });
-        stubGenerationJobSaveAndQueue(901L, "1748130000000-1");
+        stubGenerationJobSave(901L);
 
         quizSessionCreateService.createQuizSession(userId, request);
 
@@ -475,14 +478,13 @@ class QuizSessionCreateServiceTest {
                 .toList();
     }
 
-    private void stubGenerationJobSaveAndQueue(Long generationJobId, String messageId) {
+    private void stubGenerationJobSave(Long generationJobId) {
         when(quizGenerationJobRepository.save(any(QuizGenerationJob.class)))
                 .thenAnswer(invocation -> {
                     QuizGenerationJob generationJob = invocation.getArgument(0);
                     ReflectionTestUtils.setField(generationJob, "id", generationJobId);
                     return generationJob;
                 });
-        when(quizGenerationQueue.enqueue(any(QuizGenerationQueueMessage.class))).thenReturn(messageId);
     }
 
     private <T> T newEntity(Class<T> type) {

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
@@ -13,8 +13,10 @@ import com.f1.quiket.domain.part.entity.Part;
 import com.f1.quiket.domain.part.repository.PartRepository;
 import com.f1.quiket.domain.quiz.dto.QuizCreateRequest;
 import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
 import com.f1.quiket.domain.subject.entity.Subject;
@@ -34,6 +36,8 @@ class QuizSessionCreateServiceTest {
     private PartRepository partRepository;
     private QuizSessionRepository quizSessionRepository;
     private QuizSessionScopeRepository quizSessionScopeRepository;
+    private QuizGenerationJobRepository quizGenerationJobRepository;
+    private QuizGenerationQueue quizGenerationQueue;
     private QuizGenerationLockStore quizGenerationLockStore;
     private QuizSessionCreateService quizSessionCreateService;
 
@@ -43,12 +47,16 @@ class QuizSessionCreateServiceTest {
         partRepository = mock(PartRepository.class);
         quizSessionRepository = mock(QuizSessionRepository.class);
         quizSessionScopeRepository = mock(QuizSessionScopeRepository.class);
+        quizGenerationJobRepository = mock(QuizGenerationJobRepository.class);
+        quizGenerationQueue = mock(QuizGenerationQueue.class);
         quizGenerationLockStore = mock(QuizGenerationLockStore.class);
         quizSessionCreateService = new QuizSessionCreateService(
                 subjectRepository,
                 partRepository,
                 quizSessionRepository,
                 quizSessionScopeRepository,
+                quizGenerationJobRepository,
+                quizGenerationQueue,
                 quizGenerationLockStore
         );
     }
@@ -90,6 +98,7 @@ class QuizSessionCreateServiceTest {
                     ReflectionTestUtils.setField(quizSession, "id", 500L);
                     return quizSession;
                 });
+        stubGenerationJobSaveAndQueue(900L, "1748130000000-0");
 
         QuizGenerationAcceptedResponse response = quizSessionCreateService.createQuizSession(userId, request);
 
@@ -124,6 +133,26 @@ class QuizSessionCreateServiceTest {
                 .extracting(QuizSessionScope::getPartId)
                 .containsExactly(part1.getId(), part2.getId());
 
+        ArgumentCaptor<QuizGenerationJob> jobCaptor = ArgumentCaptor.forClass(QuizGenerationJob.class);
+        verify(quizGenerationJobRepository).save(jobCaptor.capture());
+        QuizGenerationJob savedJob = jobCaptor.getValue();
+        assertThat(savedJob.getId()).isEqualTo(900L);
+        assertThat(savedJob.getQuizSessionId()).isEqualTo(500L);
+        assertThat(savedJob.getUserId()).isEqualTo(userId);
+        assertThat(savedJob.getStatus()).isEqualTo("pending");
+        assertThat(savedJob.getProgressPct()).isZero();
+        assertThat(savedJob.getMqMessageId()).isEqualTo("1748130000000-0");
+
+        ArgumentCaptor<QuizGenerationQueueMessage> messageCaptor =
+                ArgumentCaptor.forClass(QuizGenerationQueueMessage.class);
+        verify(quizGenerationQueue).enqueue(messageCaptor.capture());
+        QuizGenerationQueueMessage queueMessage = messageCaptor.getValue();
+        assertThat(queueMessage.generationJobId()).isEqualTo(900L);
+        assertThat(queueMessage.quizSessionId()).isEqualTo(500L);
+        assertThat(queueMessage.quizSessionPublicId()).isEqualTo(savedSession.getPublicId());
+        assertThat(queueMessage.jobId()).isEqualTo(savedSession.getJobId());
+        assertThat(queueMessage.userId()).isEqualTo(userId);
+
         assertThat(response.getQuizSessionId()).isEqualTo(savedSession.getPublicId());
         assertThat(response.getJobId()).isEqualTo(savedSession.getJobId());
         assertThat(response.getStatus()).isEqualTo("pending");
@@ -153,7 +182,8 @@ class QuizSessionCreateServiceTest {
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(ErrorCode.QUIZ_GENERATION_IN_PROGRESS);
 
-        verifyNoInteractions(subjectRepository, partRepository, quizSessionScopeRepository);
+        verifyNoInteractions(subjectRepository, partRepository, quizSessionScopeRepository,
+                quizGenerationJobRepository, quizGenerationQueue);
     }
 
     @Test
@@ -382,6 +412,7 @@ class QuizSessionCreateServiceTest {
                     ReflectionTestUtils.setField(quizSession, "id", 501L);
                     return quizSession;
                 });
+        stubGenerationJobSaveAndQueue(901L, "1748130000000-1");
 
         quizSessionCreateService.createQuizSession(userId, request);
 
@@ -442,6 +473,16 @@ class QuizSessionCreateServiceTest {
     private List<QuizSessionScope> toList(Iterable<QuizSessionScope> scopes) {
         return java.util.stream.StreamSupport.stream(scopes.spliterator(), false)
                 .toList();
+    }
+
+    private void stubGenerationJobSaveAndQueue(Long generationJobId, String messageId) {
+        when(quizGenerationJobRepository.save(any(QuizGenerationJob.class)))
+                .thenAnswer(invocation -> {
+                    QuizGenerationJob generationJob = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(generationJob, "id", generationJobId);
+                    return generationJob;
+                });
+        when(quizGenerationQueue.enqueue(any(QuizGenerationQueueMessage.class))).thenReturn(messageId);
     }
 
     private <T> T newEntity(Class<T> type) {

--- a/src/test/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueueTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueueTest.java
@@ -1,0 +1,81 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+class RedisQuizGenerationQueueTest {
+
+    private StringRedisTemplate stringRedisTemplate;
+    private StreamOperations<String, Object, Object> streamOperations;
+    private RedisQuizGenerationQueue redisQuizGenerationQueue;
+
+    @BeforeEach
+    void setUp() {
+        stringRedisTemplate = mock(StringRedisTemplate.class);
+        streamOperations = mock(StreamOperations.class);
+        redisQuizGenerationQueue = new RedisQuizGenerationQueue(stringRedisTemplate);
+
+        when(stringRedisTemplate.opsForStream()).thenReturn(streamOperations);
+    }
+
+    @Test
+    void enqueue_adds_generation_job_to_redis_stream() {
+        QuizGenerationQueueMessage message = new QuizGenerationQueueMessage(
+                900L,
+                500L,
+                "quiz-session-public-id",
+                "quiz-job-public-id",
+                1L
+        );
+        when(streamOperations.add(eq("quiz:generation:jobs"), any(Map.class)))
+                .thenReturn(RecordId.of("1748130000000-0"));
+
+        String messageId = redisQuizGenerationQueue.enqueue(message);
+
+        assertThat(messageId).isEqualTo("1748130000000-0");
+
+        ArgumentCaptor<Map<String, String>> recordCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(streamOperations).add(eq("quiz:generation:jobs"), recordCaptor.capture());
+        assertThat(recordCaptor.getValue())
+                .containsEntry("generationJobId", "900")
+                .containsEntry("quizSessionId", "500")
+                .containsEntry("quizSessionPublicId", "quiz-session-public-id")
+                .containsEntry("jobId", "quiz-job-public-id")
+                .containsEntry("userId", "1");
+    }
+
+    @Test
+    void enqueue_throws_service_unavailable_when_redis_fails() {
+        QuizGenerationQueueMessage message = new QuizGenerationQueueMessage(
+                900L,
+                500L,
+                "quiz-session-public-id",
+                "quiz-job-public-id",
+                1L
+        );
+        when(streamOperations.add(eq("quiz:generation:jobs"), any(Map.class)))
+                .thenThrow(new DataAccessResourceFailureException("redis down"));
+
+        assertThatThrownBy(() -> redisQuizGenerationQueue.enqueue(message))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.SERVICE_UNAVAILABLE);
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- QUIZ-GEN-001 비동기 퀴즈 생성의 1차 기반 구현
- 실제 AOAI 호출 전 작업 이력과 Redis Streams 큐 발행 구조 구성

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `quiz_generation_jobs` Flyway migration 추가
- 퀴즈 생성 작업 엔티티/리포지토리 추가
- 생성 요청 시 `quiz_sessions`, `quiz_generation_jobs` 저장 후 Redis Stream enqueue
- `QuizGenerationQueue` 인터페이스와 Redis 구현체 추가
- 생성 상태 조회를 `quiz_generation_jobs` 기준으로 정리
- 퀴즈 생성/상태 조회/Redis 큐 테스트 보강

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.domain.quiz.service.RedisQuizGenerationQueueTest --tests com.f1.quiket.domain.quiz.service.QuizSessionCreateServiceTest --tests com.f1.quiket.domain.quiz.service.QuizGenerationStatusServiceTest`
2. `./gradlew test`
3. `./gradlew check`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #77

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 이번 PR은 작업 이력 생성과 Redis 큐 발행까지만 포함
- AOAI 실제 호출, Worker consume, 문항 저장, FCM 발송은 후속 이슈에서 처리
- Redis Stream key는 `quiz:generation:jobs` 사용

---

## 🧑‍💻 Assignee

- @imclaremont
