### PR TITLE
[Feat] 퀴즈 풀이 세션 시작 API 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
@@ -3,8 +3,11 @@ package com.f1.quiket.domain.quiz.controller;
 import com.f1.quiket.domain.quiz.dto.QuizCreateRequest;
 import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
 import com.f1.quiket.domain.quiz.dto.QuizGenerationStatusResponse;
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizPlayStartRequest;
 import com.f1.quiket.domain.quiz.dto.QuizSessionResponse;
 import com.f1.quiket.domain.quiz.service.QuizGenerationStatusService;
+import com.f1.quiket.domain.quiz.service.QuizPlaySessionStartService;
 import com.f1.quiket.domain.quiz.service.QuizSessionCreateService;
 import com.f1.quiket.domain.quiz.service.QuizSessionQueryService;
 import com.f1.quiket.global.auth.UserPrincipal;
@@ -33,6 +36,7 @@ public class QuizSessionController {
     private final QuizSessionCreateService quizSessionCreateService;
     private final QuizGenerationStatusService quizGenerationStatusService;
     private final QuizSessionQueryService quizSessionQueryService;
+    private final QuizPlaySessionStartService quizPlaySessionStartService;
 
     /**
      * 퀴즈 생성 요청
@@ -86,5 +90,25 @@ public class QuizSessionController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 퀴즈 풀이 세션 시작
+     */
+    @PostMapping("/{quizSessionId}/play-sessions")
+    public ResponseEntity<ApiResponse<QuizPlaySessionResponse>> startPlaySession(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("quizSessionId") String quizSessionPublicId,
+            @Valid @RequestBody QuizPlayStartRequest request
+    ) {
+        QuizPlaySessionResponse response = quizPlaySessionStartService.start(
+                principal.getUserId(),
+                quizSessionPublicId,
+                request
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(SuccessCode.CREATED, response));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlaySessionResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlaySessionResponse.java
@@ -1,0 +1,35 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizPlaySessionResponse {
+
+    private final String playSessionId;
+    private final String clientSessionId;
+    private final String quizSessionId;
+    private final String playType;
+    private final String status;
+    private final Boolean questionShuffled;
+    private final Boolean optionShuffled;
+    private final String shuffleSeed;
+    private final Integer lastQuestionIndex;
+
+    public static QuizPlaySessionResponse of(QuizPlaySession playSession, QuizSession quizSession) {
+        return QuizPlaySessionResponse.builder()
+                .playSessionId(playSession.getClientSessionId())
+                .clientSessionId(playSession.getClientSessionId())
+                .quizSessionId(quizSession.getPublicId())
+                .playType(playSession.getPlayType())
+                .status(playSession.getStatus())
+                .questionShuffled(playSession.getQuestionShuffled())
+                .optionShuffled(playSession.getOptionShuffled())
+                .shuffleSeed(playSession.getShuffleSeed())
+                .lastQuestionIndex(playSession.getLastQuestionIndex())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlaySessionResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlaySessionResponse.java
@@ -14,10 +14,6 @@ public class QuizPlaySessionResponse {
     private final String quizSessionId;
     private final String playType;
     private final String status;
-    private final Boolean questionShuffled;
-    private final Boolean optionShuffled;
-    private final String shuffleSeed;
-    private final Integer lastQuestionIndex;
 
     public static QuizPlaySessionResponse of(QuizPlaySession playSession, QuizSession quizSession) {
         return QuizPlaySessionResponse.builder()
@@ -26,10 +22,6 @@ public class QuizPlaySessionResponse {
                 .quizSessionId(quizSession.getPublicId())
                 .playType(playSession.getPlayType())
                 .status(playSession.getStatus())
-                .questionShuffled(playSession.getQuestionShuffled())
-                .optionShuffled(playSession.getOptionShuffled())
-                .shuffleSeed(playSession.getShuffleSeed())
-                .lastQuestionIndex(playSession.getLastQuestionIndex())
                 .build();
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlayStartRequest.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlayStartRequest.java
@@ -1,0 +1,30 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizPlayStartRequest {
+
+    @NotBlank(message = "풀이 세션 ID는 필수입니다")
+    @Size(max = 36, message = "풀이 세션 ID는 36자 이하여야 합니다")
+    private String clientSessionId;
+
+    @NotBlank(message = "풀이 유형은 필수입니다")
+    @Pattern(regexp = "first|retry_all|retry_wrong", message = "풀이 유형이 올바르지 않습니다")
+    private String playType;
+
+    @Size(max = 36, message = "부모 풀이 세션 ID는 36자 이하여야 합니다")
+    private String parentPlaySessionId;
+
+    private Boolean questionShuffled;
+
+    private Boolean optionShuffled;
+
+    @Size(max = 100, message = "셔플 시드는 100자 이하여야 합니다")
+    private String shuffleSeed;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.quiz.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,6 +14,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * 퀴즈 풀이 세션 엔티티
@@ -27,13 +31,18 @@ import lombok.experimental.FieldDefaults;
                 @Index(name = "idx_quiz_play_sessions_quiz_session_id", columnList = "quiz_session_id"),
                 @Index(name = "idx_quiz_play_sessions_user_id_status", columnList = "user_id, status"),
                 @Index(name = "idx_quiz_play_sessions_user_id_created_at", columnList = "user_id, created_at"),
+                @Index(name = "idx_quiz_play_sessions_parent_play_session_id", columnList = "parent_play_session_id"),
                 @Index(name = "idx_quiz_play_sessions_subject_id_created_at", columnList = "subject_id, created_at")
         }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class QuizPlaySession {
+
+    private static final String PLAY_TYPE_FIRST = "first";
+    private static final String STATUS_IN_PROGRESS = "in_progress";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,15 +61,75 @@ public class QuizPlaySession {
     @Column(name = "subject_id", nullable = false)
     Long subjectId;
 
+    @Column(name = "play_type", length = 20, nullable = false)
+    String playType;
+
+    @Column(name = "parent_play_session_id")
+    Long parentPlaySessionId;
+
+    @Column(name = "parent_quiz_session_id")
+    Long parentQuizSessionId;
+
+    @Column(name = "generation", nullable = false)
+    Integer generation;
+
+    @Column(name = "is_question_shuffled", nullable = false)
+    Boolean questionShuffled;
+
+    @Column(name = "is_option_shuffled", nullable = false)
+    Boolean optionShuffled;
+
+    @Column(name = "shuffle_seed", length = 100)
+    String shuffleSeed;
+
     @Column(name = "status", length = 20, nullable = false)
     String status;
 
     @Column(name = "last_question_index", nullable = false)
     Integer lastQuestionIndex;
 
+    @Column(name = "elapsed_ms", nullable = false)
+    Integer elapsedMs;
+
+    @Column(name = "submitted_at")
+    LocalDateTime submittedAt;
+
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     LocalDateTime updatedAt;
+
+    public static QuizPlaySession createFirst(
+            String clientSessionId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizPlaySession playSession = new QuizPlaySession();
+        playSession.clientSessionId = clientSessionId;
+        playSession.quizSessionId = quizSessionId;
+        playSession.userId = userId;
+        playSession.subjectId = subjectId;
+        playSession.playType = PLAY_TYPE_FIRST;
+        playSession.generation = 0;
+        playSession.questionShuffled = Boolean.TRUE.equals(questionShuffled);
+        playSession.optionShuffled = optionShuffled == null || Boolean.TRUE.equals(optionShuffled);
+        playSession.shuffleSeed = shuffleSeed;
+        playSession.status = STATUS_IN_PROGRESS;
+        playSession.lastQuestionIndex = 0;
+        playSession.elapsedMs = 0;
+        return playSession;
+    }
+
+    public boolean isSameStartRequest(Long quizSessionId, Long userId, String playType) {
+        return this.quizSessionId.equals(quizSessionId)
+                && this.userId.equals(userId)
+                && this.playType.equals(playType);
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.quiz.repository;
 
 import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +16,9 @@ public interface QuizPlaySessionRepository extends JpaRepository<QuizPlaySession
      * 사용자 풀이 세션 목록 조회
      */
     List<QuizPlaySession> findAllByUserId(Long userId);
+
+    /**
+     * 클라이언트 풀이 세션 단건 조회
+     */
+    Optional<QuizPlaySession> findByClientSessionId(String clientSessionId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartService.java
@@ -61,21 +61,27 @@ public class QuizPlaySessionStartService {
             QuizSession quizSession,
             QuizPlayStartRequest request
     ) {
+        QuizPlaySession playSession = QuizPlaySession.createFirst(
+                request.getClientSessionId(),
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                request.getQuestionShuffled(),
+                request.getOptionShuffled(),
+                request.getShuffleSeed()
+        );
         try {
-            QuizPlaySession playSession = QuizPlaySession.createFirst(
-                    request.getClientSessionId(),
-                    quizSession.getId(),
-                    userId,
-                    quizSession.getSubjectId(),
-                    request.getQuestionShuffled(),
-                    request.getOptionShuffled(),
-                    request.getShuffleSeed()
-            );
-            return QuizPlaySessionResponse.of(quizPlaySessionRepository.save(playSession), quizSession);
+            QuizPlaySession saved = quizPlaySessionRepository.save(playSession);
+            return QuizPlaySessionResponse.of(saved, quizSession);
         } catch (DataIntegrityViolationException e) {
-            return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
-                    .map(existing -> responseFromExisting(existing, quizSession, request))
-                    .orElseThrow(() -> e);
+            // 사전 find 이후 다른 트랜잭션이 같은 clientSessionId로 먼저 insert한 race 케이스.
+            // 같은 트랜잭션은 이미 rollback-only로 마킹된 상태라 여기서 재조회하지 않고
+            // CONFLICT 응답으로 위임 — 클라이언트가 동일 ID로 재시도하면 사전 find 분기로 idempotent 처리됨.
+            throw new CustomException(
+                    ErrorCode.CONFLICT,
+                    "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.",
+                    e
+            );
         }
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartService.java
@@ -1,0 +1,81 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizPlayStartRequest;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizPlaySessionStartService {
+
+    private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
+    private static final String PLAY_TYPE_FIRST = "first";
+
+    private final QuizSessionRepository quizSessionRepository;
+    private final QuizPlaySessionRepository quizPlaySessionRepository;
+
+    public QuizPlaySessionResponse start(Long userId, String quizSessionPublicId, QuizPlayStartRequest request) {
+        QuizSession quizSession = quizSessionRepository
+                .findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        validateStartable(quizSession, request);
+
+        return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
+                .map(existing -> responseFromExisting(existing, quizSession, request))
+                .orElseGet(() -> createPlaySession(userId, quizSession, request));
+    }
+
+    private void validateStartable(QuizSession quizSession, QuizPlayStartRequest request) {
+        if (!QUIZ_SESSION_STATUS_COMPLETED.equals(quizSession.getStatus())) {
+            throw new CustomException(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+        }
+        if (!PLAY_TYPE_FIRST.equals(request.getPlayType()) || StringUtils.hasText(request.getParentPlaySessionId())) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+    }
+
+    private QuizPlaySessionResponse responseFromExisting(
+            QuizPlaySession existing,
+            QuizSession quizSession,
+            QuizPlayStartRequest request
+    ) {
+        if (!existing.isSameStartRequest(quizSession.getId(), quizSession.getUserId(), request.getPlayType())) {
+            throw new CustomException(ErrorCode.CONFLICT, "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.");
+        }
+        return QuizPlaySessionResponse.of(existing, quizSession);
+    }
+
+    private QuizPlaySessionResponse createPlaySession(
+            Long userId,
+            QuizSession quizSession,
+            QuizPlayStartRequest request
+    ) {
+        try {
+            QuizPlaySession playSession = QuizPlaySession.createFirst(
+                    request.getClientSessionId(),
+                    quizSession.getId(),
+                    userId,
+                    quizSession.getSubjectId(),
+                    request.getQuestionShuffled(),
+                    request.getOptionShuffled(),
+                    request.getShuffleSeed()
+            );
+            return QuizPlaySessionResponse.of(quizPlaySessionRepository.save(playSession), quizSession);
+        } catch (DataIntegrityViolationException e) {
+            return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
+                    .map(existing -> responseFromExisting(existing, quizSession, request))
+                    .orElseThrow(() -> e);
+        }
+    }
+}

--- a/src/main/resources/db/migration/V10__create_quiz_play_sessions.sql
+++ b/src/main/resources/db/migration/V10__create_quiz_play_sessions.sql
@@ -1,0 +1,39 @@
+CREATE TABLE quiz_play_sessions (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    client_session_id VARCHAR(36) NOT NULL COMMENT '클라이언트 발급 풀이 세션 ID',
+    quiz_session_id BIGINT NOT NULL COMMENT '퀴즈 세션 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    subject_id BIGINT NOT NULL COMMENT '과목 ID',
+    play_type VARCHAR(20) NOT NULL DEFAULT 'first' COMMENT '풀이 유형',
+    parent_play_session_id BIGINT NULL COMMENT '부모 풀이 세션 ID',
+    parent_quiz_session_id BIGINT NULL COMMENT '부모 퀴즈 세션 ID',
+    generation TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '오답 복습 세대',
+    is_question_shuffled TINYINT(1) NOT NULL DEFAULT 0 COMMENT '문제 순서 셔플 여부',
+    is_option_shuffled TINYINT(1) NOT NULL DEFAULT 1 COMMENT '선택지 순서 셔플 여부',
+    shuffle_seed VARCHAR(100) NULL COMMENT '셔플 시드값',
+    status VARCHAR(20) NOT NULL DEFAULT 'in_progress' COMMENT '풀이 상태',
+    last_question_index TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '마지막 문항 인덱스',
+    elapsed_ms INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '누적 풀이 시간',
+    submitted_at DATETIME(3) NULL COMMENT '결과 제출 시각',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_quiz_play_sessions_client_session_id (client_session_id),
+    KEY idx_quiz_play_sessions_quiz_session_id (quiz_session_id),
+    KEY idx_quiz_play_sessions_user_id_status (user_id, status),
+    KEY idx_quiz_play_sessions_user_id_created_at (user_id, created_at),
+    KEY idx_quiz_play_sessions_parent_play_session_id (parent_play_session_id),
+    KEY idx_quiz_play_sessions_subject_id_created_at (subject_id, created_at),
+
+    CONSTRAINT fk_quiz_play_sessions_quiz_session_id
+        FOREIGN KEY (quiz_session_id) REFERENCES quiz_sessions(id),
+    CONSTRAINT chk_quiz_play_sessions_play_type
+        CHECK (play_type IN ('first', 'retry_all', 'retry_wrong')),
+    CONSTRAINT chk_quiz_play_sessions_status
+        CHECK (status IN ('in_progress', 'submitted', 'abandoned')),
+    CONSTRAINT chk_quiz_play_sessions_question_shuffled
+        CHECK (is_question_shuffled IN (0, 1)),
+    CONSTRAINT chk_quiz_play_sessions_option_shuffled
+        CHECK (is_option_shuffled IN (0, 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='퀴즈 풀이 세션';

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartServiceTest.java
@@ -1,0 +1,191 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizPlayStartRequest;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizPlaySessionStartServiceTest {
+
+    private QuizSessionRepository quizSessionRepository;
+    private QuizPlaySessionRepository quizPlaySessionRepository;
+    private QuizPlaySessionStartService quizPlaySessionStartService;
+
+    @BeforeEach
+    void setUp() {
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        quizPlaySessionStartService = new QuizPlaySessionStartService(
+                quizSessionRepository,
+                quizPlaySessionRepository
+        );
+    }
+
+    @Test
+    void start_creates_first_play_session() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizPlayStartRequest request = request("client-session-id", "first", null, true, false, "seed-1");
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.empty());
+        when(quizPlaySessionRepository.save(any(QuizPlaySession.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizPlaySessionResponse response = quizPlaySessionStartService.start(userId, quizSession.getPublicId(), request);
+
+        ArgumentCaptor<QuizPlaySession> playSessionCaptor = ArgumentCaptor.forClass(QuizPlaySession.class);
+        verify(quizPlaySessionRepository).save(playSessionCaptor.capture());
+        QuizPlaySession savedPlaySession = playSessionCaptor.getValue();
+        assertThat(savedPlaySession.getClientSessionId()).isEqualTo("client-session-id");
+        assertThat(savedPlaySession.getQuizSessionId()).isEqualTo(quizSession.getId());
+        assertThat(savedPlaySession.getUserId()).isEqualTo(userId);
+        assertThat(savedPlaySession.getSubjectId()).isEqualTo(quizSession.getSubjectId());
+        assertThat(savedPlaySession.getPlayType()).isEqualTo("first");
+        assertThat(savedPlaySession.getStatus()).isEqualTo("in_progress");
+        assertThat(savedPlaySession.getLastQuestionIndex()).isZero();
+        assertThat(savedPlaySession.getElapsedMs()).isZero();
+        assertThat(savedPlaySession.getQuestionShuffled()).isTrue();
+        assertThat(savedPlaySession.getOptionShuffled()).isFalse();
+        assertThat(savedPlaySession.getShuffleSeed()).isEqualTo("seed-1");
+
+        assertThat(response.getPlaySessionId()).isEqualTo("client-session-id");
+        assertThat(response.getClientSessionId()).isEqualTo("client-session-id");
+        assertThat(response.getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        assertThat(response.getPlayType()).isEqualTo("first");
+        assertThat(response.getStatus()).isEqualTo("in_progress");
+    }
+
+    @Test
+    void start_returns_existing_when_same_client_session_id_is_retried() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizPlayStartRequest request = request("client-session-id", "first", null, null, null, null);
+        QuizPlaySession existing = playSession("client-session-id", quizSession.getId(), userId, quizSession.getSubjectId());
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+
+        QuizPlaySessionResponse response = quizPlaySessionStartService.start(userId, quizSession.getPublicId(), request);
+
+        assertThat(response.getPlaySessionId()).isEqualTo(existing.getClientSessionId());
+        assertThat(response.getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        verify(quizPlaySessionRepository).findByClientSessionId(request.getClientSessionId());
+    }
+
+    @Test
+    void start_throws_conflict_when_client_session_id_belongs_to_other_session() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizPlayStartRequest request = request("client-session-id", "first", null, null, null, null);
+        QuizPlaySession existing = playSession("client-session-id", 999L, userId, quizSession.getSubjectId());
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> quizPlaySessionStartService.start(userId, quizSession.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    @Test
+    void start_throws_not_completed_when_quiz_generation_is_not_completed() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "pending");
+        QuizPlayStartRequest request = request("client-session-id", "first", null, null, null, null);
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+
+        assertThatThrownBy(() -> quizPlaySessionStartService.start(userId, quizSession.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+
+        verifyNoInteractions(quizPlaySessionRepository);
+    }
+
+    @Test
+    void start_throws_invalid_option_when_play_type_is_not_first() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizPlayStartRequest request = request("client-session-id", "retry_all", null, null, null, null);
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+
+        assertThatThrownBy(() -> quizPlaySessionStartService.start(userId, quizSession.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_OPTION_INVALID);
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId, String status) {
+        QuizSession quizSession = QuizSession.create(
+                publicId,
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                10,
+                "one_by_one",
+                false,
+                null,
+                null,
+                "medium",
+                status,
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizPlaySession playSession(String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        return QuizPlaySession.createFirst(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+    }
+
+    private QuizPlayStartRequest request(
+            String clientSessionId,
+            String playType,
+            String parentPlaySessionId,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizPlayStartRequest request = new QuizPlayStartRequest();
+        ReflectionTestUtils.setField(request, "clientSessionId", clientSessionId);
+        ReflectionTestUtils.setField(request, "playType", playType);
+        ReflectionTestUtils.setField(request, "parentPlaySessionId", parentPlaySessionId);
+        ReflectionTestUtils.setField(request, "questionShuffled", questionShuffled);
+        ReflectionTestUtils.setField(request, "optionShuffled", optionShuffled);
+        ReflectionTestUtils.setField(request, "shuffleSeed", shuffleSeed);
+        return request;
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- POLICY-LOCAL 기준으로 풀이 시작 시 서버에는 풀이 세션 상태만 저장합니다
- 클라이언트 발급 clientSessionId를 quiz_play_sessions에 등록합니다
- 동일 clientSessionId 재요청은 기존 풀이 세션을 반환하도록 처리합니다

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- POST /api/v1/quiz-sessions/{quizSessionId}/play-sessions 구현
- QuizPlayStartRequest, QuizPlaySessionResponse 추가
- QuizPlaySession 엔티티를 DDL 기준 필드로 보강
- quiz_play_sessions Flyway migration 추가
- 생성 완료된 퀴즈만 풀이 시작 가능하도록 검증
- MVP 범위에서 playType=first만 허용
- clientSessionId 중복 요청 idempotent 처리 및 충돌 처리 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.domain.quiz.service.QuizPlaySessionStartServiceTest`
2. `./gradlew test`
3. `./gradlew check`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #85

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 답안 저장 및 결과 제출은 다음 이슈에서 구현 예정입니다
- retry_all, retry_wrong은 이후 히스토리/다시풀기 이슈에서 확장 예정입니다

---

## 🧑‍💻 Assignee

- @imclaremont