### PR TITLE
[Feat] 과거 퀴즈 전체 다시풀기 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
@@ -1,9 +1,12 @@
 package com.f1.quiket.domain.quiz.controller;
 
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
 import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
+import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
 import com.f1.quiket.domain.quiz.service.QuizResultQueryService;
+import com.f1.quiket.domain.quiz.service.QuizResultRetryAllService;
 import com.f1.quiket.domain.quiz.service.QuizResultSubmitService;
 import com.f1.quiket.global.auth.UserPrincipal;
 import com.f1.quiket.global.response.ApiResponse;
@@ -30,6 +33,7 @@ public class QuizResultController {
 
     private final QuizResultSubmitService quizResultSubmitService;
     private final QuizResultQueryService quizResultQueryService;
+    private final QuizResultRetryAllService quizResultRetryAllService;
 
     /**
      * 퀴즈 결과 제출
@@ -56,5 +60,24 @@ public class QuizResultController {
     ) {
         QuizResultResponse response = quizResultQueryService.getQuizResult(principal.getUserId(), resultPublicId);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 전체 다시풀기 시작
+     */
+    @PostMapping("/{resultId}/retry-all")
+    public ResponseEntity<ApiResponse<QuizPlaySessionResponse>> retryAllQuestions(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("resultId") String resultPublicId,
+            @Valid @RequestBody QuizRetryRequest request
+    ) {
+        QuizPlaySessionResponse response = quizResultRetryAllService.retryAll(
+                principal.getUserId(),
+                resultPublicId,
+                request
+        );
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(SuccessCode.CREATED, response));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRetryRequest.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRetryRequest.java
@@ -1,0 +1,22 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizRetryRequest {
+
+    @NotBlank(message = "풀이 세션 ID는 필수입니다")
+    @Size(max = 36, message = "풀이 세션 ID는 36자 이하여야 합니다")
+    private String clientSessionId;
+
+    private Boolean questionShuffled;
+
+    private Boolean optionShuffled;
+
+    @Size(max = 100, message = "셔플 시드는 100자 이하여야 합니다")
+    private String shuffleSeed;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -42,6 +42,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class QuizPlaySession {
 
     private static final String PLAY_TYPE_FIRST = "first";
+    private static final String PLAY_TYPE_RETRY_ALL = "retry_all";
     private static final String STATUS_IN_PROGRESS = "in_progress";
     private static final String STATUS_SUBMITTED = "submitted";
 
@@ -112,13 +113,59 @@ public class QuizPlaySession {
             Boolean optionShuffled,
             String shuffleSeed
     ) {
+        QuizPlaySession playSession = createBase(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                PLAY_TYPE_FIRST,
+                questionShuffled,
+                optionShuffled,
+                shuffleSeed
+        );
+        playSession.generation = 0;
+        return playSession;
+    }
+
+    public static QuizPlaySession createRetryAll(
+            String clientSessionId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizPlaySession playSession = createBase(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                PLAY_TYPE_RETRY_ALL,
+                questionShuffled,
+                optionShuffled,
+                shuffleSeed
+        );
+        playSession.generation = 0;
+        return playSession;
+    }
+
+    private static QuizPlaySession createBase(
+            String clientSessionId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            String playType,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
         QuizPlaySession playSession = new QuizPlaySession();
         playSession.clientSessionId = clientSessionId;
         playSession.quizSessionId = quizSessionId;
         playSession.userId = userId;
         playSession.subjectId = subjectId;
-        playSession.playType = PLAY_TYPE_FIRST;
-        playSession.generation = 0;
+        playSession.playType = playType;
         playSession.questionShuffled = Boolean.TRUE.equals(questionShuffled);
         playSession.optionShuffled = optionShuffled == null || Boolean.TRUE.equals(optionShuffled);
         playSession.shuffleSeed = shuffleSeed;

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllService.java
@@ -1,0 +1,80 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizResultRetryAllService {
+
+    private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
+    private static final String PLAY_TYPE_RETRY_ALL = "retry_all";
+
+    private final QuizResultRepository quizResultRepository;
+    private final QuizSessionRepository quizSessionRepository;
+    private final QuizPlaySessionRepository quizPlaySessionRepository;
+
+    public QuizPlaySessionResponse retryAll(Long userId, String resultPublicId, QuizRetryRequest request) {
+        QuizResult result = quizResultRepository.findByPublicIdAndUserId(resultPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_RESULT_NOT_FOUND));
+        QuizSession quizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getQuizSessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        validateRetryable(quizSession);
+
+        return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
+                .map(existing -> responseFromExisting(existing, quizSession))
+                .orElseGet(() -> createRetryAllPlaySession(userId, quizSession, request));
+    }
+
+    private void validateRetryable(QuizSession quizSession) {
+        if (!QUIZ_SESSION_STATUS_COMPLETED.equals(quizSession.getStatus())) {
+            throw new CustomException(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+        }
+    }
+
+    private QuizPlaySessionResponse responseFromExisting(QuizPlaySession existing, QuizSession quizSession) {
+        if (!existing.isSameStartRequest(quizSession.getId(), quizSession.getUserId(), PLAY_TYPE_RETRY_ALL)) {
+            throw new CustomException(ErrorCode.CONFLICT, "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.");
+        }
+        return QuizPlaySessionResponse.of(existing, quizSession);
+    }
+
+    private QuizPlaySessionResponse createRetryAllPlaySession(
+            Long userId,
+            QuizSession quizSession,
+            QuizRetryRequest request
+    ) {
+        QuizPlaySession playSession = QuizPlaySession.createRetryAll(
+                request.getClientSessionId(),
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                request.getQuestionShuffled(),
+                request.getOptionShuffled(),
+                request.getShuffleSeed()
+        );
+        try {
+            QuizPlaySession saved = quizPlaySessionRepository.save(playSession);
+            return QuizPlaySessionResponse.of(saved, quizSession);
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(
+                    ErrorCode.CONFLICT,
+                    "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.",
+                    e
+            );
+        }
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllService.java
@@ -8,6 +8,7 @@ import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -26,17 +27,24 @@ public class QuizResultRetryAllService {
     private final QuizResultRepository quizResultRepository;
     private final QuizSessionRepository quizSessionRepository;
     private final QuizPlaySessionRepository quizPlaySessionRepository;
+    private final SubjectRepository subjectRepository;
 
     public QuizPlaySessionResponse retryAll(Long userId, String resultPublicId, QuizRetryRequest request) {
         QuizResult result = quizResultRepository.findByPublicIdAndUserId(resultPublicId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_RESULT_NOT_FOUND));
         QuizSession quizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getQuizSessionId(), userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        validateSubjectAlive(userId, quizSession.getSubjectId());
         validateRetryable(quizSession);
 
         return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
                 .map(existing -> responseFromExisting(existing, quizSession))
                 .orElseGet(() -> createRetryAllPlaySession(userId, quizSession, request));
+    }
+
+    private void validateSubjectAlive(Long userId, Long subjectId) {
+        subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subjectId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
     }
 
     private void validateRetryable(QuizSession quizSession) {

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
@@ -46,6 +46,7 @@ public class QuizResultSubmitService {
 
     private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
     private static final String PLAY_TYPE_FIRST = "first";
+    private static final String PLAY_TYPE_RETRY_ALL = "retry_all";
     private static final String QUESTION_TYPE_MULTIPLE_CHOICE = "multiple_choice";
     private static final String QUESTION_TYPE_OX = "ox";
     private static final int ABUSE_MISMATCH_THRESHOLD_PCT = 30;
@@ -133,11 +134,15 @@ public class QuizResultSubmitService {
         if (!playSession.getQuizSessionId().equals(quizSession.getId())) {
             throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
         }
-        if (!PLAY_TYPE_FIRST.equals(request.getPlayType())
-                || !PLAY_TYPE_FIRST.equals(playSession.getPlayType())
+        if (!playSession.getPlayType().equals(request.getPlayType())
+                || !isSupportedPlayType(playSession.getPlayType())
                 || StringUtils.hasText(request.getParentPlaySessionId())) {
             throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
         }
+    }
+
+    private boolean isSupportedPlayType(String playType) {
+        return PLAY_TYPE_FIRST.equals(playType) || PLAY_TYPE_RETRY_ALL.equals(playType);
     }
 
     private List<Question> findQuestions(Long userId, Long quizSessionId) {

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllServiceTest.java
@@ -1,0 +1,212 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizResultRetryAllServiceTest {
+
+    private QuizResultRepository quizResultRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private QuizPlaySessionRepository quizPlaySessionRepository;
+    private QuizResultRetryAllService quizResultRetryAllService;
+
+    @BeforeEach
+    void setUp() {
+        quizResultRepository = mock(QuizResultRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        quizResultRetryAllService = new QuizResultRetryAllService(
+                quizResultRepository,
+                quizSessionRepository,
+                quizPlaySessionRepository
+        );
+    }
+
+    @Test
+    void retryAll_creates_retry_all_play_session() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizResult result = result(3000L, "result-public-id", quizSession, userId, 700L);
+        QuizRetryRequest request = request("retry-client-session-id", true, false, "seed-1");
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.empty());
+        when(quizPlaySessionRepository.save(any(QuizPlaySession.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizPlaySessionResponse response = quizResultRetryAllService.retryAll(userId, result.getPublicId(), request);
+
+        ArgumentCaptor<QuizPlaySession> playSessionCaptor = ArgumentCaptor.forClass(QuizPlaySession.class);
+        verify(quizPlaySessionRepository).save(playSessionCaptor.capture());
+        QuizPlaySession savedPlaySession = playSessionCaptor.getValue();
+        assertThat(savedPlaySession.getClientSessionId()).isEqualTo("retry-client-session-id");
+        assertThat(savedPlaySession.getQuizSessionId()).isEqualTo(quizSession.getId());
+        assertThat(savedPlaySession.getUserId()).isEqualTo(userId);
+        assertThat(savedPlaySession.getSubjectId()).isEqualTo(quizSession.getSubjectId());
+        assertThat(savedPlaySession.getPlayType()).isEqualTo("retry_all");
+        assertThat(savedPlaySession.getStatus()).isEqualTo("in_progress");
+        assertThat(savedPlaySession.getQuestionShuffled()).isTrue();
+        assertThat(savedPlaySession.getOptionShuffled()).isFalse();
+        assertThat(savedPlaySession.getShuffleSeed()).isEqualTo("seed-1");
+
+        assertThat(response.getPlaySessionId()).isEqualTo("retry-client-session-id");
+        assertThat(response.getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        assertThat(response.getPlayType()).isEqualTo("retry_all");
+        assertThat(response.getStatus()).isEqualTo("in_progress");
+    }
+
+    @Test
+    void retryAll_returns_existing_when_same_client_session_id_is_retried() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizResult result = result(3000L, "result-public-id", quizSession, userId, 700L);
+        QuizRetryRequest request = request("retry-client-session-id", null, null, null);
+        QuizPlaySession existing = retryAllPlaySession("retry-client-session-id", quizSession.getId(), userId, quizSession.getSubjectId());
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+
+        QuizPlaySessionResponse response = quizResultRetryAllService.retryAll(userId, result.getPublicId(), request);
+
+        assertThat(response.getPlaySessionId()).isEqualTo(existing.getClientSessionId());
+        assertThat(response.getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        assertThat(response.getPlayType()).isEqualTo("retry_all");
+    }
+
+    @Test
+    void retryAll_throws_not_found_when_result_missing() {
+        Long userId = 1L;
+        QuizRetryRequest request = request("retry-client-session-id", null, null, null);
+        when(quizResultRepository.findByPublicIdAndUserId("missing-result-id", userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizResultRetryAllService.retryAll(userId, "missing-result-id", request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_RESULT_NOT_FOUND);
+    }
+
+    @Test
+    void retryAll_throws_conflict_when_client_session_id_belongs_to_other_session() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizResult result = result(3000L, "result-public-id", quizSession, userId, 700L);
+        QuizRetryRequest request = request("retry-client-session-id", null, null, null);
+        QuizPlaySession existing = QuizPlaySession.createFirst(
+                "retry-client-session-id",
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                false,
+                true,
+                null
+        );
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> quizResultRetryAllService.retryAll(userId, result.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId, String status) {
+        QuizSession quizSession = QuizSession.create(
+                publicId,
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                10,
+                "one_by_one",
+                false,
+                null,
+                null,
+                "medium",
+                status,
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizResult result(Long id, String publicId, QuizSession quizSession, Long userId, Long playSessionId) {
+        QuizResult result = QuizResult.create(
+                publicId,
+                playSessionId,
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                10,
+                8,
+                2,
+                0,
+                80,
+                430000,
+                8,
+                32,
+                false,
+                null,
+                true,
+                false
+        );
+        ReflectionTestUtils.setField(result, "id", id);
+        return result;
+    }
+
+    private QuizPlaySession retryAllPlaySession(String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        return QuizPlaySession.createRetryAll(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+    }
+
+    private QuizRetryRequest request(
+            String clientSessionId,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizRetryRequest request = new QuizRetryRequest();
+        ReflectionTestUtils.setField(request, "clientSessionId", clientSessionId);
+        ReflectionTestUtils.setField(request, "questionShuffled", questionShuffled);
+        ReflectionTestUtils.setField(request, "optionShuffled", optionShuffled);
+        ReflectionTestUtils.setField(request, "shuffleSeed", shuffleSeed);
+        return request;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllServiceTest.java
@@ -15,6 +15,8 @@ import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import java.util.Optional;
@@ -28,6 +30,7 @@ class QuizResultRetryAllServiceTest {
     private QuizResultRepository quizResultRepository;
     private QuizSessionRepository quizSessionRepository;
     private QuizPlaySessionRepository quizPlaySessionRepository;
+    private SubjectRepository subjectRepository;
     private QuizResultRetryAllService quizResultRetryAllService;
 
     @BeforeEach
@@ -35,10 +38,12 @@ class QuizResultRetryAllServiceTest {
         quizResultRepository = mock(QuizResultRepository.class);
         quizSessionRepository = mock(QuizSessionRepository.class);
         quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
         quizResultRetryAllService = new QuizResultRetryAllService(
                 quizResultRepository,
                 quizSessionRepository,
-                quizPlaySessionRepository
+                quizPlaySessionRepository,
+                subjectRepository
         );
     }
 
@@ -52,6 +57,8 @@ class QuizResultRetryAllServiceTest {
                 .thenReturn(Optional.of(result));
         when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getSubjectId(), userId))
+                .thenReturn(Optional.of(subject(quizSession.getSubjectId(), userId)));
         when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
                 .thenReturn(Optional.empty());
         when(quizPlaySessionRepository.save(any(QuizPlaySession.class)))
@@ -89,6 +96,8 @@ class QuizResultRetryAllServiceTest {
                 .thenReturn(Optional.of(result));
         when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getSubjectId(), userId))
+                .thenReturn(Optional.of(subject(quizSession.getSubjectId(), userId)));
         when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
                 .thenReturn(Optional.of(existing));
 
@@ -131,6 +140,8 @@ class QuizResultRetryAllServiceTest {
                 .thenReturn(Optional.of(result));
         when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getSubjectId(), userId))
+                .thenReturn(Optional.of(subject(quizSession.getSubjectId(), userId)));
         when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
                 .thenReturn(Optional.of(existing));
 
@@ -138,6 +149,32 @@ class QuizResultRetryAllServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    @Test
+    void retryAll_throws_subject_not_found_when_subject_is_deleted() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizResult result = result(3000L, "result-public-id", quizSession, userId, 700L);
+        QuizRetryRequest request = request("retry-client-session-id", null, null, null);
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getSubjectId(), userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizResultRetryAllService.retryAll(userId, result.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.SUBJECT_NOT_FOUND);
+    }
+
+    private Subject subject(Long id, Long userId) {
+        Subject subject = org.springframework.beans.BeanUtils.instantiateClass(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        return subject;
     }
 
     private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId, String status) {

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
@@ -229,6 +229,41 @@ class QuizResultSubmitServiceTest {
     }
 
     @Test
+    void submit_creates_retry_all_result_with_review_reward() {
+        Long userId = 1L;
+        User user = user(userId, 13, 364, 3);
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = retryAllPlaySession(701L, "retry-client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption correctOption = option(1000L, question.getId(), 1, "정답", true);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                "retry_all",
+                210000,
+                List.of(answerItem(question.getPublicId(), String.valueOf(correctOption.getId()), true, false))
+        );
+        mockSubmitData(user, subject, quizSession, playSession, List.of(question), List.of(correctOption), List.of(answer));
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.empty());
+        mockReward(user, playSession, quizSession, 1, 0, 3, false, null, 3);
+        when(quizResultRepository.save(any(QuizResult.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(userId, request);
+
+        assertThat(outcome.isCreated()).isTrue();
+        assertThat(outcome.getResponse().getPlaySessionId()).isEqualTo(playSession.getClientSessionId());
+        assertThat(outcome.getResponse().getRewards().getDotoriEarned()).isZero();
+        assertThat(outcome.getResponse().getRewards().getXpEarned()).isEqualTo(3);
+        assertThat(outcome.getResponse().getRewards().getCurrentDotoriBalance()).isEqualTo(13);
+        assertThat(outcome.getResponse().getRewards().getCurrentXpTotal()).isEqualTo(367);
+        verify(gamificationRewardService).applyQuizReward(user, playSession, quizSession, 1);
+    }
+
+    @Test
     void submit_throws_invalid_option_when_answer_question_is_missing() {
         Long userId = 1L;
         User user = user(userId, 12, 360, 3);
@@ -287,10 +322,20 @@ class QuizResultSubmitServiceTest {
             Integer elapsedMs,
             List<QuizAnswerSubmitItem> answers
     ) {
+        return request(clientSessionId, quizSessionId, "first", elapsedMs, answers);
+    }
+
+    private QuizResultSubmitRequest request(
+            String clientSessionId,
+            String quizSessionId,
+            String playType,
+            Integer elapsedMs,
+            List<QuizAnswerSubmitItem> answers
+    ) {
         QuizResultSubmitRequest request = newEntity(QuizResultSubmitRequest.class);
         ReflectionTestUtils.setField(request, "clientSessionId", clientSessionId);
         ReflectionTestUtils.setField(request, "quizSessionId", quizSessionId);
-        ReflectionTestUtils.setField(request, "playType", "first");
+        ReflectionTestUtils.setField(request, "playType", playType);
         ReflectionTestUtils.setField(request, "elapsedMs", elapsedMs);
         ReflectionTestUtils.setField(request, "answers", answers);
         return request;
@@ -374,6 +419,20 @@ class QuizResultSubmitServiceTest {
 
     private QuizPlaySession playSession(Long id, String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
         QuizPlaySession playSession = QuizPlaySession.createFirst(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+
+    private QuizPlaySession retryAllPlaySession(Long id, String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        QuizPlaySession playSession = QuizPlaySession.createRetryAll(
                 clientSessionId,
                 quizSessionId,
                 userId,


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- HISTORY-004 중 전체 다시풀기 범위 구현
- 과거 결과의 `resultId` 기준으로 기존 퀴즈 세트를 새 `retry_all` 풀이 세션으로 시작
- 동일 `clientSessionId` 재요청 시 기존 세션 반환으로 중복 생성 방지

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `POST /api/v1/quiz-results/{resultId}/retry-all` 추가
- `QuizRetryRequest`, `QuizResultRetryAllService` 추가
- `QuizPlaySession.createRetryAll` 추가
- `retry_all` 결과 제출 허용 및 복습 보상 경로 연동
- 전체 다시풀기/결과 제출 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.domain.quiz.service.QuizResultRetryAllServiceTest --tests com.f1.quiket.domain.quiz.service.QuizResultSubmitServiceTest --tests com.f1.quiket.domain.quiz.service.QuizPlaySessionStartServiceTest`
2. `./gradlew test`
3. `git diff --check`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #93

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 틀린 문제만 다시풀기는 후속 이슈에서 처리
- 전체 다시풀기는 새 퀴즈 세트 생성 없이 기존 `quizSession` 기준으로 풀이 세션만 추가

---

## 🧑‍💻 Assignee

- @imclaremont
