### PR TITLE
[Feat] 퀴즈 보상 적립 및 게임화 조회 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/gamification/controller/GamificationController.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/controller/GamificationController.java
@@ -1,0 +1,29 @@
+package com.f1.quiket.domain.gamification.controller;
+
+import com.f1.quiket.domain.gamification.dto.GamificationResponse;
+import com.f1.quiket.domain.gamification.service.GamificationService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/gamification")
+public class GamificationController {
+
+    private final GamificationService gamificationService;
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<GamificationResponse>> getMyGamification(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        GamificationResponse response = gamificationService.getMyGamification(principal.getPublicId());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/dto/GamificationResponse.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/dto/GamificationResponse.java
@@ -1,0 +1,39 @@
+package com.f1.quiket.domain.gamification.dto;
+
+import com.f1.quiket.domain.gamification.service.GamificationLevelCalculator;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.entity.type.UserLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GamificationResponse {
+
+    private final Integer dotoriBalance;
+    private final Integer xpTotal;
+    private final Integer currentLevel;
+    private final String currentLevelName;
+    private final Integer maxLevel;
+    private final Integer nextLevel;
+    private final String nextLevelName;
+    private final Integer currentLevelMinXp;
+    private final Integer nextLevelRequiredXp;
+    private final Integer levelProgressPct;
+
+    public static GamificationResponse from(User user) {
+        Integer nextLevel = GamificationLevelCalculator.nextLevel(user.getCurrentLevel());
+        return GamificationResponse.builder()
+                .dotoriBalance(user.getDotoriBalance())
+                .xpTotal(user.getXpTotal())
+                .currentLevel(user.getCurrentLevel())
+                .currentLevelName(UserLevel.titleOf(user.getCurrentLevel()))
+                .maxLevel(GamificationLevelCalculator.MAX_LEVEL)
+                .nextLevel(nextLevel)
+                .nextLevelName(nextLevel == null ? null : UserLevel.titleOf(nextLevel))
+                .currentLevelMinXp(GamificationLevelCalculator.currentLevelMinXp(user.getCurrentLevel()))
+                .nextLevelRequiredXp(GamificationLevelCalculator.nextLevelRequiredXp(user.getCurrentLevel()))
+                .levelProgressPct(GamificationLevelCalculator.progressPct(user.getXpTotal(), user.getCurrentLevel()))
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/entity/UserDotoriLog.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/entity/UserDotoriLog.java
@@ -1,0 +1,76 @@
+package com.f1.quiket.domain.gamification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "user_dotori_logs",
+        indexes = {
+                @Index(name = "idx_user_dotori_logs_user_id_created_at", columnList = "user_id, created_at"),
+                @Index(name = "idx_user_dotori_logs_play_session_id", columnList = "play_session_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserDotoriLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "play_session_id")
+    Long playSessionId;
+
+    @Column(name = "change_type", length = 20, nullable = false)
+    String changeType;
+
+    @Column(name = "amount", nullable = false)
+    Integer amount;
+
+    @Column(name = "balance_before", nullable = false)
+    Integer balanceBefore;
+
+    @Column(name = "balance_after", nullable = false)
+    Integer balanceAfter;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    public static UserDotoriLog createQuizEarn(
+            Long userId,
+            Long playSessionId,
+            Integer amount,
+            Integer balanceBefore,
+            Integer balanceAfter
+    ) {
+        UserDotoriLog log = new UserDotoriLog();
+        log.userId = userId;
+        log.playSessionId = playSessionId;
+        log.changeType = "earn_quiz";
+        log.amount = amount;
+        log.balanceBefore = balanceBefore;
+        log.balanceAfter = balanceAfter;
+        return log;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/entity/UserStreakLog.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/entity/UserStreakLog.java
@@ -1,0 +1,72 @@
+package com.f1.quiket.domain.gamification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "user_streak_logs",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_user_streak_logs_user_study_date", columnNames = {"user_id", "study_date"})
+        },
+        indexes = {
+                @Index(name = "idx_user_streak_logs_user_id_study_date", columnList = "user_id, study_date")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserStreakLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "study_date", nullable = false)
+    LocalDate studyDate;
+
+    @Column(name = "streak_count", nullable = false)
+    Integer streakCount;
+
+    @Column(name = "multiplier", precision = 3, scale = 1, nullable = false)
+    BigDecimal multiplier;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    public static UserStreakLog create(
+            Long userId,
+            LocalDate studyDate,
+            Integer streakCount,
+            BigDecimal multiplier
+    ) {
+        UserStreakLog log = new UserStreakLog();
+        log.userId = userId;
+        log.studyDate = studyDate;
+        log.streakCount = streakCount;
+        log.multiplier = multiplier;
+        return log;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/entity/UserXpLog.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/entity/UserXpLog.java
@@ -1,0 +1,101 @@
+package com.f1.quiket.domain.gamification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "user_xp_logs",
+        indexes = {
+                @Index(name = "idx_user_xp_logs_user_id_created_at", columnList = "user_id, created_at"),
+                @Index(name = "idx_user_xp_logs_play_session_id", columnList = "play_session_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserXpLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "play_session_id")
+    Long playSessionId;
+
+    @Column(name = "lecture_upload_id")
+    Long lectureUploadId;
+
+    @Column(name = "xp_type", length = 30, nullable = false)
+    String xpType;
+
+    @Column(name = "base_xp", nullable = false)
+    Integer baseXp;
+
+    @Column(name = "streak_multiplier", precision = 3, scale = 1, nullable = false)
+    BigDecimal streakMultiplier;
+
+    @Column(name = "earned_xp", nullable = false)
+    Integer earnedXp;
+
+    @Column(name = "xp_before", nullable = false)
+    Integer xpBefore;
+
+    @Column(name = "xp_after", nullable = false)
+    Integer xpAfter;
+
+    @Column(name = "level_before", nullable = false)
+    Integer levelBefore;
+
+    @Column(name = "level_after", nullable = false)
+    Integer levelAfter;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    public static UserXpLog createQuizReward(
+            Long userId,
+            Long playSessionId,
+            String xpType,
+            Integer baseXp,
+            BigDecimal streakMultiplier,
+            Integer earnedXp,
+            Integer xpBefore,
+            Integer xpAfter,
+            Integer levelBefore,
+            Integer levelAfter
+    ) {
+        UserXpLog log = new UserXpLog();
+        log.userId = userId;
+        log.playSessionId = playSessionId;
+        log.xpType = xpType;
+        log.baseXp = baseXp;
+        log.streakMultiplier = streakMultiplier;
+        log.earnedXp = earnedXp;
+        log.xpBefore = xpBefore;
+        log.xpAfter = xpAfter;
+        log.levelBefore = levelBefore;
+        log.levelAfter = levelAfter;
+        return log;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/repository/UserDotoriLogRepository.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/repository/UserDotoriLogRepository.java
@@ -1,0 +1,9 @@
+package com.f1.quiket.domain.gamification.repository;
+
+import com.f1.quiket.domain.gamification.entity.UserDotoriLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserDotoriLogRepository extends JpaRepository<UserDotoriLog, Long> {
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/repository/UserStreakLogRepository.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/repository/UserStreakLogRepository.java
@@ -1,0 +1,15 @@
+package com.f1.quiket.domain.gamification.repository;
+
+import com.f1.quiket.domain.gamification.entity.UserStreakLog;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserStreakLogRepository extends JpaRepository<UserStreakLog, Long> {
+
+    Optional<UserStreakLog> findByUserIdAndStudyDate(Long userId, LocalDate studyDate);
+
+    Optional<UserStreakLog> findTopByUserIdAndStudyDateBeforeOrderByStudyDateDesc(Long userId, LocalDate studyDate);
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/repository/UserXpLogRepository.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/repository/UserXpLogRepository.java
@@ -1,0 +1,9 @@
+package com.f1.quiket.domain.gamification.repository;
+
+import com.f1.quiket.domain.gamification.entity.UserXpLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserXpLogRepository extends JpaRepository<UserXpLog, Long> {
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculator.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculator.java
@@ -1,0 +1,75 @@
+package com.f1.quiket.domain.gamification.service;
+
+public final class GamificationLevelCalculator {
+
+    public static final int MAX_LEVEL = 10;
+
+    private static final int[] LEVEL_MIN_XP = {
+            0,
+            100,
+            350,
+            850,
+            1750,
+            3250,
+            5750,
+            9750,
+            16250,
+            26250
+    };
+
+    private GamificationLevelCalculator() {
+    }
+
+    public static int levelOf(Integer xpTotal) {
+        int normalizedXp = normalizeXp(xpTotal);
+        for (int index = LEVEL_MIN_XP.length - 1; index >= 0; index--) {
+            if (normalizedXp >= LEVEL_MIN_XP[index]) {
+                return index + 1;
+            }
+        }
+        return 1;
+    }
+
+    public static int currentLevelMinXp(Integer currentLevel) {
+        return LEVEL_MIN_XP[normalizeLevel(currentLevel) - 1];
+    }
+
+    public static Integer nextLevel(Integer currentLevel) {
+        int normalizedLevel = normalizeLevel(currentLevel);
+        if (normalizedLevel >= MAX_LEVEL) {
+            return null;
+        }
+        return normalizedLevel + 1;
+    }
+
+    public static Integer nextLevelRequiredXp(Integer currentLevel) {
+        Integer nextLevel = nextLevel(currentLevel);
+        if (nextLevel == null) {
+            return null;
+        }
+        return LEVEL_MIN_XP[nextLevel - 1];
+    }
+
+    public static int progressPct(Integer xpTotal, Integer currentLevel) {
+        int normalizedLevel = normalizeLevel(currentLevel);
+        if (normalizedLevel >= MAX_LEVEL) {
+            return 100;
+        }
+
+        int minXp = currentLevelMinXp(normalizedLevel);
+        int nextMinXp = nextLevelRequiredXp(normalizedLevel);
+        int progressPct = (normalizeXp(xpTotal) - minXp) * 100 / (nextMinXp - minXp);
+        return Math.max(0, Math.min(progressPct, 100));
+    }
+
+    private static int normalizeXp(Integer xpTotal) {
+        return Math.max(xpTotal == null ? 0 : xpTotal, 0);
+    }
+
+    private static int normalizeLevel(Integer currentLevel) {
+        if (currentLevel == null || currentLevel < 1) {
+            return 1;
+        }
+        return Math.min(currentLevel, MAX_LEVEL);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/service/GamificationRewardService.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/GamificationRewardService.java
@@ -1,0 +1,183 @@
+package com.f1.quiket.domain.gamification.service;
+
+import com.f1.quiket.domain.gamification.entity.UserDotoriLog;
+import com.f1.quiket.domain.gamification.entity.UserStreakLog;
+import com.f1.quiket.domain.gamification.entity.UserXpLog;
+import com.f1.quiket.domain.gamification.repository.UserDotoriLogRepository;
+import com.f1.quiket.domain.gamification.repository.UserStreakLogRepository;
+import com.f1.quiket.domain.gamification.repository.UserXpLogRepository;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.user.entity.User;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GamificationRewardService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final String PLAY_TYPE_FIRST = "first";
+    private static final String XP_TYPE_QUIZ_CORRECT = "quiz_correct";
+    private static final String XP_TYPE_QUIZ_RETRY = "quiz_retry";
+
+    private final UserXpLogRepository userXpLogRepository;
+    private final UserDotoriLogRepository userDotoriLogRepository;
+    private final UserStreakLogRepository userStreakLogRepository;
+
+    public QuizRewardResult applyQuizReward(
+            User user,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Integer correctCount
+    ) {
+        int normalizedCorrectCount = Math.max(correctCount == null ? 0 : correctCount, 0);
+        UserStreakLog streakLog = findOrCreateTodayStreak(user.getId());
+        BigDecimal streakMultiplier = streakLog.getMultiplier();
+
+        int dotoriEarned = calculateDotoriEarned(playSession, normalizedCorrectCount);
+        int baseXp = normalizedCorrectCount * xpPerCorrect(quizSession.getDifficulty(), playSession.getPlayType());
+        int earnedXp = calculateEarnedXp(baseXp, streakMultiplier);
+
+        int dotoriBefore = user.getDotoriBalance();
+        int xpBefore = user.getXpTotal();
+        int levelBefore = user.getCurrentLevel();
+        int dotoriAfter = dotoriBefore + dotoriEarned;
+        int xpAfter = xpBefore + earnedXp;
+        int levelAfter = GamificationLevelCalculator.levelOf(xpAfter);
+        boolean leveledUp = levelAfter > levelBefore;
+
+        user.applyQuizReward(dotoriEarned, earnedXp, levelAfter);
+        saveRewardLogs(
+                user,
+                playSession,
+                dotoriEarned,
+                dotoriBefore,
+                dotoriAfter,
+                baseXp,
+                streakMultiplier,
+                earnedXp,
+                xpBefore,
+                xpAfter,
+                levelBefore,
+                levelAfter
+        );
+
+        return new QuizRewardResult(
+                dotoriEarned,
+                earnedXp,
+                leveledUp,
+                leveledUp ? levelAfter : null,
+                user.getDotoriBalance(),
+                user.getXpTotal()
+        );
+    }
+
+    private UserStreakLog findOrCreateTodayStreak(Long userId) {
+        LocalDate today = LocalDate.now(KST);
+        return userStreakLogRepository.findByUserIdAndStudyDate(userId, today)
+                .orElseGet(() -> createTodayStreak(userId, today));
+    }
+
+    private UserStreakLog createTodayStreak(Long userId, LocalDate today) {
+        int streakCount = userStreakLogRepository.findTopByUserIdAndStudyDateBeforeOrderByStudyDateDesc(userId, today)
+                .map(previous -> previous.getStudyDate().equals(today.minusDays(1))
+                        ? previous.getStreakCount() + 1
+                        : 1)
+                .orElse(1);
+        return userStreakLogRepository.save(UserStreakLog.create(userId, today, streakCount, multiplierOf(streakCount)));
+    }
+
+    private int calculateDotoriEarned(QuizPlaySession playSession, int correctCount) {
+        if (!PLAY_TYPE_FIRST.equals(playSession.getPlayType())) {
+            return 0;
+        }
+        return correctCount;
+    }
+
+    private int xpPerCorrect(String difficulty, String playType) {
+        if (PLAY_TYPE_FIRST.equals(playType)) {
+            return switch (difficulty) {
+                case "easy" -> 3;
+                case "hard" -> 5;
+                default -> 4;
+            };
+        }
+        return switch (difficulty) {
+            case "easy" -> 2;
+            case "hard" -> 4;
+            default -> 3;
+        };
+    }
+
+    private BigDecimal multiplierOf(int streakCount) {
+        if (streakCount >= 30) {
+            return BigDecimal.valueOf(2.5);
+        }
+        if (streakCount >= 14) {
+            return BigDecimal.valueOf(2.0);
+        }
+        if (streakCount >= 6) {
+            return BigDecimal.valueOf(1.5);
+        }
+        if (streakCount >= 3) {
+            return BigDecimal.valueOf(1.2);
+        }
+        if (streakCount == 2) {
+            return BigDecimal.valueOf(1.1);
+        }
+        return BigDecimal.valueOf(1.0);
+    }
+
+    private int calculateEarnedXp(int baseXp, BigDecimal streakMultiplier) {
+        return BigDecimal.valueOf(baseXp)
+                .multiply(streakMultiplier)
+                .setScale(0, RoundingMode.DOWN)
+                .intValue();
+    }
+
+    private void saveRewardLogs(
+            User user,
+            QuizPlaySession playSession,
+            int dotoriEarned,
+            int dotoriBefore,
+            int dotoriAfter,
+            int baseXp,
+            BigDecimal streakMultiplier,
+            int earnedXp,
+            int xpBefore,
+            int xpAfter,
+            int levelBefore,
+            int levelAfter
+    ) {
+        if (dotoriEarned > 0) {
+            userDotoriLogRepository.save(UserDotoriLog.createQuizEarn(
+                    user.getId(),
+                    playSession.getId(),
+                    dotoriEarned,
+                    dotoriBefore,
+                    dotoriAfter
+            ));
+        }
+        if (earnedXp > 0) {
+            userXpLogRepository.save(UserXpLog.createQuizReward(
+                    user.getId(),
+                    playSession.getId(),
+                    PLAY_TYPE_FIRST.equals(playSession.getPlayType()) ? XP_TYPE_QUIZ_CORRECT : XP_TYPE_QUIZ_RETRY,
+                    baseXp,
+                    streakMultiplier,
+                    earnedXp,
+                    xpBefore,
+                    xpAfter,
+                    levelBefore,
+                    levelAfter
+            ));
+        }
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/service/GamificationService.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/GamificationService.java
@@ -1,0 +1,24 @@
+package com.f1.quiket.domain.gamification.service;
+
+import com.f1.quiket.domain.gamification.dto.GamificationResponse;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GamificationService {
+
+    private final UserRepository userRepository;
+
+    public GamificationResponse getMyGamification(String userPublicId) {
+        User user = userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+        return GamificationResponse.from(user);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/service/QuizRewardResult.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/QuizRewardResult.java
@@ -1,0 +1,11 @@
+package com.f1.quiket.domain.gamification.service;
+
+public record QuizRewardResult(
+        Integer dotoriEarned,
+        Integer xpEarned,
+        Boolean leveledUp,
+        Integer newLevel,
+        Integer currentDotoriBalance,
+        Integer currentXpTotal
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultResponse.java
@@ -4,6 +4,7 @@ import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
 import com.f1.quiket.domain.quiz.entity.QuizResult;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
@@ -36,6 +37,7 @@ public class QuizResultResponse {
             QuizPlaySession playSession,
             QuizSession quizSession,
             Subject subject,
+            User user,
             List<QuizReviewItemResponse> reviewItems
     ) {
         return QuizResultResponse.builder()
@@ -52,7 +54,7 @@ public class QuizResultResponse {
                 .elapsedMs(result.getElapsedMs())
                 .scoreMatched(result.getScoreMatched())
                 .abuseFlagged(result.getAbuseFlagged())
-                .rewards(QuizRewardSummaryResponse.from(result))
+                .rewards(QuizRewardSummaryResponse.of(result, user))
                 .reviewItems(reviewItems)
                 .retryAvailable(QuizRetryAvailableResponse.from(result.getWrongCount()))
                 .createdAt(result.getCreatedAt())

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRewardSummaryResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRewardSummaryResponse.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.quiz.dto;
 
 import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,13 +13,17 @@ public class QuizRewardSummaryResponse {
     private final Integer xpEarned;
     private final Boolean leveledUp;
     private final Integer newLevel;
+    private final Integer currentDotoriBalance;
+    private final Integer currentXpTotal;
 
-    public static QuizRewardSummaryResponse from(QuizResult result) {
+    public static QuizRewardSummaryResponse of(QuizResult result, User user) {
         return QuizRewardSummaryResponse.builder()
                 .dotoriEarned(result.getDotoriEarned())
                 .xpEarned(result.getXpEarned())
                 .leveledUp(result.getLeveledUp())
                 .newLevel(result.getNewLevel())
+                .currentDotoriBalance(user.getDotoriBalance())
+                .currentXpTotal(user.getXpTotal())
                 .build();
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
@@ -116,6 +116,10 @@ public class QuizResult {
             Integer skipCount,
             Integer accuracyPct,
             Integer elapsedMs,
+            Integer dotoriEarned,
+            Integer xpEarned,
+            Boolean leveledUp,
+            Integer newLevel,
             Boolean scoreMatched,
             Boolean abuseFlagged
     ) {
@@ -131,9 +135,10 @@ public class QuizResult {
         result.skipCount = skipCount;
         result.accuracyPct = accuracyPct;
         result.elapsedMs = elapsedMs;
-        result.dotoriEarned = 0;
-        result.xpEarned = 0;
-        result.leveledUp = false;
+        result.dotoriEarned = dotoriEarned;
+        result.xpEarned = xpEarned;
+        result.leveledUp = leveledUp;
+        result.newLevel = newLevel;
         result.scoreMatched = scoreMatched;
         result.abuseFlagged = abuseFlagged;
         return result;

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
@@ -1,5 +1,7 @@
 package com.f1.quiket.domain.quiz.service;
 
+import com.f1.quiket.domain.gamification.service.GamificationRewardService;
+import com.f1.quiket.domain.gamification.service.QuizRewardResult;
 import com.f1.quiket.domain.quiz.dto.QuizAnswerSubmitItem;
 import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
@@ -21,6 +23,8 @@ import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.subject.entity.Subject;
 import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import com.f1.quiket.global.util.UuidV7Generator;
@@ -55,8 +59,11 @@ public class QuizResultSubmitService {
     private final QuizPlaySessionRepository quizPlaySessionRepository;
     private final QuizPlayAnswerRepository quizPlayAnswerRepository;
     private final QuizResultRepository quizResultRepository;
+    private final UserRepository userRepository;
+    private final GamificationRewardService gamificationRewardService;
 
     public QuizResultSubmitOutcome submit(Long userId, QuizResultSubmitRequest request) {
+        User user = findUser(userId);
         QuizPlaySession playSession = findPlaySession(userId, request.getClientSessionId());
         QuizSession quizSession = findQuizSession(userId, request.getQuizSessionId());
         Subject subject = findSubject(userId, quizSession.getSubjectId());
@@ -76,6 +83,7 @@ public class QuizResultSubmitService {
                         playSession,
                         quizSession,
                         subject,
+                        user,
                         questions,
                         optionsByQuestionId,
                         answersByQuestionId
@@ -86,10 +94,16 @@ public class QuizResultSubmitService {
                         playSession,
                         quizSession,
                         subject,
+                        user,
                         questions,
                         optionsByQuestionId,
                         answersByQuestionId
                 ));
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
     }
 
     private QuizPlaySession findPlaySession(Long userId, String clientSessionId) {
@@ -158,6 +172,7 @@ public class QuizResultSubmitService {
             QuizPlaySession playSession,
             QuizSession quizSession,
             Subject subject,
+            User user,
             List<Question> questions,
             Map<Long, List<QuestionOption>> optionsByQuestionId,
             Map<Long, QuestionAnswer> answersByQuestionId
@@ -168,6 +183,7 @@ public class QuizResultSubmitService {
                 playSession,
                 quizSession,
                 subject,
+                user,
                 questions,
                 optionsByQuestionId,
                 answersByQuestionId,
@@ -182,6 +198,7 @@ public class QuizResultSubmitService {
             QuizPlaySession playSession,
             QuizSession quizSession,
             Subject subject,
+            User user,
             List<Question> questions,
             Map<Long, List<QuestionOption>> optionsByQuestionId,
             Map<Long, QuestionAnswer> answersByQuestionId
@@ -213,6 +230,12 @@ public class QuizResultSubmitService {
 
         quizPlayAnswerRepository.saveAll(playAnswers);
         playSession.submit(request.getElapsedMs());
+        QuizRewardResult reward = gamificationRewardService.applyQuizReward(
+                user,
+                playSession,
+                quizSession,
+                correctCount
+        );
         QuizResult savedResult = quizResultRepository.save(QuizResult.create(
                 UuidV7Generator.generate(),
                 playSession.getId(),
@@ -225,6 +248,10 @@ public class QuizResultSubmitService {
                 skipCount,
                 accuracyPct,
                 request.getElapsedMs(),
+                reward.dotoriEarned(),
+                reward.xpEarned(),
+                reward.leveledUp(),
+                reward.newLevel(),
                 scoreMatched,
                 abuseFlagged
         ));
@@ -234,6 +261,7 @@ public class QuizResultSubmitService {
                 playSession,
                 quizSession,
                 subject,
+                user,
                 questions,
                 optionsByQuestionId,
                 answersByQuestionId,
@@ -350,6 +378,7 @@ public class QuizResultSubmitService {
             QuizPlaySession playSession,
             QuizSession quizSession,
             Subject subject,
+            User user,
             List<Question> questions,
             Map<Long, List<QuestionOption>> optionsByQuestionId,
             Map<Long, QuestionAnswer> answersByQuestionId,
@@ -365,7 +394,7 @@ public class QuizResultSubmitService {
                         getPlayAnswer(playAnswersByQuestionId, question)
                 ))
                 .toList();
-        return QuizResultResponse.of(result, playSession, quizSession, subject, reviewItems);
+        return QuizResultResponse.of(result, playSession, quizSession, subject, user, reviewItems);
     }
 
     private QuizPlayAnswer getPlayAnswer(Map<Long, QuizPlayAnswer> playAnswersByQuestionId, Question question) {

--- a/src/main/java/com/f1/quiket/domain/user/entity/User.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/User.java
@@ -93,6 +93,12 @@ public class User extends BaseEntity {
         this.nickname = nickname;
     }
 
+    public void applyQuizReward(Integer dotoriEarned, Integer xpEarned, Integer levelAfter) {
+        this.dotoriBalance += dotoriEarned;
+        this.xpTotal += xpEarned;
+        this.currentLevel = levelAfter;
+    }
+
     public void recordLoginFailure(int maxFailedCount) {
         LocalDateTime now = LocalDateTime.now();
         this.failedLoginCount++;

--- a/src/main/java/com/f1/quiket/domain/user/entity/User.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/User.java
@@ -93,7 +93,7 @@ public class User extends BaseEntity {
         this.nickname = nickname;
     }
 
-    public void applyQuizReward(Integer dotoriEarned, Integer xpEarned, Integer levelAfter) {
+    public void applyQuizReward(int dotoriEarned, int xpEarned, int levelAfter) {
         this.dotoriBalance += dotoriEarned;
         this.xpTotal += xpEarned;
         this.currentLevel = levelAfter;

--- a/src/main/java/com/f1/quiket/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/f1/quiket/domain/user/repository/UserRepository.java
@@ -21,5 +21,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndDeletedAtIsNull(String email);
 
+    Optional<User> findByIdAndDeletedAtIsNull(Long id);
+
     Optional<User> findByPublicIdAndDeletedAtIsNull(String publicId);
 }

--- a/src/main/resources/db/migration/V12__create_gamification_logs.sql
+++ b/src/main/resources/db/migration/V12__create_gamification_logs.sql
@@ -1,0 +1,55 @@
+CREATE TABLE IF NOT EXISTS user_xp_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    play_session_id BIGINT NULL COMMENT '풀이 세션 ID',
+    lecture_upload_id BIGINT NULL COMMENT '업로드 ID',
+    xp_type VARCHAR(30) NOT NULL COMMENT 'XP 유형',
+    base_xp SMALLINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '기본 XP',
+    streak_multiplier DECIMAL(3,1) NOT NULL DEFAULT 1.0 COMMENT '연속 학습 배수',
+    earned_xp SMALLINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '실제 적립 XP',
+    xp_before INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '적립 전 누적 XP',
+    xp_after INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '적립 후 누적 XP',
+    level_before TINYINT UNSIGNED NOT NULL DEFAULT 1 COMMENT '적립 전 레벨',
+    level_after TINYINT UNSIGNED NOT NULL DEFAULT 1 COMMENT '적립 후 레벨',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '적립 시각',
+
+    PRIMARY KEY (id),
+    KEY idx_user_xp_logs_user_id_created_at (user_id, created_at),
+    KEY idx_user_xp_logs_play_session_id (play_session_id),
+
+    CONSTRAINT chk_user_xp_logs_xp_type
+        CHECK (xp_type IN ('quiz_correct', 'quiz_retry', 'upload', 'streak_bonus'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='XP 적립 이력';
+
+CREATE TABLE IF NOT EXISTS user_dotori_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    play_session_id BIGINT NULL COMMENT '풀이 세션 ID',
+    change_type VARCHAR(20) NOT NULL COMMENT '변동 유형',
+    amount SMALLINT NOT NULL COMMENT '변동량',
+    balance_before INT NOT NULL COMMENT '변동 전 잔액',
+    balance_after INT NOT NULL COMMENT '변동 후 잔액',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '변동 시각',
+
+    PRIMARY KEY (id),
+    KEY idx_user_dotori_logs_user_id_created_at (user_id, created_at),
+    KEY idx_user_dotori_logs_play_session_id (play_session_id),
+
+    CONSTRAINT chk_user_dotori_logs_change_type
+        CHECK (change_type IN ('earn_quiz', 'spend_item')),
+    CONSTRAINT chk_user_dotori_logs_balance_after
+        CHECK (balance_after >= 0)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='도토리 적립/차감 이력';
+
+CREATE TABLE IF NOT EXISTS user_streak_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    study_date DATE NOT NULL COMMENT '학습 날짜',
+    streak_count SMALLINT UNSIGNED NOT NULL DEFAULT 1 COMMENT '연속 학습 일수',
+    multiplier DECIMAL(3,1) NOT NULL DEFAULT 1.0 COMMENT '적용 배수',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '기록 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_user_streak_logs_user_study_date (user_id, study_date),
+    KEY idx_user_streak_logs_user_id_study_date (user_id, study_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='연속 학습 이력';

--- a/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
@@ -1,0 +1,174 @@
+package com.f1.quiket.domain.gamification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.gamification.entity.UserDotoriLog;
+import com.f1.quiket.domain.gamification.entity.UserStreakLog;
+import com.f1.quiket.domain.gamification.entity.UserXpLog;
+import com.f1.quiket.domain.gamification.repository.UserDotoriLogRepository;
+import com.f1.quiket.domain.gamification.repository.UserStreakLogRepository;
+import com.f1.quiket.domain.gamification.repository.UserXpLogRepository;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.user.entity.User;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class GamificationRewardServiceTest {
+
+    private UserXpLogRepository userXpLogRepository;
+    private UserDotoriLogRepository userDotoriLogRepository;
+    private UserStreakLogRepository userStreakLogRepository;
+    private GamificationRewardService gamificationRewardService;
+
+    @BeforeEach
+    void setUp() {
+        userXpLogRepository = mock(UserXpLogRepository.class);
+        userDotoriLogRepository = mock(UserDotoriLogRepository.class);
+        userStreakLogRepository = mock(UserStreakLogRepository.class);
+        gamificationRewardService = new GamificationRewardService(
+                userXpLogRepository,
+                userDotoriLogRepository,
+                userStreakLogRepository
+        );
+    }
+
+    @Test
+    void applyQuizReward_rewards_dotori_and_xp_for_first_play() {
+        User user = user(1L, 10, 360, 3);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "medium");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        LocalDate today = today();
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today))
+                .thenReturn(Optional.empty());
+        when(userStreakLogRepository.findTopByUserIdAndStudyDateBeforeOrderByStudyDateDesc(user.getId(), today))
+                .thenReturn(Optional.empty());
+        when(userStreakLogRepository.save(any(UserStreakLog.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 2);
+
+        assertThat(result.dotoriEarned()).isEqualTo(2);
+        assertThat(result.xpEarned()).isEqualTo(8);
+        assertThat(result.leveledUp()).isFalse();
+        assertThat(result.currentDotoriBalance()).isEqualTo(12);
+        assertThat(result.currentXpTotal()).isEqualTo(368);
+        assertThat(user.getDotoriBalance()).isEqualTo(12);
+        assertThat(user.getXpTotal()).isEqualTo(368);
+        assertThat(user.getCurrentLevel()).isEqualTo(3);
+
+        ArgumentCaptor<UserDotoriLog> dotoriCaptor = ArgumentCaptor.forClass(UserDotoriLog.class);
+        verify(userDotoriLogRepository).save(dotoriCaptor.capture());
+        assertThat(dotoriCaptor.getValue().getAmount()).isEqualTo(2);
+        assertThat(dotoriCaptor.getValue().getBalanceBefore()).isEqualTo(10);
+        assertThat(dotoriCaptor.getValue().getBalanceAfter()).isEqualTo(12);
+
+        ArgumentCaptor<UserXpLog> xpCaptor = ArgumentCaptor.forClass(UserXpLog.class);
+        verify(userXpLogRepository).save(xpCaptor.capture());
+        assertThat(xpCaptor.getValue().getXpType()).isEqualTo("quiz_correct");
+        assertThat(xpCaptor.getValue().getBaseXp()).isEqualTo(8);
+        assertThat(xpCaptor.getValue().getStreakMultiplier()).isEqualByComparingTo(BigDecimal.valueOf(1.0));
+        assertThat(xpCaptor.getValue().getEarnedXp()).isEqualTo(8);
+        assertThat(xpCaptor.getValue().getXpBefore()).isEqualTo(360);
+        assertThat(xpCaptor.getValue().getXpAfter()).isEqualTo(368);
+    }
+
+    @Test
+    void applyQuizReward_updates_level_when_xp_crosses_threshold() {
+        User user = user(1L, 0, 98, 1);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "medium");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        UserStreakLog streak = UserStreakLog.create(user.getId(), today(), 1, BigDecimal.valueOf(1.0));
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today()))
+                .thenReturn(Optional.of(streak));
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 1);
+
+        assertThat(result.xpEarned()).isEqualTo(4);
+        assertThat(result.leveledUp()).isTrue();
+        assertThat(result.newLevel()).isEqualTo(2);
+        assertThat(user.getXpTotal()).isEqualTo(102);
+        assertThat(user.getCurrentLevel()).isEqualTo(2);
+    }
+
+    @Test
+    void applyQuizReward_applies_consecutive_streak_multiplier() {
+        User user = user(1L, 0, 0, 1);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "medium");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        LocalDate today = today();
+        UserStreakLog previous = UserStreakLog.create(user.getId(), today.minusDays(1), 2, BigDecimal.valueOf(1.1));
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today))
+                .thenReturn(Optional.empty());
+        when(userStreakLogRepository.findTopByUserIdAndStudyDateBeforeOrderByStudyDateDesc(user.getId(), today))
+                .thenReturn(Optional.of(previous));
+        when(userStreakLogRepository.save(any(UserStreakLog.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 2);
+
+        assertThat(result.xpEarned()).isEqualTo(9);
+
+        ArgumentCaptor<UserStreakLog> streakCaptor = ArgumentCaptor.forClass(UserStreakLog.class);
+        verify(userStreakLogRepository).save(streakCaptor.capture());
+        assertThat(streakCaptor.getValue().getStreakCount()).isEqualTo(3);
+        assertThat(streakCaptor.getValue().getMultiplier()).isEqualByComparingTo(BigDecimal.valueOf(1.2));
+    }
+
+    private LocalDate today() {
+        return LocalDate.now(ZoneId.of("Asia/Seoul"));
+    }
+
+    private User user(Long id, Integer dotoriBalance, Integer xpTotal, Integer currentLevel) {
+        User user = User.create("user-public-id", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", id);
+        ReflectionTestUtils.setField(user, "dotoriBalance", dotoriBalance);
+        ReflectionTestUtils.setField(user, "xpTotal", xpTotal);
+        ReflectionTestUtils.setField(user, "currentLevel", currentLevel);
+        return user;
+    }
+
+    private QuizSession quizSession(Long id, Long userId, Long subjectId, String difficulty) {
+        QuizSession quizSession = QuizSession.create(
+                "quiz-session-public-id",
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                2,
+                "one_by_one",
+                true,
+                "per_question",
+                60,
+                difficulty,
+                "completed",
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizPlaySession playSession(Long id, Long quizSessionId, Long userId, Long subjectId) {
+        QuizPlaySession playSession = QuizPlaySession.createFirst(
+                "client-session-id",
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/gamification/service/GamificationServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/gamification/service/GamificationServiceTest.java
@@ -1,0 +1,82 @@
+package com.f1.quiket.domain.gamification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.gamification.dto.GamificationResponse;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class GamificationServiceTest {
+
+    private UserRepository userRepository;
+    private GamificationService gamificationService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        gamificationService = new GamificationService(userRepository);
+    }
+
+    @Test
+    void getMyGamification_returns_level_progress() {
+        User user = user(20, 360, 3);
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId()))
+                .thenReturn(Optional.of(user));
+
+        GamificationResponse response = gamificationService.getMyGamification(user.getPublicId());
+
+        assertThat(response.getDotoriBalance()).isEqualTo(20);
+        assertThat(response.getXpTotal()).isEqualTo(360);
+        assertThat(response.getCurrentLevel()).isEqualTo(3);
+        assertThat(response.getCurrentLevelName()).isEqualTo("펜굴리는 다람쥐");
+        assertThat(response.getMaxLevel()).isEqualTo(10);
+        assertThat(response.getNextLevel()).isEqualTo(4);
+        assertThat(response.getNextLevelName()).isEqualTo("노력형 다람쥐");
+        assertThat(response.getCurrentLevelMinXp()).isEqualTo(350);
+        assertThat(response.getNextLevelRequiredXp()).isEqualTo(850);
+        assertThat(response.getLevelProgressPct()).isEqualTo(2);
+    }
+
+    @Test
+    void getMyGamification_returns_max_level_without_next_level() {
+        User user = user(99, 30000, 10);
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId()))
+                .thenReturn(Optional.of(user));
+
+        GamificationResponse response = gamificationService.getMyGamification(user.getPublicId());
+
+        assertThat(response.getCurrentLevel()).isEqualTo(10);
+        assertThat(response.getNextLevel()).isNull();
+        assertThat(response.getNextLevelName()).isNull();
+        assertThat(response.getNextLevelRequiredXp()).isNull();
+        assertThat(response.getLevelProgressPct()).isEqualTo(100);
+    }
+
+    @Test
+    void getMyGamification_throws_not_found_when_user_missing() {
+        when(userRepository.findByPublicIdAndDeletedAtIsNull("missing-user"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> gamificationService.getMyGamification("missing-user"))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
+    }
+
+    private User user(Integer dotoriBalance, Integer xpTotal, Integer currentLevel) {
+        User user = User.create("user-public-id", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "dotoriBalance", dotoriBalance);
+        ReflectionTestUtils.setField(user, "xpTotal", xpTotal);
+        ReflectionTestUtils.setField(user, "currentLevel", currentLevel);
+        return user;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.f1.quiket.domain.gamification.service.GamificationRewardService;
+import com.f1.quiket.domain.gamification.service.QuizRewardResult;
 import com.f1.quiket.domain.quiz.dto.QuizAnswerSubmitItem;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
@@ -27,6 +29,8 @@ import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.subject.entity.Subject;
 import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import java.util.ArrayList;
@@ -47,6 +51,8 @@ class QuizResultSubmitServiceTest {
     private QuizPlaySessionRepository quizPlaySessionRepository;
     private QuizPlayAnswerRepository quizPlayAnswerRepository;
     private QuizResultRepository quizResultRepository;
+    private UserRepository userRepository;
+    private GamificationRewardService gamificationRewardService;
     private QuizResultSubmitService quizResultSubmitService;
 
     @BeforeEach
@@ -59,6 +65,8 @@ class QuizResultSubmitServiceTest {
         quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
         quizPlayAnswerRepository = mock(QuizPlayAnswerRepository.class);
         quizResultRepository = mock(QuizResultRepository.class);
+        userRepository = mock(UserRepository.class);
+        gamificationRewardService = mock(GamificationRewardService.class);
         quizResultSubmitService = new QuizResultSubmitService(
                 quizSessionRepository,
                 subjectRepository,
@@ -67,13 +75,16 @@ class QuizResultSubmitServiceTest {
                 questionAnswerRepository,
                 quizPlaySessionRepository,
                 quizPlayAnswerRepository,
-                quizResultRepository
+                quizResultRepository,
+                userRepository,
+                gamificationRewardService
         );
     }
 
     @Test
     void submit_creates_result_with_server_grading() {
         Long userId = 1L;
+        User user = user(userId, 12, 360, 3);
         Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
         QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
         QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
@@ -87,9 +98,10 @@ class QuizResultSubmitServiceTest {
                 430000,
                 List.of(answerItem(question.getPublicId(), String.valueOf(correctOption.getId()), true, false))
         );
-        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(correctOption, wrongOption), List.of(answer));
+        mockSubmitData(user, subject, quizSession, playSession, List.of(question), List.of(correctOption, wrongOption), List.of(answer));
         when(quizResultRepository.findByPlaySessionId(playSession.getId()))
                 .thenReturn(Optional.empty());
+        mockReward(user, playSession, quizSession, 1, 1, 4, false, null, 3);
         when(quizResultRepository.save(any(QuizResult.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -106,7 +118,10 @@ class QuizResultSubmitServiceTest {
         assertThat(outcome.getResponse().getAccuracyPct()).isEqualTo(100);
         assertThat(outcome.getResponse().getScoreMatched()).isTrue();
         assertThat(outcome.getResponse().getAbuseFlagged()).isFalse();
-        assertThat(outcome.getResponse().getRewards().getDotoriEarned()).isZero();
+        assertThat(outcome.getResponse().getRewards().getDotoriEarned()).isEqualTo(1);
+        assertThat(outcome.getResponse().getRewards().getXpEarned()).isEqualTo(4);
+        assertThat(outcome.getResponse().getRewards().getCurrentDotoriBalance()).isEqualTo(13);
+        assertThat(outcome.getResponse().getRewards().getCurrentXpTotal()).isEqualTo(364);
         assertThat(outcome.getResponse().getReviewItems()).hasSize(1);
         assertThat(outcome.getResponse().getReviewItems().get(0).getCorrectServer()).isTrue();
         assertThat(playSession.getStatus()).isEqualTo("submitted");
@@ -127,11 +142,15 @@ class QuizResultSubmitServiceTest {
         assertThat(savedResult.getAccuracyPct()).isEqualTo(100);
         assertThat(savedResult.getScoreMatched()).isTrue();
         assertThat(savedResult.getAbuseFlagged()).isFalse();
+        assertThat(savedResult.getDotoriEarned()).isEqualTo(1);
+        assertThat(savedResult.getXpEarned()).isEqualTo(4);
+        verify(gamificationRewardService).applyQuizReward(user, playSession, quizSession, 1);
     }
 
     @Test
     void submit_returns_existing_result_when_duplicate_request_is_retried() {
         Long userId = 1L;
+        User user = user(userId, 13, 364, 3);
         Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
         QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
         QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
@@ -146,7 +165,7 @@ class QuizResultSubmitServiceTest {
                 430000,
                 List.of(answerItem(question.getPublicId(), String.valueOf(option.getId()), true, false))
         );
-        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
+        mockSubmitData(user, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
         when(quizResultRepository.findByPlaySessionId(playSession.getId()))
                 .thenReturn(Optional.of(existingResult));
         when(quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId()))
@@ -157,13 +176,16 @@ class QuizResultSubmitServiceTest {
         assertThat(outcome.isCreated()).isFalse();
         assertThat(outcome.getResponse().getResultId()).isEqualTo("result-public-id");
         assertThat(outcome.getResponse().getCorrectCount()).isEqualTo(1);
+        assertThat(outcome.getResponse().getRewards().getCurrentDotoriBalance()).isEqualTo(13);
         verify(quizPlayAnswerRepository, never()).saveAll(any());
         verify(quizResultRepository, never()).save(any());
+        verify(gamificationRewardService, never()).applyQuizReward(any(), any(), any(), any());
     }
 
     @Test
     void submit_flags_score_mismatch_and_abuse_when_client_score_differs() {
         Long userId = 1L;
+        User user = user(userId, 12, 360, 3);
         Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
         QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
         QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
@@ -183,7 +205,7 @@ class QuizResultSubmitServiceTest {
                 )
         );
         mockSubmitData(
-                userId,
+                user,
                 subject,
                 quizSession,
                 playSession,
@@ -193,6 +215,7 @@ class QuizResultSubmitServiceTest {
         );
         when(quizResultRepository.findByPlaySessionId(playSession.getId()))
                 .thenReturn(Optional.empty());
+        mockReward(user, playSession, quizSession, 1, 1, 4, false, null, 3);
         when(quizResultRepository.save(any(QuizResult.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -207,6 +230,7 @@ class QuizResultSubmitServiceTest {
     @Test
     void submit_throws_invalid_option_when_answer_question_is_missing() {
         Long userId = 1L;
+        User user = user(userId, 12, 360, 3);
         Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
         QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
         QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
@@ -219,7 +243,7 @@ class QuizResultSubmitServiceTest {
                 430000,
                 List.of(answerItem("unknown-question-id", String.valueOf(option.getId()), true, false))
         );
-        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
+        mockSubmitData(user, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
         when(quizResultRepository.findByPlaySessionId(playSession.getId()))
                 .thenReturn(Optional.empty());
 
@@ -230,7 +254,7 @@ class QuizResultSubmitServiceTest {
     }
 
     private void mockSubmitData(
-            Long userId,
+            User user,
             Subject subject,
             QuizSession quizSession,
             QuizPlaySession playSession,
@@ -238,6 +262,9 @@ class QuizResultSubmitServiceTest {
             List<QuestionOption> options,
             List<QuestionAnswer> answers
     ) {
+        Long userId = user.getId();
+        when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                .thenReturn(Optional.of(user));
         when(quizPlaySessionRepository.findByClientSessionId(playSession.getClientSessionId()))
                 .thenReturn(Optional.of(playSession));
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
@@ -277,6 +304,41 @@ class QuizResultSubmitServiceTest {
         ReflectionTestUtils.setField(item, "answerElapsedMs", 15000);
         ReflectionTestUtils.setField(item, "marked", false);
         return item;
+    }
+
+    private void mockReward(
+            User user,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Integer correctCount,
+            Integer dotoriEarned,
+            Integer xpEarned,
+            Boolean leveledUp,
+            Integer newLevel,
+            Integer levelAfter
+    ) {
+        when(gamificationRewardService.applyQuizReward(user, playSession, quizSession, correctCount))
+                .thenAnswer(invocation -> {
+                    user.applyQuizReward(dotoriEarned, xpEarned, levelAfter);
+                    return new QuizRewardResult(
+                            dotoriEarned,
+                            xpEarned,
+                            leveledUp,
+                            newLevel,
+                            user.getDotoriBalance(),
+                            user.getXpTotal()
+                    );
+                });
+    }
+
+    private User user(Long id, Integer dotoriBalance, Integer xpTotal, Integer currentLevel) {
+        User user = User.create("user-public-id", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", id);
+        ReflectionTestUtils.setField(user, "emailVerified", true);
+        ReflectionTestUtils.setField(user, "dotoriBalance", dotoriBalance);
+        ReflectionTestUtils.setField(user, "xpTotal", xpTotal);
+        ReflectionTestUtils.setField(user, "currentLevel", currentLevel);
+        return user;
     }
 
     private Subject subject(Long id, String publicId, Long userId, String name) {
@@ -384,6 +446,10 @@ class QuizResultSubmitServiceTest {
                 skipCount,
                 accuracyPct,
                 playSession.getElapsedMs(),
+                1,
+                4,
+                false,
+                null,
                 true,
                 false
         );


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 퀴즈 결과 제출 시 첫 풀이 기준 도토리/XP 보상을 적립합니다
- 사용자 XP/레벨 캐시와 보상 원장을 함께 저장합니다
- 내 게임화 상태 조회 API를 추가합니다

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `user_xp_logs`, `user_dotori_logs`, `user_streak_logs` Flyway migration 추가
- 퀴즈 정답 수, 난이도, 연속 학습 배수 기준 보상 계산 구현
- 결과 제출 응답의 보상 요약에 현재 도토리/XP 잔액 추가
- `GET /api/v1/gamification/me` 구현
- 보상 적립, 레벨 계산, 중복 제출 보상 미지급 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.domain.gamification.service.GamificationServiceTest --tests com.f1.quiket.domain.gamification.service.GamificationRewardServiceTest --tests com.f1.quiket.domain.quiz.service.QuizResultSubmitServiceTest`
2. `./gradlew test`
3. `git diff --check HEAD`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #89

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- MVP는 첫 풀이(`playType=first`) 보상 적립 기준으로 구현했습니다
- 오답 복습 보상 정책은 추후 확장 가능하도록 서비스 내부 계산 경로만 열어두었습니다

---

## 🧑‍💻 Assignee

- @imclaremont
