### PR TITLE
[Feat] 퀴즈 결과 제출 및 서버 재채점 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
@@ -1,0 +1,44 @@
+package com.f1.quiket.domain.quiz.controller;
+
+import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
+import com.f1.quiket.domain.quiz.service.QuizResultSubmitService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 퀴즈 결과 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/quiz-results")
+public class QuizResultController {
+
+    private final QuizResultSubmitService quizResultSubmitService;
+
+    /**
+     * 퀴즈 결과 제출
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<QuizResultResponse>> submitQuizResult(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody QuizResultSubmitRequest request
+    ) {
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(principal.getUserId(), request);
+
+        return ResponseEntity
+                .status(outcome.isCreated() ? HttpStatus.CREATED : HttpStatus.OK)
+                .body(ApiResponse.success(outcome.isCreated() ? SuccessCode.CREATED : SuccessCode.OK, outcome.getResponse()));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAnswerSubmitItem.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAnswerSubmitItem.java
@@ -1,0 +1,33 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizAnswerSubmitItem {
+
+    @NotBlank(message = "문항 ID는 필수입니다")
+    @Size(max = 36, message = "문항 ID는 36자 이하여야 합니다")
+    private String questionId;
+
+    @Size(max = 36, message = "선택지 ID는 36자 이하여야 합니다")
+    private String selectedOptionId;
+
+    @Size(max = 10, message = "선택값은 10자 이하여야 합니다")
+    private String selectedValue;
+
+    private Boolean correctClient;
+
+    @NotNull(message = "스킵 여부는 필수입니다")
+    private Boolean skipped;
+
+    @Min(value = 0, message = "문항 풀이 시간은 0 이상이어야 합니다")
+    private Integer answerElapsedMs;
+
+    private Boolean marked;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultResponse.java
@@ -1,0 +1,61 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.subject.entity.Subject;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizResultResponse {
+
+    private final String resultId;
+    private final String playSessionId;
+    private final String quizSessionId;
+    private final String subjectId;
+    private final String subjectName;
+    private final Integer totalCount;
+    private final Integer correctCount;
+    private final Integer wrongCount;
+    private final Integer skipCount;
+    private final Integer accuracyPct;
+    private final Integer elapsedMs;
+    private final Boolean scoreMatched;
+    private final Boolean abuseFlagged;
+    private final QuizRewardSummaryResponse rewards;
+    private final List<QuizReviewItemResponse> reviewItems;
+    private final QuizRetryAvailableResponse retryAvailable;
+    private final LocalDateTime createdAt;
+
+    public static QuizResultResponse of(
+            QuizResult result,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            List<QuizReviewItemResponse> reviewItems
+    ) {
+        return QuizResultResponse.builder()
+                .resultId(result.getPublicId())
+                .playSessionId(playSession.getClientSessionId())
+                .quizSessionId(quizSession.getPublicId())
+                .subjectId(subject.getPublicId())
+                .subjectName(subject.getName())
+                .totalCount(result.getTotalCount())
+                .correctCount(result.getCorrectCount())
+                .wrongCount(result.getWrongCount())
+                .skipCount(result.getSkipCount())
+                .accuracyPct(result.getAccuracyPct())
+                .elapsedMs(result.getElapsedMs())
+                .scoreMatched(result.getScoreMatched())
+                .abuseFlagged(result.getAbuseFlagged())
+                .rewards(QuizRewardSummaryResponse.from(result))
+                .reviewItems(reviewItems)
+                .retryAvailable(QuizRetryAvailableResponse.from(result.getWrongCount()))
+                .createdAt(result.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultSubmitOutcome.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultSubmitOutcome.java
@@ -1,0 +1,12 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class QuizResultSubmitOutcome {
+
+    private final QuizResultResponse response;
+    private final boolean created;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultSubmitRequest.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultSubmitRequest.java
@@ -1,0 +1,47 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizResultSubmitRequest {
+
+    @NotBlank(message = "풀이 세션 ID는 필수입니다")
+    @Size(max = 36, message = "풀이 세션 ID는 36자 이하여야 합니다")
+    private String clientSessionId;
+
+    @NotBlank(message = "퀴즈 세션 ID는 필수입니다")
+    @Size(max = 36, message = "퀴즈 세션 ID는 36자 이하여야 합니다")
+    private String quizSessionId;
+
+    @NotBlank(message = "풀이 유형은 필수입니다")
+    @Pattern(regexp = "first|retry_all|retry_wrong", message = "풀이 유형이 올바르지 않습니다")
+    private String playType;
+
+    @Size(max = 36, message = "부모 풀이 세션 ID는 36자 이하여야 합니다")
+    private String parentPlaySessionId;
+
+    @NotNull(message = "풀이 시간은 필수입니다")
+    @Min(value = 0, message = "풀이 시간은 0 이상이어야 합니다")
+    private Integer elapsedMs;
+
+    private Boolean questionShuffled;
+
+    private Boolean optionShuffled;
+
+    @Size(max = 100, message = "셔플 시드는 100자 이하여야 합니다")
+    private String shuffleSeed;
+
+    @Valid
+    @NotEmpty(message = "답안 목록은 필수입니다")
+    private List<QuizAnswerSubmitItem> answers;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRetryAvailableResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRetryAvailableResponse.java
@@ -1,0 +1,21 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizRetryAvailableResponse {
+
+    private final Boolean retryAll;
+    private final Boolean retryWrong;
+    private final Integer wrongCount;
+
+    public static QuizRetryAvailableResponse from(Integer wrongCount) {
+        return QuizRetryAvailableResponse.builder()
+                .retryAll(true)
+                .retryWrong(wrongCount > 0)
+                .wrongCount(wrongCount)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizReviewItemResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizReviewItemResponse.java
@@ -1,0 +1,51 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizReviewItemResponse {
+
+    private final String questionId;
+    private final Integer displayOrder;
+    private final String summary;
+    private final String body;
+    private final List<QuestionOptionResponse> options;
+    private final String selectedOptionId;
+    private final String selectedValue;
+    private final String answerValue;
+    private final Boolean correctServer;
+    private final Boolean skipped;
+    private final String correctExplanation;
+    private final String incorrectExplanation;
+
+    public static QuizReviewItemResponse of(
+            Question question,
+            List<QuestionOption> options,
+            QuestionAnswer answer,
+            QuizPlayAnswer playAnswer
+    ) {
+        return QuizReviewItemResponse.builder()
+                .questionId(question.getPublicId())
+                .displayOrder(question.getDisplayOrder())
+                .summary(question.getSummary())
+                .body(question.getBody())
+                .options(options.stream()
+                        .map(QuestionOptionResponse::from)
+                        .toList())
+                .selectedOptionId(playAnswer.getSelectedOptionId() == null ? null : String.valueOf(playAnswer.getSelectedOptionId()))
+                .selectedValue(playAnswer.getSelectedValue())
+                .answerValue(answer.getAnswerValue())
+                .correctServer(playAnswer.getCorrectServer())
+                .skipped(playAnswer.getSkipped())
+                .correctExplanation(question.getCorrectExplanation())
+                .incorrectExplanation(question.getIncorrectExplanation())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRewardSummaryResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRewardSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizRewardSummaryResponse {
+
+    private final Integer dotoriEarned;
+    private final Integer xpEarned;
+    private final Boolean leveledUp;
+    private final Integer newLevel;
+
+    public static QuizRewardSummaryResponse from(QuizResult result) {
+        return QuizRewardSummaryResponse.builder()
+                .dotoriEarned(result.getDotoriEarned())
+                .xpEarned(result.getXpEarned())
+                .leveledUp(result.getLeveledUp())
+                .newLevel(result.getNewLevel())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlayAnswer.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlayAnswer.java
@@ -1,0 +1,109 @@
+package com.f1.quiket.domain.quiz.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 퀴즈 풀이 답안 엔티티
+ */
+@Entity
+@Table(
+        name = "quiz_play_answers",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_quiz_play_answers_session_question", columnNames = {"play_session_id", "question_id"})
+        },
+        indexes = {
+                @Index(name = "idx_quiz_play_answers_question_id", columnList = "question_id"),
+                @Index(name = "idx_quiz_play_answers_user_id", columnList = "user_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuizPlayAnswer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "play_session_id", nullable = false)
+    Long playSessionId;
+
+    @Column(name = "question_id", nullable = false)
+    Long questionId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "selected_option_id")
+    Long selectedOptionId;
+
+    @Column(name = "selected_value", length = 10)
+    String selectedValue;
+
+    @Column(name = "is_correct_client")
+    Boolean correctClient;
+
+    @Column(name = "is_correct_server")
+    Boolean correctServer;
+
+    @Column(name = "is_skipped", nullable = false)
+    Boolean skipped;
+
+    @Column(name = "answer_elapsed_ms")
+    Integer answerElapsedMs;
+
+    @Column(name = "is_marked", nullable = false)
+    Boolean marked;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+
+    public static QuizPlayAnswer create(
+            Long playSessionId,
+            Long questionId,
+            Long userId,
+            Long selectedOptionId,
+            String selectedValue,
+            Boolean correctClient,
+            Boolean correctServer,
+            Boolean skipped,
+            Integer answerElapsedMs,
+            Boolean marked
+    ) {
+        QuizPlayAnswer answer = new QuizPlayAnswer();
+        answer.playSessionId = playSessionId;
+        answer.questionId = questionId;
+        answer.userId = userId;
+        answer.selectedOptionId = selectedOptionId;
+        answer.selectedValue = selectedValue;
+        answer.correctClient = correctClient;
+        answer.correctServer = correctServer;
+        answer.skipped = skipped;
+        answer.answerElapsedMs = answerElapsedMs;
+        answer.marked = Boolean.TRUE.equals(marked);
+        return answer;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -43,6 +43,7 @@ public class QuizPlaySession {
 
     private static final String PLAY_TYPE_FIRST = "first";
     private static final String STATUS_IN_PROGRESS = "in_progress";
+    private static final String STATUS_SUBMITTED = "submitted";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -131,5 +132,11 @@ public class QuizPlaySession {
         return this.quizSessionId.equals(quizSessionId)
                 && this.userId.equals(userId)
                 && this.playType.equals(playType);
+    }
+
+    public void submit(Integer elapsedMs) {
+        this.status = STATUS_SUBMITTED;
+        this.elapsedMs = elapsedMs;
+        this.submittedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
@@ -136,8 +136,6 @@ public class QuizResult {
         result.leveledUp = false;
         result.scoreMatched = scoreMatched;
         result.abuseFlagged = abuseFlagged;
-        result.createdAt = LocalDateTime.now();
-        result.updatedAt = result.createdAt;
         return result;
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.quiz.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,6 +14,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * 퀴즈 결과 엔티티
@@ -32,6 +36,7 @@ import lombok.experimental.FieldDefaults;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class QuizResult {
 
@@ -61,9 +66,78 @@ public class QuizResult {
     @Column(name = "correct_count", nullable = false)
     Integer correctCount;
 
+    @Column(name = "wrong_count", nullable = false)
+    Integer wrongCount;
+
+    @Column(name = "skip_count", nullable = false)
+    Integer skipCount;
+
+    @Column(name = "accuracy_pct", nullable = false)
+    Integer accuracyPct;
+
+    @Column(name = "elapsed_ms", nullable = false)
+    Integer elapsedMs;
+
+    @Column(name = "dotori_earned", nullable = false)
+    Integer dotoriEarned;
+
+    @Column(name = "xp_earned", nullable = false)
+    Integer xpEarned;
+
+    @Column(name = "is_leveled_up", nullable = false)
+    Boolean leveledUp;
+
+    @Column(name = "new_level")
+    Integer newLevel;
+
+    @Column(name = "is_score_matched", nullable = false)
+    Boolean scoreMatched;
+
+    @Column(name = "is_abuse_flagged", nullable = false)
+    Boolean abuseFlagged;
+
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     LocalDateTime updatedAt;
+
+    public static QuizResult create(
+            String publicId,
+            Long playSessionId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            Integer totalCount,
+            Integer correctCount,
+            Integer wrongCount,
+            Integer skipCount,
+            Integer accuracyPct,
+            Integer elapsedMs,
+            Boolean scoreMatched,
+            Boolean abuseFlagged
+    ) {
+        QuizResult result = new QuizResult();
+        result.publicId = publicId;
+        result.playSessionId = playSessionId;
+        result.quizSessionId = quizSessionId;
+        result.userId = userId;
+        result.subjectId = subjectId;
+        result.totalCount = totalCount;
+        result.correctCount = correctCount;
+        result.wrongCount = wrongCount;
+        result.skipCount = skipCount;
+        result.accuracyPct = accuracyPct;
+        result.elapsedMs = elapsedMs;
+        result.dotoriEarned = 0;
+        result.xpEarned = 0;
+        result.leveledUp = false;
+        result.scoreMatched = scoreMatched;
+        result.abuseFlagged = abuseFlagged;
+        result.createdAt = LocalDateTime.now();
+        result.updatedAt = result.createdAt;
+        return result;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlayAnswerRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlayAnswerRepository.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.quiz.repository;
+
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 퀴즈 풀이 답안 조회 리포지토리
+ */
+@Repository
+public interface QuizPlayAnswerRepository extends JpaRepository<QuizPlayAnswer, Long> {
+
+    /**
+     * 풀이 세션 답안 목록 조회
+     */
+    List<QuizPlayAnswer> findAllByPlaySessionId(Long playSessionId);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.quiz.repository;
 
 import com.f1.quiket.domain.quiz.entity.QuizResult;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +16,9 @@ public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
      * 사용자 결과 목록 조회
      */
     List<QuizResult> findAllByUserId(Long userId);
+
+    /**
+     * 풀이 세션 결과 단건 조회
+     */
+    Optional<QuizResult> findByPlaySessionId(Long playSessionId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
@@ -1,0 +1,381 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizAnswerSubmitItem;
+import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
+import com.f1.quiket.domain.quiz.dto.QuizReviewItemResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.global.util.UuidV7Generator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizResultSubmitService {
+
+    private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
+    private static final String PLAY_TYPE_FIRST = "first";
+    private static final String QUESTION_TYPE_MULTIPLE_CHOICE = "multiple_choice";
+    private static final String QUESTION_TYPE_OX = "ox";
+    private static final int ABUSE_MISMATCH_THRESHOLD_PCT = 30;
+
+    private final QuizSessionRepository quizSessionRepository;
+    private final SubjectRepository subjectRepository;
+    private final QuestionRepository questionRepository;
+    private final QuestionOptionRepository questionOptionRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
+    private final QuizPlaySessionRepository quizPlaySessionRepository;
+    private final QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private final QuizResultRepository quizResultRepository;
+
+    public QuizResultSubmitOutcome submit(Long userId, QuizResultSubmitRequest request) {
+        QuizPlaySession playSession = findPlaySession(userId, request.getClientSessionId());
+        QuizSession quizSession = findQuizSession(userId, request.getQuizSessionId());
+        Subject subject = findSubject(userId, quizSession.getSubjectId());
+
+        validateSubmitTarget(playSession, quizSession, request);
+
+        List<Question> questions = findQuestions(userId, quizSession.getId());
+        List<Long> questionIds = questions.stream()
+                .map(Question::getId)
+                .toList();
+        Map<Long, List<QuestionOption>> optionsByQuestionId = getOptionsByQuestionId(questionIds);
+        Map<Long, QuestionAnswer> answersByQuestionId = getAnswersByQuestionId(questionIds);
+
+        return quizResultRepository.findByPlaySessionId(playSession.getId())
+                .map(existing -> responseFromExisting(
+                        existing,
+                        playSession,
+                        quizSession,
+                        subject,
+                        questions,
+                        optionsByQuestionId,
+                        answersByQuestionId
+                ))
+                .orElseGet(() -> createResult(
+                        userId,
+                        request,
+                        playSession,
+                        quizSession,
+                        subject,
+                        questions,
+                        optionsByQuestionId,
+                        answersByQuestionId
+                ));
+    }
+
+    private QuizPlaySession findPlaySession(Long userId, String clientSessionId) {
+        return quizPlaySessionRepository.findByClientSessionId(clientSessionId)
+                .filter(playSession -> playSession.getUserId().equals(userId))
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_PLAY_SESSION_NOT_FOUND));
+    }
+
+    private QuizSession findQuizSession(Long userId, String quizSessionPublicId) {
+        return quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+    }
+
+    private Subject findSubject(Long userId, Long subjectId) {
+        return subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subjectId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+    }
+
+    private void validateSubmitTarget(
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            QuizResultSubmitRequest request
+    ) {
+        if (!QUIZ_SESSION_STATUS_COMPLETED.equals(quizSession.getStatus())) {
+            throw new CustomException(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+        }
+        if (!playSession.getQuizSessionId().equals(quizSession.getId())) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+        if (!PLAY_TYPE_FIRST.equals(request.getPlayType())
+                || !PLAY_TYPE_FIRST.equals(playSession.getPlayType())
+                || StringUtils.hasText(request.getParentPlaySessionId())) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+    }
+
+    private List<Question> findQuestions(Long userId, Long quizSessionId) {
+        List<Question> questions = questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(
+                quizSessionId,
+                userId
+        );
+        if (questions.isEmpty()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "완료된 퀴즈 세션에 문항이 존재하지 않습니다.");
+        }
+        return questions;
+    }
+
+    private Map<Long, List<QuestionOption>> getOptionsByQuestionId(List<Long> questionIds) {
+        return questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(questionIds)
+                .stream()
+                .collect(Collectors.groupingBy(QuestionOption::getQuestionId));
+    }
+
+    private Map<Long, QuestionAnswer> getAnswersByQuestionId(List<Long> questionIds) {
+        Map<Long, QuestionAnswer> answersByQuestionId = questionAnswerRepository.findAllByQuestionIdIn(questionIds)
+                .stream()
+                .collect(Collectors.toMap(QuestionAnswer::getQuestionId, Function.identity()));
+        if (answersByQuestionId.size() != questionIds.size()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 문항 정답 정보가 올바르지 않습니다.");
+        }
+        return answersByQuestionId;
+    }
+
+    private QuizResultSubmitOutcome responseFromExisting(
+            QuizResult result,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            List<Question> questions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId
+    ) {
+        List<QuizPlayAnswer> playAnswers = quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId());
+        QuizResultResponse response = buildResponse(
+                result,
+                playSession,
+                quizSession,
+                subject,
+                questions,
+                optionsByQuestionId,
+                answersByQuestionId,
+                playAnswers
+        );
+        return new QuizResultSubmitOutcome(response, false);
+    }
+
+    private QuizResultSubmitOutcome createResult(
+            Long userId,
+            QuizResultSubmitRequest request,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            List<Question> questions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId
+    ) {
+        Map<Long, QuizPlayAnswer> playAnswersByQuestionId = gradeAnswers(
+                userId,
+                request,
+                playSession,
+                questions,
+                optionsByQuestionId,
+                answersByQuestionId
+        );
+        List<QuizPlayAnswer> playAnswers = questions.stream()
+                .map(question -> playAnswersByQuestionId.get(question.getId()))
+                .toList();
+
+        int totalCount = questions.size();
+        int correctCount = (int) playAnswers.stream()
+                .filter(QuizPlayAnswer::getCorrectServer)
+                .count();
+        int skipCount = (int) playAnswers.stream()
+                .filter(QuizPlayAnswer::getSkipped)
+                .count();
+        int wrongCount = totalCount - correctCount - skipCount;
+        int accuracyPct = correctCount * 100 / totalCount;
+        int mismatchCount = calculateMismatchCount(playAnswers);
+        boolean scoreMatched = mismatchCount == 0;
+        boolean abuseFlagged = mismatchCount * 100 >= totalCount * ABUSE_MISMATCH_THRESHOLD_PCT;
+
+        quizPlayAnswerRepository.saveAll(playAnswers);
+        playSession.submit(request.getElapsedMs());
+        QuizResult savedResult = quizResultRepository.save(QuizResult.create(
+                UuidV7Generator.generate(),
+                playSession.getId(),
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                totalCount,
+                correctCount,
+                wrongCount,
+                skipCount,
+                accuracyPct,
+                request.getElapsedMs(),
+                scoreMatched,
+                abuseFlagged
+        ));
+
+        QuizResultResponse response = buildResponse(
+                savedResult,
+                playSession,
+                quizSession,
+                subject,
+                questions,
+                optionsByQuestionId,
+                answersByQuestionId,
+                playAnswers
+        );
+        return new QuizResultSubmitOutcome(response, true);
+    }
+
+    private Map<Long, QuizPlayAnswer> gradeAnswers(
+            Long userId,
+            QuizResultSubmitRequest request,
+            QuizPlaySession playSession,
+            List<Question> questions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId
+    ) {
+        Map<String, Question> questionsByPublicId = questions.stream()
+                .collect(Collectors.toMap(Question::getPublicId, Function.identity(), (left, right) -> left, LinkedHashMap::new));
+        validateSubmittedQuestions(request.getAnswers(), questionsByPublicId);
+
+        Map<Long, QuestionOption> optionsById = optionsByQuestionId.values().stream()
+                .flatMap(List::stream)
+                .collect(Collectors.toMap(QuestionOption::getId, Function.identity()));
+
+        Map<Long, QuizPlayAnswer> playAnswersByQuestionId = new LinkedHashMap<>();
+        for (QuizAnswerSubmitItem item : request.getAnswers()) {
+            Question question = questionsByPublicId.get(item.getQuestionId());
+            QuestionAnswer answer = answersByQuestionId.get(question.getId());
+            GradedAnswer gradedAnswer = gradeAnswer(item, question, answer, optionsById);
+            QuizPlayAnswer playAnswer = QuizPlayAnswer.create(
+                    playSession.getId(),
+                    question.getId(),
+                    userId,
+                    gradedAnswer.selectedOptionId(),
+                    gradedAnswer.selectedValue(),
+                    item.getCorrectClient(),
+                    gradedAnswer.correct(),
+                    item.getSkipped(),
+                    item.getAnswerElapsedMs(),
+                    item.getMarked()
+            );
+            playAnswersByQuestionId.put(question.getId(), playAnswer);
+        }
+        return playAnswersByQuestionId;
+    }
+
+    private void validateSubmittedQuestions(List<QuizAnswerSubmitItem> items, Map<String, Question> questionsByPublicId) {
+        if (items.size() != questionsByPublicId.size()) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+
+        Set<String> submittedQuestionIds = new HashSet<>();
+        for (QuizAnswerSubmitItem item : items) {
+            if (!questionsByPublicId.containsKey(item.getQuestionId()) || !submittedQuestionIds.add(item.getQuestionId())) {
+                throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+            }
+        }
+    }
+
+    private GradedAnswer gradeAnswer(
+            QuizAnswerSubmitItem item,
+            Question question,
+            QuestionAnswer answer,
+            Map<Long, QuestionOption> optionsById
+    ) {
+        if (Boolean.TRUE.equals(item.getSkipped())) {
+            return new GradedAnswer(null, null, false);
+        }
+        if (QUESTION_TYPE_MULTIPLE_CHOICE.equals(question.getQuestionType())) {
+            Long selectedOptionId = parseSelectedOptionId(item.getSelectedOptionId());
+            QuestionOption selectedOption = optionsById.get(selectedOptionId);
+            if (selectedOption == null || !selectedOption.getQuestionId().equals(question.getId())) {
+                throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+            }
+            return new GradedAnswer(selectedOptionId, null, Boolean.TRUE.equals(selectedOption.getCorrect()));
+        }
+        if (QUESTION_TYPE_OX.equals(question.getQuestionType())) {
+            String selectedValue = normalizeSelectedValue(item.getSelectedValue());
+            if (!"O".equals(selectedValue) && !"X".equals(selectedValue)) {
+                throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+            }
+            return new GradedAnswer(null, selectedValue, selectedValue.equals(answer.getAnswerValue()));
+        }
+        throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 문항 유형이 올바르지 않습니다.");
+    }
+
+    private Long parseSelectedOptionId(String selectedOptionId) {
+        if (!StringUtils.hasText(selectedOptionId)) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+        try {
+            return Long.parseLong(selectedOptionId);
+        } catch (NumberFormatException e) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+    }
+
+    private String normalizeSelectedValue(String selectedValue) {
+        if (!StringUtils.hasText(selectedValue)) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+        return selectedValue.trim().toUpperCase();
+    }
+
+    private int calculateMismatchCount(List<QuizPlayAnswer> playAnswers) {
+        return (int) playAnswers.stream()
+                .filter(answer -> answer.getCorrectClient() != null)
+                .filter(answer -> !answer.getCorrectClient().equals(answer.getCorrectServer()))
+                .count();
+    }
+
+    private QuizResultResponse buildResponse(
+            QuizResult result,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            List<Question> questions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId,
+            List<QuizPlayAnswer> playAnswers
+    ) {
+        Map<Long, QuizPlayAnswer> playAnswersByQuestionId = playAnswers.stream()
+                .collect(Collectors.toMap(QuizPlayAnswer::getQuestionId, Function.identity()));
+        List<QuizReviewItemResponse> reviewItems = questions.stream()
+                .map(question -> QuizReviewItemResponse.of(
+                        question,
+                        optionsByQuestionId.getOrDefault(question.getId(), List.of()),
+                        answersByQuestionId.get(question.getId()),
+                        getPlayAnswer(playAnswersByQuestionId, question)
+                ))
+                .toList();
+        return QuizResultResponse.of(result, playSession, quizSession, subject, reviewItems);
+    }
+
+    private QuizPlayAnswer getPlayAnswer(Map<Long, QuizPlayAnswer> playAnswersByQuestionId, Question question) {
+        QuizPlayAnswer playAnswer = playAnswersByQuestionId.get(question.getId());
+        if (playAnswer == null) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 풀이 답안 정보가 올바르지 않습니다.");
+        }
+        return playAnswer;
+    }
+
+    private record GradedAnswer(Long selectedOptionId, String selectedValue, Boolean correct) {
+    }
+}

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     QUIZ_GENERATION_IN_PROGRESS(409, "QUIZ_GENERATION_IN_PROGRESS", "이미 생성 중인 퀴즈가 있습니다."),
     QUIZ_SESSION_NOT_FOUND(404, "QUIZ_SESSION_NOT_FOUND", "퀴즈 세션을 찾을 수 없습니다."),
     QUIZ_SESSION_NOT_COMPLETED(409, "QUIZ_SESSION_NOT_COMPLETED", "아직 생성 완료 전인 퀴즈입니다."),
+    QUIZ_PLAY_SESSION_NOT_FOUND(404, "QUIZ_PLAY_SESSION_NOT_FOUND", "퀴즈 풀이 세션을 찾을 수 없습니다."),
 
     // MyPage Errors
     MY_EMAIL_CHANGE_TOO_FREQUENT(429, "MY_EMAIL_CHANGE_TOO_FREQUENT", "이메일 변경은 하루에 1회만 가능합니다."),

--- a/src/main/resources/db/migration/V11__create_quiz_play_answers_and_results.sql
+++ b/src/main/resources/db/migration/V11__create_quiz_play_answers_and_results.sql
@@ -1,0 +1,56 @@
+CREATE TABLE IF NOT EXISTS quiz_play_answers (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    play_session_id BIGINT NOT NULL COMMENT '풀이 세션 ID',
+    question_id BIGINT NOT NULL COMMENT '문항 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    selected_option_id BIGINT NULL COMMENT '선택한 선택지 ID',
+    selected_value VARCHAR(10) NULL COMMENT '선택한 값',
+    is_correct_client TINYINT(1) NULL COMMENT '클라이언트 채점 결과',
+    is_correct_server TINYINT(1) NULL COMMENT '서버 재채점 결과',
+    is_skipped TINYINT(1) NOT NULL DEFAULT 0 COMMENT '미선택 제출 여부',
+    answer_elapsed_ms INT UNSIGNED NULL COMMENT '문항 응답 소요 시간',
+    is_marked TINYINT(1) NOT NULL DEFAULT 0 COMMENT '어려움 마킹 여부',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_quiz_play_answers_session_question (play_session_id, question_id),
+    KEY idx_quiz_play_answers_question_id (question_id),
+    KEY idx_quiz_play_answers_user_id (user_id),
+
+    CONSTRAINT chk_quiz_play_answers_is_correct_client
+        CHECK (is_correct_client IN (0, 1) OR is_correct_client IS NULL),
+    CONSTRAINT chk_quiz_play_answers_is_correct_server
+        CHECK (is_correct_server IN (0, 1) OR is_correct_server IS NULL)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='문항별 답안 및 채점 결과';
+
+CREATE TABLE IF NOT EXISTS quiz_results (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    public_id CHAR(36) NOT NULL COMMENT '외부 노출용 UUID v7',
+    play_session_id BIGINT NOT NULL COMMENT '풀이 세션 ID',
+    quiz_session_id BIGINT NOT NULL COMMENT '퀴즈 세션 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    subject_id BIGINT NOT NULL COMMENT '과목 ID',
+    total_count TINYINT UNSIGNED NOT NULL COMMENT '총 문항 수',
+    correct_count TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '정답 수',
+    wrong_count TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '오답 수',
+    skip_count TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '미선택 수',
+    accuracy_pct TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '정답률',
+    elapsed_ms INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '누적 풀이 시간',
+    dotori_earned SMALLINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '획득 도토리',
+    xp_earned SMALLINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '획득 XP',
+    is_leveled_up TINYINT(1) NOT NULL DEFAULT 0 COMMENT '레벨업 여부',
+    new_level TINYINT UNSIGNED NULL COMMENT '새 레벨',
+    is_score_matched TINYINT(1) NOT NULL DEFAULT 1 COMMENT '클라이언트-서버 채점 일치 여부',
+    is_abuse_flagged TINYINT(1) NOT NULL DEFAULT 0 COMMENT '어뷰징 의심 여부',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '결과 저장 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_quiz_results_public_id (public_id),
+    UNIQUE KEY uq_quiz_results_play_session_id (play_session_id),
+    KEY idx_quiz_results_user_id_created_at (user_id, created_at),
+    KEY idx_quiz_results_quiz_session_id (quiz_session_id),
+    KEY idx_quiz_results_subject_id_created_at (subject_id, created_at),
+    KEY idx_quiz_results_is_abuse_flagged (is_abuse_flagged)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='퀴즈 풀이 결과 요약';

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
@@ -1,0 +1,430 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.dto.QuizAnswerSubmitItem;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizResultSubmitServiceTest {
+
+    private QuizSessionRepository quizSessionRepository;
+    private SubjectRepository subjectRepository;
+    private QuestionRepository questionRepository;
+    private QuestionOptionRepository questionOptionRepository;
+    private QuestionAnswerRepository questionAnswerRepository;
+    private QuizPlaySessionRepository quizPlaySessionRepository;
+    private QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private QuizResultRepository quizResultRepository;
+    private QuizResultSubmitService quizResultSubmitService;
+
+    @BeforeEach
+    void setUp() {
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        questionRepository = mock(QuestionRepository.class);
+        questionOptionRepository = mock(QuestionOptionRepository.class);
+        questionAnswerRepository = mock(QuestionAnswerRepository.class);
+        quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        quizPlayAnswerRepository = mock(QuizPlayAnswerRepository.class);
+        quizResultRepository = mock(QuizResultRepository.class);
+        quizResultSubmitService = new QuizResultSubmitService(
+                quizSessionRepository,
+                subjectRepository,
+                questionRepository,
+                questionOptionRepository,
+                questionAnswerRepository,
+                quizPlaySessionRepository,
+                quizPlayAnswerRepository,
+                quizResultRepository
+        );
+    }
+
+    @Test
+    void submit_creates_result_with_server_grading() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption correctOption = option(1000L, question.getId(), 1, "정답", true);
+        QuestionOption wrongOption = option(1001L, question.getId(), 2, "오답", false);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                430000,
+                List.of(answerItem(question.getPublicId(), String.valueOf(correctOption.getId()), true, false))
+        );
+        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(correctOption, wrongOption), List.of(answer));
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.empty());
+        when(quizResultRepository.save(any(QuizResult.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(userId, request);
+
+        assertThat(outcome.isCreated()).isTrue();
+        assertThat(outcome.getResponse().getPlaySessionId()).isEqualTo(playSession.getClientSessionId());
+        assertThat(outcome.getResponse().getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        assertThat(outcome.getResponse().getSubjectId()).isEqualTo(subject.getPublicId());
+        assertThat(outcome.getResponse().getTotalCount()).isEqualTo(1);
+        assertThat(outcome.getResponse().getCorrectCount()).isEqualTo(1);
+        assertThat(outcome.getResponse().getWrongCount()).isZero();
+        assertThat(outcome.getResponse().getSkipCount()).isZero();
+        assertThat(outcome.getResponse().getAccuracyPct()).isEqualTo(100);
+        assertThat(outcome.getResponse().getScoreMatched()).isTrue();
+        assertThat(outcome.getResponse().getAbuseFlagged()).isFalse();
+        assertThat(outcome.getResponse().getRewards().getDotoriEarned()).isZero();
+        assertThat(outcome.getResponse().getReviewItems()).hasSize(1);
+        assertThat(outcome.getResponse().getReviewItems().get(0).getCorrectServer()).isTrue();
+        assertThat(playSession.getStatus()).isEqualTo("submitted");
+        assertThat(playSession.getElapsedMs()).isEqualTo(430000);
+
+        ArgumentCaptor<Iterable<QuizPlayAnswer>> answersCaptor = answerIterableCaptor();
+        verify(quizPlayAnswerRepository).saveAll(answersCaptor.capture());
+        List<QuizPlayAnswer> savedAnswers = toList(answersCaptor.getValue());
+        assertThat(savedAnswers).hasSize(1);
+        assertThat(savedAnswers.get(0).getQuestionId()).isEqualTo(question.getId());
+        assertThat(savedAnswers.get(0).getSelectedOptionId()).isEqualTo(correctOption.getId());
+        assertThat(savedAnswers.get(0).getCorrectServer()).isTrue();
+
+        ArgumentCaptor<QuizResult> resultCaptor = ArgumentCaptor.forClass(QuizResult.class);
+        verify(quizResultRepository).save(resultCaptor.capture());
+        QuizResult savedResult = resultCaptor.getValue();
+        assertThat(savedResult.getCorrectCount()).isEqualTo(1);
+        assertThat(savedResult.getAccuracyPct()).isEqualTo(100);
+        assertThat(savedResult.getScoreMatched()).isTrue();
+        assertThat(savedResult.getAbuseFlagged()).isFalse();
+    }
+
+    @Test
+    void submit_returns_existing_result_when_duplicate_request_is_retried() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption option = option(1000L, question.getId(), 1, "정답", true);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizResult existingResult = result(3000L, "result-public-id", playSession, quizSession, subject, 1, 1, 0, 0, 100);
+        QuizPlayAnswer existingAnswer = playAnswer(playSession.getId(), question.getId(), userId, option.getId(), true, false);
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                430000,
+                List.of(answerItem(question.getPublicId(), String.valueOf(option.getId()), true, false))
+        );
+        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.of(existingResult));
+        when(quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId()))
+                .thenReturn(List.of(existingAnswer));
+
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(userId, request);
+
+        assertThat(outcome.isCreated()).isFalse();
+        assertThat(outcome.getResponse().getResultId()).isEqualTo("result-public-id");
+        assertThat(outcome.getResponse().getCorrectCount()).isEqualTo(1);
+        verify(quizPlayAnswerRepository, never()).saveAll(any());
+        verify(quizResultRepository, never()).save(any());
+    }
+
+    @Test
+    void submit_flags_score_mismatch_and_abuse_when_client_score_differs() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question1 = question(901L, "question-public-id-1", quizSession.getId(), userId, subject.getId(), 1);
+        Question question2 = question(902L, "question-public-id-2", quizSession.getId(), userId, subject.getId(), 2);
+        QuestionOption q1Correct = option(1001L, question1.getId(), 1, "정답", true);
+        QuestionOption q2Wrong = option(1002L, question2.getId(), 2, "오답", false);
+        QuestionAnswer answer1 = answer(2001L, question1.getId(), "1");
+        QuestionAnswer answer2 = answer(2002L, question2.getId(), "1");
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                120000,
+                List.of(
+                        answerItem(question1.getPublicId(), String.valueOf(q1Correct.getId()), true, false),
+                        answerItem(question2.getPublicId(), String.valueOf(q2Wrong.getId()), true, false)
+                )
+        );
+        mockSubmitData(
+                userId,
+                subject,
+                quizSession,
+                playSession,
+                List.of(question1, question2),
+                List.of(q1Correct, q2Wrong),
+                List.of(answer1, answer2)
+        );
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.empty());
+        when(quizResultRepository.save(any(QuizResult.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(userId, request);
+
+        assertThat(outcome.getResponse().getCorrectCount()).isEqualTo(1);
+        assertThat(outcome.getResponse().getWrongCount()).isEqualTo(1);
+        assertThat(outcome.getResponse().getScoreMatched()).isFalse();
+        assertThat(outcome.getResponse().getAbuseFlagged()).isTrue();
+    }
+
+    @Test
+    void submit_throws_invalid_option_when_answer_question_is_missing() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption option = option(1000L, question.getId(), 1, "정답", true);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                430000,
+                List.of(answerItem("unknown-question-id", String.valueOf(option.getId()), true, false))
+        );
+        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizResultSubmitService.submit(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_OPTION_INVALID);
+    }
+
+    private void mockSubmitData(
+            Long userId,
+            Subject subject,
+            QuizSession quizSession,
+            QuizPlaySession playSession,
+            List<Question> questions,
+            List<QuestionOption> options,
+            List<QuestionAnswer> answers
+    ) {
+        when(quizPlaySessionRepository.findByClientSessionId(playSession.getClientSessionId()))
+                .thenReturn(Optional.of(playSession));
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subject.getId(), userId))
+                .thenReturn(Optional.of(subject));
+        when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(quizSession.getId(), userId))
+                .thenReturn(questions);
+        when(questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(
+                questions.stream().map(Question::getId).toList()
+        )).thenReturn(options);
+        when(questionAnswerRepository.findAllByQuestionIdIn(questions.stream().map(Question::getId).toList()))
+                .thenReturn(answers);
+    }
+
+    private QuizResultSubmitRequest request(
+            String clientSessionId,
+            String quizSessionId,
+            Integer elapsedMs,
+            List<QuizAnswerSubmitItem> answers
+    ) {
+        QuizResultSubmitRequest request = newEntity(QuizResultSubmitRequest.class);
+        ReflectionTestUtils.setField(request, "clientSessionId", clientSessionId);
+        ReflectionTestUtils.setField(request, "quizSessionId", quizSessionId);
+        ReflectionTestUtils.setField(request, "playType", "first");
+        ReflectionTestUtils.setField(request, "elapsedMs", elapsedMs);
+        ReflectionTestUtils.setField(request, "answers", answers);
+        return request;
+    }
+
+    private QuizAnswerSubmitItem answerItem(String questionId, String selectedOptionId, Boolean correctClient, Boolean skipped) {
+        QuizAnswerSubmitItem item = newEntity(QuizAnswerSubmitItem.class);
+        ReflectionTestUtils.setField(item, "questionId", questionId);
+        ReflectionTestUtils.setField(item, "selectedOptionId", selectedOptionId);
+        ReflectionTestUtils.setField(item, "correctClient", correctClient);
+        ReflectionTestUtils.setField(item, "skipped", skipped);
+        ReflectionTestUtils.setField(item, "answerElapsedMs", 15000);
+        ReflectionTestUtils.setField(item, "marked", false);
+        return item;
+    }
+
+    private Subject subject(Long id, String publicId, Long userId, String name) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId, String status) {
+        QuizSession quizSession = QuizSession.create(
+                publicId,
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                1,
+                "one_by_one",
+                true,
+                "per_question",
+                60,
+                "medium",
+                status,
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizPlaySession playSession(Long id, String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        QuizPlaySession playSession = QuizPlaySession.createFirst(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+
+    private Question question(Long id, String publicId, Long quizSessionId, Long userId, Long subjectId, Integer displayOrder) {
+        Question question = newEntity(Question.class);
+        ReflectionTestUtils.setField(question, "id", id);
+        ReflectionTestUtils.setField(question, "publicId", publicId);
+        ReflectionTestUtils.setField(question, "quizSessionId", quizSessionId);
+        ReflectionTestUtils.setField(question, "userId", userId);
+        ReflectionTestUtils.setField(question, "subjectId", subjectId);
+        ReflectionTestUtils.setField(question, "chapterId", 100L + displayOrder);
+        ReflectionTestUtils.setField(question, "partId", 200L + displayOrder);
+        ReflectionTestUtils.setField(question, "questionType", "multiple_choice");
+        ReflectionTestUtils.setField(question, "difficulty", "medium");
+        ReflectionTestUtils.setField(question, "summary", "핵심 개념 확인");
+        ReflectionTestUtils.setField(question, "body", "다음 중 올바른 것은?");
+        ReflectionTestUtils.setField(question, "correctExplanation", "정답 해설");
+        ReflectionTestUtils.setField(question, "incorrectExplanation", "오답 해설");
+        ReflectionTestUtils.setField(question, "displayOrder", displayOrder);
+        return question;
+    }
+
+    private QuestionOption option(Long id, Long questionId, Integer optionNumber, String content, Boolean correct) {
+        QuestionOption option = newEntity(QuestionOption.class);
+        ReflectionTestUtils.setField(option, "id", id);
+        ReflectionTestUtils.setField(option, "questionId", questionId);
+        ReflectionTestUtils.setField(option, "optionNumber", optionNumber);
+        ReflectionTestUtils.setField(option, "content", content);
+        ReflectionTestUtils.setField(option, "correct", correct);
+        return option;
+    }
+
+    private QuestionAnswer answer(Long id, Long questionId, String answerValue) {
+        QuestionAnswer answer = newEntity(QuestionAnswer.class);
+        ReflectionTestUtils.setField(answer, "id", id);
+        ReflectionTestUtils.setField(answer, "questionId", questionId);
+        ReflectionTestUtils.setField(answer, "answerValue", answerValue);
+        return answer;
+    }
+
+    private QuizResult result(
+            Long id,
+            String publicId,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            Integer totalCount,
+            Integer correctCount,
+            Integer wrongCount,
+            Integer skipCount,
+            Integer accuracyPct
+    ) {
+        QuizResult result = QuizResult.create(
+                publicId,
+                playSession.getId(),
+                quizSession.getId(),
+                playSession.getUserId(),
+                subject.getId(),
+                totalCount,
+                correctCount,
+                wrongCount,
+                skipCount,
+                accuracyPct,
+                playSession.getElapsedMs(),
+                true,
+                false
+        );
+        ReflectionTestUtils.setField(result, "id", id);
+        return result;
+    }
+
+    private QuizPlayAnswer playAnswer(
+            Long playSessionId,
+            Long questionId,
+            Long userId,
+            Long selectedOptionId,
+            Boolean correctServer,
+            Boolean skipped
+    ) {
+        return QuizPlayAnswer.create(
+                playSessionId,
+                questionId,
+                userId,
+                selectedOptionId,
+                null,
+                correctServer,
+                correctServer,
+                skipped,
+                15000,
+                false
+        );
+    }
+
+    private List<QuizPlayAnswer> toList(Iterable<QuizPlayAnswer> answers) {
+        List<QuizPlayAnswer> result = new ArrayList<>();
+        answers.forEach(result::add);
+        return result;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ArgumentCaptor<Iterable<QuizPlayAnswer>> answerIterableCaptor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(Iterable.class);
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}


### PR DESCRIPTION
## 🧩 Description

- 퀴즈 결과 제출 API 구현
- 제출 답안 서버 재채점 및 결과 요약 저장
- clientSessionId 기준 중복 제출 시 기존 결과 반환

---

## 🛠️ Changes

- POST /api/v1/quiz-results 컨트롤러 추가
- quiz_play_answers, quiz_results 런타임 마이그레이션 추가
- QuizPlayAnswer 엔티티/리포지토리 추가
- QuizResult 엔티티 결과 요약 필드 확장
- 서버 재채점, 정답률, 스킵/오답 수, 채점 불일치/어뷰징 플래그 계산 구현
- 결과 응답에 보상 기본값, 리뷰 항목, 재풀이 가능 정보 포함

---

## 🧪 How to Test

1. ./gradlew test --tests com.f1.quiket.domain.quiz.service.QuizResultSubmitServiceTest
2. ./gradlew test

---

## 🔗 Related Issue

Closes #87

---

## ⚠️ Notes

- 보상 적립 로직은 후속 이슈에서 연결 예정
- 이번 PR에서는 보상 응답값을 0/default로 반환

---

## 🧑‍💻 Assignee

- @imclaremont