### PR TITLE
[Feat] 과거 퀴즈 결과 상세 조회 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
@@ -3,6 +3,7 @@ package com.f1.quiket.domain.quiz.controller;
 import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
+import com.f1.quiket.domain.quiz.service.QuizResultQueryService;
 import com.f1.quiket.domain.quiz.service.QuizResultSubmitService;
 import com.f1.quiket.global.auth.UserPrincipal;
 import com.f1.quiket.global.response.ApiResponse;
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class QuizResultController {
 
     private final QuizResultSubmitService quizResultSubmitService;
+    private final QuizResultQueryService quizResultQueryService;
 
     /**
      * 퀴즈 결과 제출
@@ -40,5 +44,17 @@ public class QuizResultController {
         return ResponseEntity
                 .status(outcome.isCreated() ? HttpStatus.CREATED : HttpStatus.OK)
                 .body(ApiResponse.success(outcome.isCreated() ? SuccessCode.CREATED : SuccessCode.OK, outcome.getResponse()));
+    }
+
+    /**
+     * 과거 퀴즈 결과 상세 조회
+     */
+    @GetMapping("/{resultId}")
+    public ResponseEntity<ApiResponse<QuizResultResponse>> getQuizResult(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("resultId") String resultPublicId
+    ) {
+        QuizResultResponse response = quizResultQueryService.getQuizResult(principal.getUserId(), resultPublicId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
@@ -21,4 +21,9 @@ public interface QuizPlaySessionRepository extends JpaRepository<QuizPlaySession
      * 클라이언트 풀이 세션 단건 조회
      */
     Optional<QuizPlaySession> findByClientSessionId(String clientSessionId);
+
+    /**
+     * 사용자 풀이 세션 단건 조회
+     */
+    Optional<QuizPlaySession> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
@@ -21,4 +21,9 @@ public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
      * 풀이 세션 결과 단건 조회
      */
     Optional<QuizResult> findByPlaySessionId(Long playSessionId);
+
+    /**
+     * 사용자 결과 단건 조회
+     */
+    Optional<QuizResult> findByPublicIdAndUserId(String publicId, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultQueryService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultQueryService.java
@@ -46,9 +46,9 @@ public class QuizResultQueryService {
     private final QuizResultResponseAssembler quizResultResponseAssembler;
 
     public QuizResultResponse getQuizResult(Long userId, String resultPublicId) {
-        User user = findUser(userId);
         QuizResult result = quizResultRepository.findByPublicIdAndUserId(resultPublicId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_RESULT_NOT_FOUND));
+        User user = findUser(userId);
         QuizPlaySession playSession = quizPlaySessionRepository.findByIdAndUserId(result.getPlaySessionId(), userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_PLAY_SESSION_NOT_FOUND));
         QuizSession quizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getQuizSessionId(), userId)

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultQueryService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultQueryService.java
@@ -1,0 +1,111 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizResultQueryService {
+
+    private final QuizResultRepository quizResultRepository;
+    private final QuizPlaySessionRepository quizPlaySessionRepository;
+    private final QuizSessionRepository quizSessionRepository;
+    private final SubjectRepository subjectRepository;
+    private final UserRepository userRepository;
+    private final QuestionRepository questionRepository;
+    private final QuestionOptionRepository questionOptionRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
+    private final QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private final QuizResultResponseAssembler quizResultResponseAssembler;
+
+    public QuizResultResponse getQuizResult(Long userId, String resultPublicId) {
+        User user = findUser(userId);
+        QuizResult result = quizResultRepository.findByPublicIdAndUserId(resultPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_RESULT_NOT_FOUND));
+        QuizPlaySession playSession = quizPlaySessionRepository.findByIdAndUserId(result.getPlaySessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_PLAY_SESSION_NOT_FOUND));
+        QuizSession quizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getQuizSessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        Subject subject = subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getSubjectId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+
+        List<Question> questions = findQuestions(userId, quizSession.getId());
+        List<Long> questionIds = questions.stream()
+                .map(Question::getId)
+                .toList();
+        Map<Long, List<QuestionOption>> optionsByQuestionId = getOptionsByQuestionId(questionIds);
+        Map<Long, QuestionAnswer> answersByQuestionId = getAnswersByQuestionId(questionIds);
+        List<QuizPlayAnswer> playAnswers = quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId());
+
+        return quizResultResponseAssembler.build(
+                result,
+                playSession,
+                quizSession,
+                subject,
+                user,
+                questions,
+                optionsByQuestionId,
+                answersByQuestionId,
+                playAnswers
+        );
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    private List<Question> findQuestions(Long userId, Long quizSessionId) {
+        List<Question> questions = questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(
+                quizSessionId,
+                userId
+        );
+        if (questions.isEmpty()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "완료된 퀴즈 세션에 문항이 존재하지 않습니다.");
+        }
+        return questions;
+    }
+
+    private Map<Long, List<QuestionOption>> getOptionsByQuestionId(List<Long> questionIds) {
+        return questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(questionIds)
+                .stream()
+                .collect(Collectors.groupingBy(QuestionOption::getQuestionId));
+    }
+
+    private Map<Long, QuestionAnswer> getAnswersByQuestionId(List<Long> questionIds) {
+        Map<Long, QuestionAnswer> answersByQuestionId = questionAnswerRepository.findAllByQuestionIdIn(questionIds)
+                .stream()
+                .collect(Collectors.toMap(QuestionAnswer::getQuestionId, Function.identity()));
+        if (answersByQuestionId.size() != questionIds.size()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 문항 정답 정보가 올바르지 않습니다.");
+        }
+        return answersByQuestionId;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultResponseAssembler.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultResponseAssembler.java
@@ -1,0 +1,56 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.dto.QuizReviewItemResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuizResultResponseAssembler {
+
+    public QuizResultResponse build(
+            QuizResult result,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            User user,
+            List<Question> questions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId,
+            List<QuizPlayAnswer> playAnswers
+    ) {
+        Map<Long, QuizPlayAnswer> playAnswersByQuestionId = playAnswers.stream()
+                .collect(Collectors.toMap(QuizPlayAnswer::getQuestionId, Function.identity()));
+        List<QuizReviewItemResponse> reviewItems = questions.stream()
+                .map(question -> QuizReviewItemResponse.of(
+                        question,
+                        optionsByQuestionId.getOrDefault(question.getId(), List.of()),
+                        answersByQuestionId.get(question.getId()),
+                        getPlayAnswer(playAnswersByQuestionId, question)
+                ))
+                .toList();
+        return QuizResultResponse.of(result, playSession, quizSession, subject, user, reviewItems);
+    }
+
+    private QuizPlayAnswer getPlayAnswer(Map<Long, QuizPlayAnswer> playAnswersByQuestionId, Question question) {
+        QuizPlayAnswer playAnswer = playAnswersByQuestionId.get(question.getId());
+        if (playAnswer == null) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 풀이 답안 정보가 올바르지 않습니다.");
+        }
+        return playAnswer;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
@@ -6,7 +6,6 @@ import com.f1.quiket.domain.quiz.dto.QuizAnswerSubmitItem;
 import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
-import com.f1.quiket.domain.quiz.dto.QuizReviewItemResponse;
 import com.f1.quiket.domain.quiz.entity.Question;
 import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
 import com.f1.quiket.domain.quiz.entity.QuestionOption;
@@ -61,6 +60,7 @@ public class QuizResultSubmitService {
     private final QuizResultRepository quizResultRepository;
     private final UserRepository userRepository;
     private final GamificationRewardService gamificationRewardService;
+    private final QuizResultResponseAssembler quizResultResponseAssembler;
 
     public QuizResultSubmitOutcome submit(Long userId, QuizResultSubmitRequest request) {
         User user = findUser(userId);
@@ -178,7 +178,7 @@ public class QuizResultSubmitService {
             Map<Long, QuestionAnswer> answersByQuestionId
     ) {
         List<QuizPlayAnswer> playAnswers = quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId());
-        QuizResultResponse response = buildResponse(
+        QuizResultResponse response = quizResultResponseAssembler.build(
                 result,
                 playSession,
                 quizSession,
@@ -256,7 +256,7 @@ public class QuizResultSubmitService {
                 abuseFlagged
         ));
 
-        QuizResultResponse response = buildResponse(
+        QuizResultResponse response = quizResultResponseAssembler.build(
                 savedResult,
                 playSession,
                 quizSession,
@@ -371,38 +371,6 @@ public class QuizResultSubmitService {
                 .filter(answer -> answer.getCorrectClient() != null)
                 .filter(answer -> !answer.getCorrectClient().equals(answer.getCorrectServer()))
                 .count();
-    }
-
-    private QuizResultResponse buildResponse(
-            QuizResult result,
-            QuizPlaySession playSession,
-            QuizSession quizSession,
-            Subject subject,
-            User user,
-            List<Question> questions,
-            Map<Long, List<QuestionOption>> optionsByQuestionId,
-            Map<Long, QuestionAnswer> answersByQuestionId,
-            List<QuizPlayAnswer> playAnswers
-    ) {
-        Map<Long, QuizPlayAnswer> playAnswersByQuestionId = playAnswers.stream()
-                .collect(Collectors.toMap(QuizPlayAnswer::getQuestionId, Function.identity()));
-        List<QuizReviewItemResponse> reviewItems = questions.stream()
-                .map(question -> QuizReviewItemResponse.of(
-                        question,
-                        optionsByQuestionId.getOrDefault(question.getId(), List.of()),
-                        answersByQuestionId.get(question.getId()),
-                        getPlayAnswer(playAnswersByQuestionId, question)
-                ))
-                .toList();
-        return QuizResultResponse.of(result, playSession, quizSession, subject, user, reviewItems);
-    }
-
-    private QuizPlayAnswer getPlayAnswer(Map<Long, QuizPlayAnswer> playAnswersByQuestionId, Question question) {
-        QuizPlayAnswer playAnswer = playAnswersByQuestionId.get(question.getId());
-        if (playAnswer == null) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 풀이 답안 정보가 올바르지 않습니다.");
-        }
-        return playAnswer;
     }
 
     private record GradedAnswer(Long selectedOptionId, String selectedValue, Boolean correct) {

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
     QUIZ_SESSION_NOT_FOUND(404, "QUIZ_SESSION_NOT_FOUND", "퀴즈 세션을 찾을 수 없습니다."),
     QUIZ_SESSION_NOT_COMPLETED(409, "QUIZ_SESSION_NOT_COMPLETED", "아직 생성 완료 전인 퀴즈입니다."),
     QUIZ_PLAY_SESSION_NOT_FOUND(404, "QUIZ_PLAY_SESSION_NOT_FOUND", "퀴즈 풀이 세션을 찾을 수 없습니다."),
+    QUIZ_RESULT_NOT_FOUND(404, "QUIZ_RESULT_NOT_FOUND", "퀴즈 결과를 찾을 수 없습니다."),
 
     // MyPage Errors
     MY_EMAIL_CHANGE_TOO_FREQUENT(429, "MY_EMAIL_CHANGE_TOO_FREQUENT", "이메일 변경은 하루에 1회만 가능합니다."),

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultQueryServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultQueryServiceTest.java
@@ -1,0 +1,289 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizResultQueryServiceTest {
+
+    private QuizResultRepository quizResultRepository;
+    private QuizPlaySessionRepository quizPlaySessionRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private SubjectRepository subjectRepository;
+    private UserRepository userRepository;
+    private QuestionRepository questionRepository;
+    private QuestionOptionRepository questionOptionRepository;
+    private QuestionAnswerRepository questionAnswerRepository;
+    private QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private QuizResultQueryService quizResultQueryService;
+
+    @BeforeEach
+    void setUp() {
+        quizResultRepository = mock(QuizResultRepository.class);
+        quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        userRepository = mock(UserRepository.class);
+        questionRepository = mock(QuestionRepository.class);
+        questionOptionRepository = mock(QuestionOptionRepository.class);
+        questionAnswerRepository = mock(QuestionAnswerRepository.class);
+        quizPlayAnswerRepository = mock(QuizPlayAnswerRepository.class);
+        quizResultQueryService = new QuizResultQueryService(
+                quizResultRepository,
+                quizPlaySessionRepository,
+                quizSessionRepository,
+                subjectRepository,
+                userRepository,
+                questionRepository,
+                questionOptionRepository,
+                questionAnswerRepository,
+                quizPlayAnswerRepository,
+                new QuizResultResponseAssembler()
+        );
+    }
+
+    @Test
+    void getQuizResult_returns_saved_result_detail() {
+        Long userId = 1L;
+        User user = user(userId, 20, 400, 3);
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId());
+        QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption correctOption = option(1000L, question.getId(), 1, "정답", true);
+        QuestionOption wrongOption = option(1001L, question.getId(), 2, "오답", false);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizPlayAnswer playAnswer = playAnswer(playSession.getId(), question.getId(), userId, correctOption.getId(), true, false);
+        QuizResult result = result(3000L, "result-public-id", playSession, quizSession, subject, 1, 1, 0, 0, 100);
+
+        when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                .thenReturn(Optional.of(user));
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizPlaySessionRepository.findByIdAndUserId(playSession.getId(), userId))
+                .thenReturn(Optional.of(playSession));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subject.getId(), userId))
+                .thenReturn(Optional.of(subject));
+        when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(quizSession.getId(), userId))
+                .thenReturn(List.of(question));
+        when(questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(List.of(question.getId())))
+                .thenReturn(List.of(correctOption, wrongOption));
+        when(questionAnswerRepository.findAllByQuestionIdIn(List.of(question.getId())))
+                .thenReturn(List.of(answer));
+        when(quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId()))
+                .thenReturn(List.of(playAnswer));
+
+        QuizResultResponse response = quizResultQueryService.getQuizResult(userId, result.getPublicId());
+
+        assertThat(response.getResultId()).isEqualTo(result.getPublicId());
+        assertThat(response.getPlaySessionId()).isEqualTo(playSession.getClientSessionId());
+        assertThat(response.getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        assertThat(response.getSubjectName()).isEqualTo(subject.getName());
+        assertThat(response.getCorrectCount()).isEqualTo(1);
+        assertThat(response.getRewards().getDotoriEarned()).isEqualTo(1);
+        assertThat(response.getRewards().getCurrentDotoriBalance()).isEqualTo(20);
+        assertThat(response.getReviewItems()).hasSize(1);
+        assertThat(response.getReviewItems().get(0).getQuestionId()).isEqualTo(question.getPublicId());
+        assertThat(response.getReviewItems().get(0).getSelectedOptionId()).isEqualTo(String.valueOf(correctOption.getId()));
+        assertThat(response.getReviewItems().get(0).getAnswerValue()).isEqualTo("1");
+        assertThat(response.getReviewItems().get(0).getCorrectServer()).isTrue();
+    }
+
+    @Test
+    void getQuizResult_throws_not_found_when_result_missing() {
+        Long userId = 1L;
+        User user = user(userId, 20, 400, 3);
+        when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                .thenReturn(Optional.of(user));
+        when(quizResultRepository.findByPublicIdAndUserId("missing-result-id", userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizResultQueryService.getQuizResult(userId, "missing-result-id"))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_RESULT_NOT_FOUND);
+    }
+
+    private User user(Long id, Integer dotoriBalance, Integer xpTotal, Integer currentLevel) {
+        User user = User.create("user-public-id", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", id);
+        ReflectionTestUtils.setField(user, "emailVerified", true);
+        ReflectionTestUtils.setField(user, "dotoriBalance", dotoriBalance);
+        ReflectionTestUtils.setField(user, "xpTotal", xpTotal);
+        ReflectionTestUtils.setField(user, "currentLevel", currentLevel);
+        return user;
+    }
+
+    private Subject subject(Long id, String publicId, Long userId, String name) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId) {
+        QuizSession quizSession = QuizSession.create(
+                publicId,
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                1,
+                "one_by_one",
+                true,
+                "per_question",
+                60,
+                "medium",
+                "completed",
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizPlaySession playSession(Long id, String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        QuizPlaySession playSession = QuizPlaySession.createFirst(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        playSession.submit(430000);
+        return playSession;
+    }
+
+    private Question question(Long id, String publicId, Long quizSessionId, Long userId, Long subjectId, Integer displayOrder) {
+        Question question = newEntity(Question.class);
+        ReflectionTestUtils.setField(question, "id", id);
+        ReflectionTestUtils.setField(question, "publicId", publicId);
+        ReflectionTestUtils.setField(question, "quizSessionId", quizSessionId);
+        ReflectionTestUtils.setField(question, "userId", userId);
+        ReflectionTestUtils.setField(question, "subjectId", subjectId);
+        ReflectionTestUtils.setField(question, "chapterId", 100L + displayOrder);
+        ReflectionTestUtils.setField(question, "partId", 200L + displayOrder);
+        ReflectionTestUtils.setField(question, "questionType", "multiple_choice");
+        ReflectionTestUtils.setField(question, "difficulty", "medium");
+        ReflectionTestUtils.setField(question, "summary", "핵심 개념 확인");
+        ReflectionTestUtils.setField(question, "body", "다음 중 올바른 것은?");
+        ReflectionTestUtils.setField(question, "correctExplanation", "정답 해설");
+        ReflectionTestUtils.setField(question, "incorrectExplanation", "오답 해설");
+        ReflectionTestUtils.setField(question, "displayOrder", displayOrder);
+        return question;
+    }
+
+    private QuestionOption option(Long id, Long questionId, Integer optionNumber, String content, Boolean correct) {
+        QuestionOption option = newEntity(QuestionOption.class);
+        ReflectionTestUtils.setField(option, "id", id);
+        ReflectionTestUtils.setField(option, "questionId", questionId);
+        ReflectionTestUtils.setField(option, "optionNumber", optionNumber);
+        ReflectionTestUtils.setField(option, "content", content);
+        ReflectionTestUtils.setField(option, "correct", correct);
+        return option;
+    }
+
+    private QuestionAnswer answer(Long id, Long questionId, String answerValue) {
+        QuestionAnswer answer = newEntity(QuestionAnswer.class);
+        ReflectionTestUtils.setField(answer, "id", id);
+        ReflectionTestUtils.setField(answer, "questionId", questionId);
+        ReflectionTestUtils.setField(answer, "answerValue", answerValue);
+        return answer;
+    }
+
+    private QuizResult result(
+            Long id,
+            String publicId,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            Integer totalCount,
+            Integer correctCount,
+            Integer wrongCount,
+            Integer skipCount,
+            Integer accuracyPct
+    ) {
+        QuizResult result = QuizResult.create(
+                publicId,
+                playSession.getId(),
+                quizSession.getId(),
+                playSession.getUserId(),
+                subject.getId(),
+                totalCount,
+                correctCount,
+                wrongCount,
+                skipCount,
+                accuracyPct,
+                playSession.getElapsedMs(),
+                1,
+                4,
+                false,
+                null,
+                true,
+                false
+        );
+        ReflectionTestUtils.setField(result, "id", id);
+        return result;
+    }
+
+    private QuizPlayAnswer playAnswer(
+            Long playSessionId,
+            Long questionId,
+            Long userId,
+            Long selectedOptionId,
+            Boolean correctServer,
+            Boolean skipped
+    ) {
+        return QuizPlayAnswer.create(
+                playSessionId,
+                questionId,
+                userId,
+                selectedOptionId,
+                null,
+                correctServer,
+                correctServer,
+                skipped,
+                15000,
+                false
+        );
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
@@ -77,7 +77,8 @@ class QuizResultSubmitServiceTest {
                 quizPlayAnswerRepository,
                 quizResultRepository,
                 userRepository,
-                gamificationRewardService
+                gamificationRewardService,
+                new QuizResultResponseAssembler()
         );
     }
 


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- HISTORY-003 과거 퀴즈 결과 상세 조회 API를 구현했습니다
- 완료된 퀴즈 기록의 resultId로 저장된 결과/답안/해설 데이터를 다시 조회할 수 있습니다
- 결과 제출 응답과 과거 조회 응답이 같은 조립 로직을 사용하도록 분리했습니다

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `GET /api/v1/quiz-results/{resultId}` 구현
- `QuizResultQueryService` 추가
- `QuizResultResponseAssembler` 추가로 결과 응답 조립 공통화
- resultId/userId 기준 결과 조회 Repository 메서드 추가
- 결과 없음 도메인 에러 `QUIZ_RESULT_NOT_FOUND` 추가
- 과거 결과 상세 조회 서비스 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.domain.quiz.service.QuizResultSubmitServiceTest --tests com.f1.quiket.domain.quiz.service.QuizResultQueryServiceTest`
2. `./gradlew test`
3. `git diff --check HEAD`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #91

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 기능명세 HISTORY-003 범위입니다
- 전체 다시풀기/틀린 문제 다시풀기 생성은 후속 이슈에서 처리합니다

---

## 🧑‍💻 Assignee

- @imclaremont
