### PR TITLE
[Feat] AI 생성 결과 저장 및 실패 처리 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/quiz/entity/Question.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/Question.java
@@ -79,4 +79,36 @@ public class Question {
 
     @Column(name = "display_order", nullable = false)
     Integer displayOrder;
+
+    public static Question create(
+            String publicId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            Long chapterId,
+            Long partId,
+            String questionType,
+            String difficulty,
+            String body,
+            String summary,
+            String correctExplanation,
+            String incorrectExplanation,
+            Integer displayOrder
+    ) {
+        Question question = new Question();
+        question.publicId = publicId;
+        question.quizSessionId = quizSessionId;
+        question.userId = userId;
+        question.subjectId = subjectId;
+        question.chapterId = chapterId;
+        question.partId = partId;
+        question.questionType = questionType;
+        question.difficulty = difficulty;
+        question.body = body;
+        question.summary = summary;
+        question.correctExplanation = correctExplanation;
+        question.incorrectExplanation = incorrectExplanation;
+        question.displayOrder = displayOrder;
+        return question;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionAnswer.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionAnswer.java
@@ -37,4 +37,11 @@ public class QuestionAnswer {
 
     @Column(name = "answer_value", length = 10, nullable = false)
     String answerValue;
+
+    public static QuestionAnswer create(Long questionId, String answerValue) {
+        QuestionAnswer answer = new QuestionAnswer();
+        answer.questionId = questionId;
+        answer.answerValue = answerValue;
+        return answer;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionOption.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionOption.java
@@ -49,4 +49,18 @@ public class QuestionOption {
 
     @Column(name = "is_correct", nullable = false)
     Boolean correct;
+
+    public static QuestionOption create(
+            Long questionId,
+            Integer optionNumber,
+            String content,
+            Boolean correct
+    ) {
+        QuestionOption option = new QuestionOption();
+        option.questionId = questionId;
+        option.optionNumber = optionNumber;
+        option.content = content;
+        option.correct = correct;
+        return option;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizGenerationJob.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizGenerationJob.java
@@ -153,4 +153,10 @@ public class QuizGenerationJob {
     public void increaseRetryCount() {
         this.retryCount++;
     }
+
+    public boolean isTerminalStatus() {
+        return STATUS_COMPLETED.equals(this.status)
+                || STATUS_FAILED.equals(this.status)
+                || STATUS_TIMEOUT.equals(this.status);
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizSession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizSession.java
@@ -33,6 +33,11 @@ import lombok.experimental.FieldDefaults;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class QuizSession extends BaseEntity {
 
+    private static final String STATUS_IN_PROGRESS = "in_progress";
+    private static final String STATUS_COMPLETED = "completed";
+    private static final String STATUS_FAILED = "failed";
+    private static final int FAIL_REASON_MAX_LENGTH = 255;
+
     @Column(name = "public_id", length = 36, nullable = false)
     String publicId;
 
@@ -111,5 +116,30 @@ public class QuizSession extends BaseEntity {
         quizSession.status = status;
         quizSession.jobId = jobId;
         return quizSession;
+    }
+
+    public void markGenerationInProgress() {
+        this.status = STATUS_IN_PROGRESS;
+        this.failReason = null;
+    }
+
+    public void markGenerationCompleted(Integer generatedCount) {
+        this.status = STATUS_COMPLETED;
+        this.generatedCount = generatedCount;
+        this.failReason = null;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void markGenerationFailed(String failReason) {
+        this.status = STATUS_FAILED;
+        this.failReason = truncateFailReason(failReason);
+        this.completedAt = LocalDateTime.now();
+    }
+
+    private String truncateFailReason(String failReason) {
+        if (failReason == null || failReason.length() <= FAIL_REASON_MAX_LENGTH) {
+            return failReason;
+        }
+        return failReason.substring(0, FAIL_REASON_MAX_LENGTH);
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizGenerationJobRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizGenerationJobRepository.java
@@ -1,6 +1,8 @@
 package com.f1.quiket.domain.quiz.repository;
 
 import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface QuizGenerationJobRepository extends JpaRepository<QuizGenerationJob, Long> {
 
     Optional<QuizGenerationJob> findByQuizSessionId(Long quizSessionId);
+
+    List<QuizGenerationJob> findAllByStatusAndTimeoutAtBefore(String status, LocalDateTime timeoutAt);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
@@ -27,4 +27,9 @@ public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> 
      * 사용자 퀴즈 세션 단건 조회
      */
     Optional<QuizSession> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
+
+    /**
+     * 사용자 퀴즈 세션 단건 조회 (PK 기반)
+     */
+    Optional<QuizSession> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionScopeRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionScopeRepository.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.quiz.repository;
 
 import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,9 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface QuizSessionScopeRepository extends JpaRepository<QuizSessionScope, Long> {
+
+    /**
+     * 퀴즈 세션 출제 범위 목록 조회
+     */
+    List<QuizSessionScope> findAllByQuizSessionId(Long quizSessionId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessor.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessor.java
@@ -56,6 +56,14 @@ public class QuizGenerationJobProcessor {
     private final QuestionAnswerRepository questionAnswerRepository;
     private final TransactionTemplate transactionTemplate;
 
+    /**
+     * 퀴즈 생성 작업 처리.
+     *
+     * <p>성공/실패 무관 항상 {@code true} 반환 — 호출 측({@code QuizGenerationWorker})이
+     * 큐에서 메시지를 ack(삭제)하도록 함. 실패 케이스는 generation_job/quiz_session을
+     * failed 상태로 마킹해 사용자 status 조회로 노출되며, 큐에는 남기지 않음 (자동 재시도 X).
+     * 자동 재시도가 필요해지면 후속 이슈에서 {@code retryCount}/{@code is_retryable} 기반 재enqueue 도입.</p>
+     */
     public boolean process(QuizGenerationQueueMessage message) {
         try {
             GenerationContext context = transactionTemplate.execute(status -> prepareContext(message));

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessor.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessor.java
@@ -1,0 +1,256 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.dto.QuizAiGeneratedOption;
+import com.f1.quiket.domain.quiz.dto.QuizAiGeneratedQuestion;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationPrompt;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationRequest;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.global.util.UuidV7Generator;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class QuizGenerationJobProcessor {
+
+    private static final String STATUS_IN_PROGRESS = "in_progress";
+    private static final String FAIL_CODE_GENERATION_FAILED = "quiz_generation_failed";
+    private static final String TIMEOUT_FAIL_REASON = "퀴즈 생성 작업이 제한 시간을 초과했습니다.";
+    private static final int MAX_RETRY_COUNT = 3;
+    private static final int FAIL_REASON_MAX_LENGTH = 500;
+
+    private final QuizAiClient quizAiClient;
+    private final QuizGenerationPromptBuilder promptBuilder;
+    private final QuizAiResponseValidator responseValidator;
+    private final QuizGenerationJobRepository quizGenerationJobRepository;
+    private final QuizSessionRepository quizSessionRepository;
+    private final QuizSessionScopeRepository quizSessionScopeRepository;
+    private final SubjectRepository subjectRepository;
+    private final PartRepository partRepository;
+    private final QuestionRepository questionRepository;
+    private final QuestionOptionRepository questionOptionRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
+    private final TransactionTemplate transactionTemplate;
+
+    public boolean process(QuizGenerationQueueMessage message) {
+        try {
+            GenerationContext context = transactionTemplate.execute(status -> prepareContext(message));
+            if (context == null) {
+                return true;
+            }
+
+            QuizAiGenerationPrompt prompt = promptBuilder.build(context.request());
+            QuizAiGenerationResponse response = quizAiClient.generate(prompt);
+            responseValidator.validate(context.request(), response);
+
+            transactionTemplate.executeWithoutResult(status -> completeGeneration(context, response));
+            return true;
+        } catch (Exception e) {
+            transactionTemplate.executeWithoutResult(status -> failGeneration(message, e));
+            return true;
+        }
+    }
+
+    public int markTimedOutJobs() {
+        Integer count = transactionTemplate.execute(status -> {
+            List<QuizGenerationJob> jobs = quizGenerationJobRepository.findAllByStatusAndTimeoutAtBefore(
+                    STATUS_IN_PROGRESS,
+                    LocalDateTime.now()
+            );
+            jobs.forEach(this::markTimedOutJob);
+            return jobs.size();
+        });
+        return count == null ? 0 : count;
+    }
+
+    private GenerationContext prepareContext(QuizGenerationQueueMessage message) {
+        QuizGenerationJob job = quizGenerationJobRepository.findById(message.generationJobId())
+                .orElse(null);
+        if (job == null || job.isTerminalStatus()) {
+            return null;
+        }
+
+        QuizSession quizSession = findQuizSession(message);
+        Subject subject = subjectRepository
+                .findByIdAndUserIdAndDeletedAtIsNull(quizSession.getSubjectId(), quizSession.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+        List<Part> parts = findScopeParts(quizSession);
+
+        job.markInProgress();
+        quizSession.markGenerationInProgress();
+
+        QuizAiGenerationRequest request = new QuizAiGenerationRequest(
+                subject,
+                parts,
+                quizSession.getQuizType(),
+                quizSession.getChoiceCount(),
+                quizSession.getQuestionCount(),
+                quizSession.getPlayMode(),
+                quizSession.getTimerEnabled(),
+                quizSession.getTimerScope(),
+                quizSession.getTimerSeconds(),
+                quizSession.getDifficulty()
+        );
+        Map<String, Part> partsByPublicId = parts.stream()
+                .collect(Collectors.toMap(Part::getPublicId, Function.identity()));
+        return new GenerationContext(message.generationJobId(), quizSession.getId(), quizSession.getUserId(), request, partsByPublicId);
+    }
+
+    private QuizSession findQuizSession(QuizGenerationQueueMessage message) {
+        return quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(message.quizSessionId(), message.userId())
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+    }
+
+    private List<Part> findScopeParts(QuizSession quizSession) {
+        List<Long> partIds = quizSessionScopeRepository.findAllByQuizSessionId(quizSession.getId()).stream()
+                .map(QuizSessionScope::getPartId)
+                .toList();
+        if (partIds.isEmpty()) {
+            throw new CustomException(ErrorCode.QUIZ_SCOPE_INVALID);
+        }
+
+        List<Part> parts = partRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(partIds, quizSession.getUserId());
+        if (parts.size() != partIds.stream().distinct().count()) {
+            throw new CustomException(ErrorCode.QUIZ_SCOPE_INVALID);
+        }
+        return parts;
+    }
+
+    private void completeGeneration(GenerationContext context, QuizAiGenerationResponse response) {
+        QuizGenerationJob job = quizGenerationJobRepository.findById(context.generationJobId())
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        if (job.isTerminalStatus()) {
+            return;
+        }
+
+        QuizSession quizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(
+                context.quizSessionId(),
+                context.userId()
+        ).orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+
+        List<QuizAiGeneratedQuestion> generatedQuestions = response.getQuestions();
+        for (int i = 0; i < generatedQuestions.size(); i++) {
+            saveQuestion(quizSession, context.partsByPublicId(), generatedQuestions.get(i), i + 1);
+        }
+        quizSession.markGenerationCompleted(generatedQuestions.size());
+        job.markCompleted();
+    }
+
+    private void saveQuestion(
+            QuizSession quizSession,
+            Map<String, Part> partsByPublicId,
+            QuizAiGeneratedQuestion generatedQuestion,
+            int displayOrder
+    ) {
+        Part part = partsByPublicId.get(generatedQuestion.getPartId());
+        if (part == null) {
+            throw new CustomException(ErrorCode.QUIZ_SCOPE_INVALID);
+        }
+
+        Question savedQuestion = questionRepository.save(Question.create(
+                UuidV7Generator.generate(),
+                quizSession.getId(),
+                quizSession.getUserId(),
+                quizSession.getSubjectId(),
+                part.getChapterId(),
+                part.getId(),
+                generatedQuestion.getQuestionType(),
+                generatedQuestion.getDifficulty(),
+                generatedQuestion.getBody(),
+                generatedQuestion.getSummary(),
+                generatedQuestion.getCorrectExplanation(),
+                generatedQuestion.getIncorrectExplanation(),
+                displayOrder
+        ));
+        saveOptions(savedQuestion, generatedQuestion);
+        questionAnswerRepository.save(QuestionAnswer.create(savedQuestion.getId(), generatedQuestion.getAnswerValue()));
+    }
+
+    private void saveOptions(Question question, QuizAiGeneratedQuestion generatedQuestion) {
+        List<QuizAiGeneratedOption> generatedOptions = generatedQuestion.getOptions();
+        if (generatedOptions == null || generatedOptions.isEmpty()) {
+            return;
+        }
+
+        List<QuestionOption> options = generatedOptions.stream()
+                .map(option -> QuestionOption.create(
+                        question.getId(),
+                        option.getOptionNumber(),
+                        option.getContent(),
+                        String.valueOf(option.getOptionNumber()).equals(generatedQuestion.getAnswerValue())
+                ))
+                .toList();
+        questionOptionRepository.saveAll(options);
+    }
+
+    private void failGeneration(QuizGenerationQueueMessage message, Exception e) {
+        QuizGenerationJob job = quizGenerationJobRepository.findById(message.generationJobId())
+                .orElse(null);
+        if (job == null || job.isTerminalStatus()) {
+            return;
+        }
+
+        job.increaseRetryCount();
+        String failReason = truncateFailReason(resolveFailReason(e));
+        job.markFailed(resolveFailCode(e), failReason, job.getRetryCount() < MAX_RETRY_COUNT);
+        quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(message.quizSessionId(), message.userId())
+                .ifPresent(quizSession -> quizSession.markGenerationFailed(failReason));
+    }
+
+    private void markTimedOutJob(QuizGenerationJob job) {
+        job.markTimeout(TIMEOUT_FAIL_REASON);
+        quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(job.getQuizSessionId(), job.getUserId())
+                .ifPresent(quizSession -> quizSession.markGenerationFailed(TIMEOUT_FAIL_REASON));
+    }
+
+    private String resolveFailCode(Exception e) {
+        if (e instanceof CustomException customException) {
+            return customException.getErrorCode().getCode();
+        }
+        return FAIL_CODE_GENERATION_FAILED;
+    }
+
+    private String resolveFailReason(Exception e) {
+        return e.getMessage() == null ? "퀴즈 생성 처리에 실패했습니다." : e.getMessage();
+    }
+
+    private String truncateFailReason(String failReason) {
+        if (failReason.length() <= FAIL_REASON_MAX_LENGTH) {
+            return failReason;
+        }
+        return failReason.substring(0, FAIL_REASON_MAX_LENGTH);
+    }
+
+    private record GenerationContext(
+            Long generationJobId,
+            Long quizSessionId,
+            Long userId,
+            QuizAiGenerationRequest request,
+            Map<String, Part> partsByPublicId
+    ) {
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueue.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueue.java
@@ -1,6 +1,12 @@
 package com.f1.quiket.domain.quiz.service;
 
+import java.util.Optional;
+
 public interface QuizGenerationQueue {
 
     String enqueue(QuizGenerationQueueMessage message);
+
+    Optional<QuizGenerationQueueRecord> poll();
+
+    void acknowledge(String messageId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueueRecord.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueueRecord.java
@@ -1,0 +1,7 @@
+package com.f1.quiket.domain.quiz.service;
+
+public record QuizGenerationQueueRecord(
+        String messageId,
+        QuizGenerationQueueMessage message
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
@@ -2,9 +2,14 @@ package com.f1.quiket.domain.quiz.service;
 
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.Limit;
+import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
@@ -14,6 +19,7 @@ import org.springframework.stereotype.Component;
 public class RedisQuizGenerationQueue implements QuizGenerationQueue {
 
     private static final String STREAM_KEY = "quiz:generation:jobs";
+    private static final int POLL_COUNT = 1;
 
     private final StringRedisTemplate stringRedisTemplate;
 
@@ -31,6 +37,34 @@ public class RedisQuizGenerationQueue implements QuizGenerationQueue {
         }
     }
 
+    @Override
+    public Optional<QuizGenerationQueueRecord> poll() {
+        try {
+            List<MapRecord<String, Object, Object>> records = stringRedisTemplate.opsForStream()
+                    .range(STREAM_KEY, Range.unbounded(), Limit.limit().count(POLL_COUNT));
+            if (records == null || records.isEmpty()) {
+                return Optional.empty();
+            }
+
+            MapRecord<String, Object, Object> record = records.get(0);
+            return Optional.of(new QuizGenerationQueueRecord(
+                    record.getId().getValue(),
+                    toMessage(record.getValue())
+            ));
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    @Override
+    public void acknowledge(String messageId) {
+        try {
+            stringRedisTemplate.opsForStream().delete(STREAM_KEY, messageId);
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
     private Map<String, String> toRecord(QuizGenerationQueueMessage message) {
         return Map.of(
                 "generationJobId", String.valueOf(message.generationJobId()),
@@ -39,5 +73,27 @@ public class RedisQuizGenerationQueue implements QuizGenerationQueue {
                 "jobId", message.jobId(),
                 "userId", String.valueOf(message.userId())
         );
+    }
+
+    private QuizGenerationQueueMessage toMessage(Map<Object, Object> record) {
+        return new QuizGenerationQueueMessage(
+                parseLong(record, "generationJobId"),
+                parseLong(record, "quizSessionId"),
+                value(record, "quizSessionPublicId"),
+                value(record, "jobId"),
+                parseLong(record, "userId")
+        );
+    }
+
+    private Long parseLong(Map<Object, Object> record, String key) {
+        return Long.valueOf(value(record, key));
+    }
+
+    private String value(Map<Object, Object> record, String key) {
+        Object value = record.get(key);
+        if (value == null) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE);
+        }
+        return String.valueOf(value);
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
@@ -14,6 +14,18 @@ import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+/**
+ * Redis Stream 기반 퀴즈 생성 큐 — MVP 단일 워커 가정.
+ *
+ * <h3>제약</h3>
+ * <ul>
+ *     <li>{@code XRANGE} + {@code XDEL} 패턴 — Consumer Group({@code XREADGROUP}/{@code XACK}) 미사용</li>
+ *     <li>워커 인스턴스가 2개 이상이면 동일 메시지가 중복 처리될 수 있음 — 단일 워커 한정으로만 안전</li>
+ *     <li>워커가 처리 도중 죽으면 {@link #acknowledge(String)}가 호출되지 않아 같은 메시지가 다음 poll에 재선택 → 처리 idempotency 가정 필요</li>
+ * </ul>
+ *
+ * <p>운영 트래픽 증가 또는 워커 다중화 시 Consumer Group 기반 redelivery로 전환 필요 (후속 이슈).</p>
+ */
 @Component
 @RequiredArgsConstructor
 public class RedisQuizGenerationQueue implements QuizGenerationQueue {

--- a/src/main/java/com/f1/quiket/support/quiz/QuizGenerationWorker.java
+++ b/src/main/java/com/f1/quiket/support/quiz/QuizGenerationWorker.java
@@ -8,6 +8,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+/**
+ * Redis Stream에서 퀴즈 생성 작업을 poll하여 처리하는 단일 워커.
+ *
+ * <p>{@code @Scheduled} 기본 단일 스레드라 한 인스턴스 내에서 동시 실행 없음.
+ * 다중 인스턴스 운영은 {@link com.f1.quiket.domain.quiz.service.RedisQuizGenerationQueue}의
+ * 단일 워커 가정과 충돌하므로 Consumer Group 도입 전까지 금지.</p>
+ */
 @Component
 @RequiredArgsConstructor
 @ConditionalOnProperty(name = "quiket.quiz.generation.worker.enabled", havingValue = "true")
@@ -16,12 +23,18 @@ public class QuizGenerationWorker {
     private final QuizGenerationQueue quizGenerationQueue;
     private final QuizGenerationJobProcessor quizGenerationJobProcessor;
 
+    /**
+     * 큐에서 1건 poll하여 처리하고 성공/실패 무관 ack한다.
+     */
     @Scheduled(fixedDelayString = "${quiket.quiz.generation.worker.fixed-delay-ms:1000}")
-    public void consume() {
+    public void pollAndProcess() {
         quizGenerationQueue.poll()
                 .ifPresent(this::processRecord);
     }
 
+    /**
+     * timeout_at 초과한 in_progress 작업을 timeout 상태로 정리한다.
+     */
     @Scheduled(fixedDelayString = "${quiket.quiz.generation.worker.timeout-sweep-fixed-delay-ms:60000}")
     public void sweepTimeouts() {
         quizGenerationJobProcessor.markTimedOutJobs();

--- a/src/main/java/com/f1/quiket/support/quiz/QuizGenerationWorker.java
+++ b/src/main/java/com/f1/quiket/support/quiz/QuizGenerationWorker.java
@@ -1,0 +1,36 @@
+package com.f1.quiket.support.quiz;
+
+import com.f1.quiket.domain.quiz.service.QuizGenerationJobProcessor;
+import com.f1.quiket.domain.quiz.service.QuizGenerationQueue;
+import com.f1.quiket.domain.quiz.service.QuizGenerationQueueRecord;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "quiket.quiz.generation.worker.enabled", havingValue = "true")
+public class QuizGenerationWorker {
+
+    private final QuizGenerationQueue quizGenerationQueue;
+    private final QuizGenerationJobProcessor quizGenerationJobProcessor;
+
+    @Scheduled(fixedDelayString = "${quiket.quiz.generation.worker.fixed-delay-ms:1000}")
+    public void consume() {
+        quizGenerationQueue.poll()
+                .ifPresent(this::processRecord);
+    }
+
+    @Scheduled(fixedDelayString = "${quiket.quiz.generation.worker.timeout-sweep-fixed-delay-ms:60000}")
+    public void sweepTimeouts() {
+        quizGenerationJobProcessor.markTimedOutJobs();
+    }
+
+    private void processRecord(QuizGenerationQueueRecord record) {
+        boolean processed = quizGenerationJobProcessor.process(record.message());
+        if (processed) {
+            quizGenerationQueue.acknowledge(record.messageId());
+        }
+    }
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -69,3 +69,9 @@ quiket:
   jwt:
     secret: ${QUIKET_JWT_SECRET}
     enabled: false  # Swagger UI 비활성화
+  quiz:
+    generation:
+      worker:
+        enabled: ${QUIKET_QUIZ_GENERATION_WORKER_ENABLED:true}
+        fixed-delay-ms: ${QUIKET_QUIZ_GENERATION_WORKER_FIXED_DELAY_MS:1000}
+        timeout-sweep-fixed-delay-ms: ${QUIKET_QUIZ_GENERATION_TIMEOUT_SWEEP_FIXED_DELAY_MS:60000}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,6 +44,12 @@ quiket:
     secret: ${QUIKET_JWT_SECRET:local-dev-jwt-secret-for-quiket-f1-authentication}
     access-token-expires-in-seconds: 1800
     refresh-token-expires-in-seconds: 2592000
+  quiz:
+    generation:
+      worker:
+        enabled: ${QUIKET_QUIZ_GENERATION_WORKER_ENABLED:false}
+        fixed-delay-ms: ${QUIKET_QUIZ_GENERATION_WORKER_FIXED_DELAY_MS:1000}
+        timeout-sweep-fixed-delay-ms: ${QUIKET_QUIZ_GENERATION_TIMEOUT_SWEEP_FIXED_DELAY_MS:60000}
 
 kakao:
   oauth:

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessorTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessorTest.java
@@ -1,0 +1,288 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.BeanUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+class QuizGenerationJobProcessorTest {
+
+    private QuizAiClient quizAiClient;
+    private QuizGenerationJobRepository quizGenerationJobRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private QuizSessionScopeRepository quizSessionScopeRepository;
+    private SubjectRepository subjectRepository;
+    private PartRepository partRepository;
+    private QuestionRepository questionRepository;
+    private QuestionOptionRepository questionOptionRepository;
+    private QuestionAnswerRepository questionAnswerRepository;
+    private QuizGenerationJobProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        quizAiClient = mock(QuizAiClient.class);
+        quizGenerationJobRepository = mock(QuizGenerationJobRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        quizSessionScopeRepository = mock(QuizSessionScopeRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        partRepository = mock(PartRepository.class);
+        questionRepository = mock(QuestionRepository.class);
+        questionOptionRepository = mock(QuestionOptionRepository.class);
+        questionAnswerRepository = mock(QuestionAnswerRepository.class);
+
+        PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+        when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+        doNothing().when(transactionManager).commit(any(TransactionStatus.class));
+        doNothing().when(transactionManager).rollback(any(TransactionStatus.class));
+
+        processor = new QuizGenerationJobProcessor(
+                quizAiClient,
+                new QuizGenerationPromptBuilder(),
+                new QuizAiResponseValidator(),
+                quizGenerationJobRepository,
+                quizSessionRepository,
+                quizSessionScopeRepository,
+                subjectRepository,
+                partRepository,
+                questionRepository,
+                questionOptionRepository,
+                questionAnswerRepository,
+                new TransactionTemplate(transactionManager)
+        );
+    }
+
+    @Test
+    void process_saves_generated_questions_and_marks_completed() {
+        QuizGenerationJob job = job(900L, 500L, 1L);
+        QuizSession quizSession = quizSession(500L, 1L, 10L, "pending");
+        Subject subject = subject(10L, 1L);
+        Part part = part(100L, "part-public-id", 200L, 10L, 1L);
+        stubGenerationContext(job, quizSession, subject, part);
+        when(quizAiClient.generate(any())).thenReturn(aiResponse());
+        stubQuestionSave();
+
+        boolean processed = processor.process(message());
+
+        assertThat(processed).isTrue();
+        assertThat(job.getStatus()).isEqualTo("completed");
+        assertThat(job.getProgressPct()).isEqualTo(100);
+        assertThat(job.isRetryable()).isFalse();
+        assertThat(quizSession.getStatus()).isEqualTo("completed");
+        assertThat(quizSession.getGeneratedCount()).isEqualTo(1);
+
+        ArgumentCaptor<Question> questionCaptor = ArgumentCaptor.forClass(Question.class);
+        verify(questionRepository).save(questionCaptor.capture());
+        Question question = questionCaptor.getValue();
+        assertThat(question.getQuizSessionId()).isEqualTo(500L);
+        assertThat(question.getUserId()).isEqualTo(1L);
+        assertThat(question.getSubjectId()).isEqualTo(10L);
+        assertThat(question.getChapterId()).isEqualTo(200L);
+        assertThat(question.getPartId()).isEqualTo(100L);
+        assertThat(question.getQuestionType()).isEqualTo("multiple_choice");
+        assertThat(question.getSummary()).isEqualTo("데이터모델링핵심");
+        assertThat(question.getDisplayOrder()).isEqualTo(1);
+
+        ArgumentCaptor<Iterable<QuestionOption>> optionsCaptor = ArgumentCaptor.forClass(Iterable.class);
+        verify(questionOptionRepository).saveAll(optionsCaptor.capture());
+        List<QuestionOption> options = toList(optionsCaptor.getValue());
+        assertThat(options).hasSize(4);
+        assertThat(options.get(0).getQuestionId()).isEqualTo(1000L);
+        assertThat(options.get(0).getOptionNumber()).isEqualTo(1);
+        assertThat(options.get(0).getCorrect()).isTrue();
+        assertThat(options.get(1).getCorrect()).isFalse();
+
+        ArgumentCaptor<QuestionAnswer> answerCaptor = ArgumentCaptor.forClass(QuestionAnswer.class);
+        verify(questionAnswerRepository).save(answerCaptor.capture());
+        assertThat(answerCaptor.getValue().getQuestionId()).isEqualTo(1000L);
+        assertThat(answerCaptor.getValue().getAnswerValue()).isEqualTo("1");
+    }
+
+    @Test
+    void process_marks_failed_when_ai_client_fails() {
+        QuizGenerationJob job = job(900L, 500L, 1L);
+        QuizSession quizSession = quizSession(500L, 1L, 10L, "pending");
+        Subject subject = subject(10L, 1L);
+        Part part = part(100L, "part-public-id", 200L, 10L, 1L);
+        stubGenerationContext(job, quizSession, subject, part);
+        when(quizAiClient.generate(any()))
+                .thenThrow(new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AOAI 호출 실패"));
+
+        boolean processed = processor.process(message());
+
+        assertThat(processed).isTrue();
+        assertThat(job.getStatus()).isEqualTo("failed");
+        assertThat(job.getRetryCount()).isEqualTo(1);
+        assertThat(job.getFailCode()).isEqualTo(ErrorCode.SERVICE_UNAVAILABLE.getCode());
+        assertThat(job.getFailReason()).isEqualTo("AOAI 호출 실패");
+        assertThat(job.isRetryable()).isTrue();
+        assertThat(quizSession.getStatus()).isEqualTo("failed");
+        assertThat(quizSession.getFailReason()).isEqualTo("AOAI 호출 실패");
+        verifyNoInteractions(questionRepository, questionOptionRepository, questionAnswerRepository);
+    }
+
+    @Test
+    void markTimedOutJobs_marks_job_timeout_and_session_failed() {
+        QuizGenerationJob job = job(900L, 500L, 1L);
+        job.markInProgress();
+        ReflectionTestUtils.setField(job, "timeoutAt", LocalDateTime.now().minusSeconds(1));
+        QuizSession quizSession = quizSession(500L, 1L, 10L, "in_progress");
+
+        when(quizGenerationJobRepository.findAllByStatusAndTimeoutAtBefore(any(), any()))
+                .thenReturn(List.of(job));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(500L, 1L))
+                .thenReturn(Optional.of(quizSession));
+
+        int count = processor.markTimedOutJobs();
+
+        assertThat(count).isEqualTo(1);
+        assertThat(job.getStatus()).isEqualTo("timeout");
+        assertThat(job.getFailCode()).isEqualTo("timeout");
+        assertThat(job.getFailReason()).isEqualTo("퀴즈 생성 작업이 제한 시간을 초과했습니다.");
+        assertThat(quizSession.getStatus()).isEqualTo("failed");
+        assertThat(quizSession.getFailReason()).isEqualTo("퀴즈 생성 작업이 제한 시간을 초과했습니다.");
+    }
+
+    private void stubGenerationContext(QuizGenerationJob job, QuizSession quizSession, Subject subject, Part part) {
+        when(quizGenerationJobRepository.findById(900L)).thenReturn(Optional.of(job));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(500L, 1L)).thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(10L, 1L)).thenReturn(Optional.of(subject));
+        when(quizSessionScopeRepository.findAllByQuizSessionId(500L))
+                .thenReturn(List.of(QuizSessionScope.create(500L, 100L, 200L)));
+        when(partRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(List.of(100L), 1L))
+                .thenReturn(List.of(part));
+    }
+
+    private void stubQuestionSave() {
+        AtomicLong sequence = new AtomicLong(1000L);
+        when(questionRepository.save(any(Question.class))).thenAnswer(invocation -> {
+            Question question = invocation.getArgument(0);
+            ReflectionTestUtils.setField(question, "id", sequence.getAndIncrement());
+            return question;
+        });
+    }
+
+    private QuizGenerationQueueMessage message() {
+        return new QuizGenerationQueueMessage(900L, 500L, "quiz-session-public-id", "quiz-job-public-id", 1L);
+    }
+
+    private QuizGenerationJob job(Long id, Long quizSessionId, Long userId) {
+        QuizGenerationJob job = QuizGenerationJob.create(quizSessionId, userId, null);
+        ReflectionTestUtils.setField(job, "id", id);
+        return job;
+    }
+
+    private QuizSession quizSession(Long id, Long userId, Long subjectId, String status) {
+        QuizSession quizSession = BeanUtils.instantiateClass(QuizSession.class);
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        ReflectionTestUtils.setField(quizSession, "publicId", "quiz-session-public-id");
+        ReflectionTestUtils.setField(quizSession, "userId", userId);
+        ReflectionTestUtils.setField(quizSession, "subjectId", subjectId);
+        ReflectionTestUtils.setField(quizSession, "quizType", "multiple_choice");
+        ReflectionTestUtils.setField(quizSession, "choiceCount", 4);
+        ReflectionTestUtils.setField(quizSession, "questionCount", 1);
+        ReflectionTestUtils.setField(quizSession, "playMode", "one_by_one");
+        ReflectionTestUtils.setField(quizSession, "timerEnabled", false);
+        ReflectionTestUtils.setField(quizSession, "difficulty", "medium");
+        ReflectionTestUtils.setField(quizSession, "status", status);
+        ReflectionTestUtils.setField(quizSession, "jobId", "quiz-job-public-id");
+        return quizSession;
+    }
+
+    private Subject subject(Long id, Long userId) {
+        Subject subject = BeanUtils.instantiateClass(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", "subject-public-id");
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", "데이터 모델링");
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private Part part(Long id, String publicId, Long chapterId, Long subjectId, Long userId) {
+        Part part = BeanUtils.instantiateClass(Part.class);
+        ReflectionTestUtils.setField(part, "id", id);
+        ReflectionTestUtils.setField(part, "publicId", publicId);
+        ReflectionTestUtils.setField(part, "chapterId", chapterId);
+        ReflectionTestUtils.setField(part, "subjectId", subjectId);
+        ReflectionTestUtils.setField(part, "userId", userId);
+        ReflectionTestUtils.setField(part, "name", "데이터 모델링 개요");
+        ReflectionTestUtils.setField(part, "partNumber", 1);
+        ReflectionTestUtils.setField(part, "content", "데이터 모델링은 현실 세계의 데이터를 추상화하고 구조화하는 과정입니다.");
+        return part;
+    }
+
+    private QuizAiGenerationResponse aiResponse() {
+        try {
+            return new ObjectMapper().readValue("""
+                    {
+                      "questions": [
+                        {
+                          "partId": "part-public-id",
+                          "questionType": "multiple_choice",
+                          "difficulty": "medium",
+                          "summary": "데이터모델링핵심",
+                          "body": "다음 중 데이터 모델링의 설명으로 올바른 것은?",
+                          "options": [
+                            {"optionNumber": 1, "content": "현실 세계의 데이터를 추상화한다"},
+                            {"optionNumber": 2, "content": "서버 배포만 자동화한다"},
+                            {"optionNumber": 3, "content": "UI 색상만 정리한다"},
+                            {"optionNumber": 4, "content": "로그 파일만 삭제한다"}
+                          ],
+                          "answerValue": "1",
+                          "correctExplanation": "데이터 모델링은 현실 데이터를 추상화합니다.",
+                          "incorrectExplanation": "다른 선택지는 데이터 모델링의 핵심과 맞지 않습니다."
+                        }
+                      ]
+                    }
+                    """, QuizAiGenerationResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private <T> List<T> toList(Iterable<T> iterable) {
+        List<T> values = new ArrayList<>();
+        iterable.forEach(values::add);
+        return values;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueueTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueueTest.java
@@ -10,11 +10,16 @@ import static org.mockito.Mockito.when;
 
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.Limit;
+import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.core.StreamOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -77,5 +82,37 @@ class RedisQuizGenerationQueueTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(ErrorCode.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    void poll_returns_oldest_generation_job_record() {
+        MapRecord<String, Object, Object> record = MapRecord
+                .create("quiz:generation:jobs", Map.<Object, Object>of(
+                        "generationJobId", "900",
+                        "quizSessionId", "500",
+                        "quizSessionPublicId", "quiz-session-public-id",
+                        "jobId", "quiz-job-public-id",
+                        "userId", "1"
+                ))
+                .withId(RecordId.of("1748130000000-0"));
+        when(streamOperations.range(eq("quiz:generation:jobs"), any(Range.class), any(Limit.class)))
+                .thenReturn(List.of(record));
+
+        Optional<QuizGenerationQueueRecord> polledRecord = redisQuizGenerationQueue.poll();
+
+        assertThat(polledRecord).isPresent();
+        assertThat(polledRecord.get().messageId()).isEqualTo("1748130000000-0");
+        assertThat(polledRecord.get().message().generationJobId()).isEqualTo(900L);
+        assertThat(polledRecord.get().message().quizSessionId()).isEqualTo(500L);
+        assertThat(polledRecord.get().message().quizSessionPublicId()).isEqualTo("quiz-session-public-id");
+        assertThat(polledRecord.get().message().jobId()).isEqualTo("quiz-job-public-id");
+        assertThat(polledRecord.get().message().userId()).isEqualTo(1L);
+    }
+
+    @Test
+    void acknowledge_deletes_generation_job_record() {
+        redisQuizGenerationQueue.acknowledge("1748130000000-0");
+
+        verify(streamOperations).delete("quiz:generation:jobs", "1748130000000-0");
     }
 }


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- Redis Stream에 적재된 퀴즈 생성 job을 Spring scheduled worker에서 처리합니다
- AOAI 생성 결과를 questions, question_options, question_answers에 저장합니다
- 생성 성공, 실패, 타임아웃 상태를 quiz_sessions와 quiz_generation_jobs에 반영합니다

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- Redis 큐 poll/ack 기능 추가
- QuizGenerationWorker 및 QuizGenerationJobProcessor 추가
- AI 생성 결과 저장용 Question/QuestionOption/QuestionAnswer factory 추가
- QuizSession 생성 상태 변경 메서드 추가
- job timeout sweep 및 실패 시 failReason/retryCount 반영
- prod/local worker 설정값 추가
- 큐 poll/ack, 생성 성공/실패/타임아웃 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.domain.quiz.service.RedisQuizGenerationQueueTest --tests com.f1.quiket.domain.quiz.service.QuizGenerationJobProcessorTest`
2. `./gradlew test`
3. `./gradlew check`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #81

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- local 기본값은 `QUIKET_QUIZ_GENERATION_WORKER_ENABLED=false`입니다
- prod 기본값은 worker enabled이며 필요 시 환경변수로 비활성화할 수 있습니다
- FCM 알림 발송은 이번 범위에서 제외했습니다

---

## 🧑‍💻 Assignee

- @imclaremont