### PR TITLE
[Feat] 과거 퀴즈 틀린 문제만 다시풀기 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
@@ -7,6 +7,7 @@ import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
 import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
 import com.f1.quiket.domain.quiz.service.QuizResultQueryService;
 import com.f1.quiket.domain.quiz.service.QuizResultRetryAllService;
+import com.f1.quiket.domain.quiz.service.QuizResultRetryWrongService;
 import com.f1.quiket.domain.quiz.service.QuizResultSubmitService;
 import com.f1.quiket.global.auth.UserPrincipal;
 import com.f1.quiket.global.response.ApiResponse;
@@ -34,6 +35,7 @@ public class QuizResultController {
     private final QuizResultSubmitService quizResultSubmitService;
     private final QuizResultQueryService quizResultQueryService;
     private final QuizResultRetryAllService quizResultRetryAllService;
+    private final QuizResultRetryWrongService quizResultRetryWrongService;
 
     /**
      * 퀴즈 결과 제출
@@ -72,6 +74,25 @@ public class QuizResultController {
             @Valid @RequestBody QuizRetryRequest request
     ) {
         QuizPlaySessionResponse response = quizResultRetryAllService.retryAll(
+                principal.getUserId(),
+                resultPublicId,
+                request
+        );
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(SuccessCode.CREATED, response));
+    }
+
+    /**
+     * 틀린 문제만 다시풀기 시작
+     */
+    @PostMapping("/{resultId}/retry-wrong")
+    public ResponseEntity<ApiResponse<QuizPlaySessionResponse>> retryWrongQuestions(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("resultId") String resultPublicId,
+            @Valid @RequestBody QuizRetryRequest request
+    ) {
+        QuizPlaySessionResponse response = quizResultRetryWrongService.retryWrong(
                 principal.getUserId(),
                 resultPublicId,
                 request

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -43,6 +43,7 @@ public class QuizPlaySession {
 
     private static final String PLAY_TYPE_FIRST = "first";
     private static final String PLAY_TYPE_RETRY_ALL = "retry_all";
+    private static final String PLAY_TYPE_RETRY_WRONG = "retry_wrong";
     private static final String STATUS_IN_PROGRESS = "in_progress";
     private static final String STATUS_SUBMITTED = "submitted";
 
@@ -150,6 +151,34 @@ public class QuizPlaySession {
         return playSession;
     }
 
+    public static QuizPlaySession createRetryWrong(
+            String clientSessionId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            Long parentPlaySessionId,
+            Long parentQuizSessionId,
+            Integer generation,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizPlaySession playSession = createBase(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                PLAY_TYPE_RETRY_WRONG,
+                questionShuffled == null || Boolean.TRUE.equals(questionShuffled),
+                optionShuffled,
+                shuffleSeed
+        );
+        playSession.parentPlaySessionId = parentPlaySessionId;
+        playSession.parentQuizSessionId = parentQuizSessionId;
+        playSession.generation = generation;
+        return playSession;
+    }
+
     private static QuizPlaySession createBase(
             String clientSessionId,
             Long quizSessionId,
@@ -179,6 +208,15 @@ public class QuizPlaySession {
         return this.quizSessionId.equals(quizSessionId)
                 && this.userId.equals(userId)
                 && this.playType.equals(playType);
+    }
+
+    public boolean isSameRetryWrongRequest(Long parentPlaySessionId, Long parentQuizSessionId, Long userId) {
+        return this.userId.equals(userId)
+                && PLAY_TYPE_RETRY_WRONG.equals(this.playType)
+                && this.parentPlaySessionId != null
+                && this.parentPlaySessionId.equals(parentPlaySessionId)
+                && this.parentQuizSessionId != null
+                && this.parentQuizSessionId.equals(parentQuizSessionId);
     }
 
     public void submit(Integer elapsedMs) {

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -169,7 +169,7 @@ public class QuizPlaySession {
                 userId,
                 subjectId,
                 PLAY_TYPE_RETRY_WRONG,
-                questionShuffled == null || Boolean.TRUE.equals(questionShuffled),
+                questionShuffled,
                 optionShuffled,
                 shuffleSeed
         );

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongService.java
@@ -1,0 +1,286 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.global.util.UuidV7Generator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizResultRetryWrongService {
+
+    private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
+
+    private final QuizResultRepository quizResultRepository;
+    private final QuizPlaySessionRepository quizPlaySessionRepository;
+    private final QuizSessionRepository quizSessionRepository;
+    private final SubjectRepository subjectRepository;
+    private final QuestionRepository questionRepository;
+    private final QuestionOptionRepository questionOptionRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
+    private final QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private final QuizSessionScopeRepository quizSessionScopeRepository;
+
+    public QuizPlaySessionResponse retryWrong(Long userId, String resultPublicId, QuizRetryRequest request) {
+        QuizResult result = quizResultRepository.findByPublicIdAndUserId(resultPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_RESULT_NOT_FOUND));
+        QuizPlaySession parentPlaySession = quizPlaySessionRepository.findByIdAndUserId(result.getPlaySessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_PLAY_SESSION_NOT_FOUND));
+        QuizSession parentQuizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getQuizSessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        validateSubjectAlive(userId, parentQuizSession.getSubjectId());
+        validateRetryable(parentQuizSession);
+
+        return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
+                .map(existing -> responseFromExisting(existing, parentPlaySession, parentQuizSession, userId))
+                .orElseGet(() -> createRetryWrongPlaySession(userId, parentPlaySession, parentQuizSession, request));
+    }
+
+    private void validateSubjectAlive(Long userId, Long subjectId) {
+        subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subjectId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+    }
+
+    private void validateRetryable(QuizSession quizSession) {
+        if (!QUIZ_SESSION_STATUS_COMPLETED.equals(quizSession.getStatus())) {
+            throw new CustomException(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+        }
+    }
+
+    private QuizPlaySessionResponse responseFromExisting(
+            QuizPlaySession existing,
+            QuizPlaySession parentPlaySession,
+            QuizSession parentQuizSession,
+            Long userId
+    ) {
+        if (!existing.isSameRetryWrongRequest(parentPlaySession.getId(), parentQuizSession.getId(), userId)) {
+            throw new CustomException(ErrorCode.CONFLICT, "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.");
+        }
+        QuizSession childQuizSession = quizSessionRepository
+                .findByIdAndUserIdAndDeletedAtIsNull(existing.getQuizSessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        return QuizPlaySessionResponse.of(existing, childQuizSession);
+    }
+
+    private QuizPlaySessionResponse createRetryWrongPlaySession(
+            Long userId,
+            QuizPlaySession parentPlaySession,
+            QuizSession parentQuizSession,
+            QuizRetryRequest request
+    ) {
+        List<Question> parentQuestions = findParentQuestions(userId, parentQuizSession.getId());
+        List<QuizPlayAnswer> parentPlayAnswers = quizPlayAnswerRepository.findAllByPlaySessionId(parentPlaySession.getId());
+        List<Question> wrongQuestions = findWrongQuestions(parentQuestions, parentPlayAnswers);
+        Map<Long, List<QuestionOption>> optionsByQuestionId = getOptionsByQuestionId(parentQuestions);
+        Map<Long, QuestionAnswer> answersByQuestionId = getAnswersByQuestionId(parentQuestions);
+
+        try {
+            QuizSession childQuizSession = createChildQuizSession(parentQuizSession, wrongQuestions);
+            copyScopes(childQuizSession, wrongQuestions);
+            copyQuestions(childQuizSession, wrongQuestions, optionsByQuestionId, answersByQuestionId);
+            QuizPlaySession playSession = createPlaySession(userId, parentPlaySession, parentQuizSession, childQuizSession, request);
+            QuizPlaySession savedPlaySession = quizPlaySessionRepository.save(playSession);
+            return QuizPlaySessionResponse.of(savedPlaySession, childQuizSession);
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(
+                    ErrorCode.CONFLICT,
+                    "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.",
+                    e
+            );
+        }
+    }
+
+    private List<Question> findParentQuestions(Long userId, Long quizSessionId) {
+        List<Question> questions = questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(
+                quizSessionId,
+                userId
+        );
+        if (questions.isEmpty()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "완료된 퀴즈 세션에 문항이 존재하지 않습니다.");
+        }
+        return questions;
+    }
+
+    private List<Question> findWrongQuestions(List<Question> parentQuestions, List<QuizPlayAnswer> parentPlayAnswers) {
+        Set<Long> wrongQuestionIds = parentPlayAnswers.stream()
+                .filter(answer -> Boolean.FALSE.equals(answer.getCorrectServer()))
+                .map(QuizPlayAnswer::getQuestionId)
+                .collect(Collectors.toSet());
+        List<Question> wrongQuestions = parentQuestions.stream()
+                .filter(question -> wrongQuestionIds.contains(question.getId()))
+                .toList();
+        if (wrongQuestions.isEmpty()) {
+            throw new CustomException(ErrorCode.CONFLICT, "오답 문항이 없어 다시 풀 수 없습니다.");
+        }
+        if (wrongQuestions.size() != wrongQuestionIds.size()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "풀이 답안의 문항 정보가 올바르지 않습니다.");
+        }
+        return wrongQuestions;
+    }
+
+    private Map<Long, List<QuestionOption>> getOptionsByQuestionId(List<Question> questions) {
+        return questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(questionIds(questions))
+                .stream()
+                .collect(Collectors.groupingBy(QuestionOption::getQuestionId));
+    }
+
+    private Map<Long, QuestionAnswer> getAnswersByQuestionId(List<Question> questions) {
+        Map<Long, QuestionAnswer> answersByQuestionId = questionAnswerRepository.findAllByQuestionIdIn(questionIds(questions))
+                .stream()
+                .collect(Collectors.toMap(QuestionAnswer::getQuestionId, Function.identity()));
+        if (answersByQuestionId.size() != questions.size()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 문항 정답 정보가 올바르지 않습니다.");
+        }
+        return answersByQuestionId;
+    }
+
+    private List<Long> questionIds(List<Question> questions) {
+        return questions.stream()
+                .map(Question::getId)
+                .toList();
+    }
+
+    private QuizSession createChildQuizSession(QuizSession parentQuizSession, List<Question> wrongQuestions) {
+        QuizSession childQuizSession = QuizSession.create(
+                UuidV7Generator.generate(),
+                parentQuizSession.getUserId(),
+                parentQuizSession.getSubjectId(),
+                parentQuizSession.getQuizType(),
+                parentQuizSession.getChoiceCount(),
+                wrongQuestions.size(),
+                parentQuizSession.getPlayMode(),
+                parentQuizSession.getTimerEnabled(),
+                parentQuizSession.getTimerScope(),
+                parentQuizSession.getTimerSeconds(),
+                parentQuizSession.getDifficulty(),
+                QUIZ_SESSION_STATUS_COMPLETED,
+                null
+        );
+        childQuizSession.markGenerationCompleted(wrongQuestions.size());
+        return quizSessionRepository.save(childQuizSession);
+    }
+
+    private void copyScopes(QuizSession childQuizSession, List<Question> wrongQuestions) {
+        Map<Long, Question> questionsByPartId = wrongQuestions.stream()
+                .collect(Collectors.toMap(
+                        Question::getPartId,
+                        Function.identity(),
+                        (first, ignored) -> first,
+                        LinkedHashMap::new
+                ));
+        List<QuizSessionScope> scopes = questionsByPartId.values().stream()
+                .map(question -> QuizSessionScope.create(
+                        childQuizSession.getId(),
+                        question.getPartId(),
+                        question.getChapterId()
+                ))
+                .toList();
+        quizSessionScopeRepository.saveAll(scopes);
+    }
+
+    private void copyQuestions(
+            QuizSession childQuizSession,
+            List<Question> wrongQuestions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId
+    ) {
+        int displayOrder = 1;
+        for (Question parentQuestion : wrongQuestions) {
+            Question childQuestion = questionRepository.save(Question.create(
+                    UuidV7Generator.generate(),
+                    childQuizSession.getId(),
+                    parentQuestion.getUserId(),
+                    parentQuestion.getSubjectId(),
+                    parentQuestion.getChapterId(),
+                    parentQuestion.getPartId(),
+                    parentQuestion.getQuestionType(),
+                    parentQuestion.getDifficulty(),
+                    parentQuestion.getBody(),
+                    parentQuestion.getSummary(),
+                    parentQuestion.getCorrectExplanation(),
+                    parentQuestion.getIncorrectExplanation(),
+                    displayOrder++
+            ));
+            copyOptions(parentQuestion, childQuestion, optionsByQuestionId);
+            copyAnswer(parentQuestion, childQuestion, answersByQuestionId);
+        }
+    }
+
+    private void copyOptions(
+            Question parentQuestion,
+            Question childQuestion,
+            Map<Long, List<QuestionOption>> optionsByQuestionId
+    ) {
+        List<QuestionOption> childOptions = optionsByQuestionId.getOrDefault(parentQuestion.getId(), List.of())
+                .stream()
+                .map(option -> QuestionOption.create(
+                        childQuestion.getId(),
+                        option.getOptionNumber(),
+                        option.getContent(),
+                        option.getCorrect()
+                ))
+                .toList();
+        if (!childOptions.isEmpty()) {
+            questionOptionRepository.saveAll(childOptions);
+        }
+    }
+
+    private void copyAnswer(
+            Question parentQuestion,
+            Question childQuestion,
+            Map<Long, QuestionAnswer> answersByQuestionId
+    ) {
+        QuestionAnswer parentAnswer = answersByQuestionId.get(parentQuestion.getId());
+        questionAnswerRepository.save(QuestionAnswer.create(childQuestion.getId(), parentAnswer.getAnswerValue()));
+    }
+
+    private QuizPlaySession createPlaySession(
+            Long userId,
+            QuizPlaySession parentPlaySession,
+            QuizSession parentQuizSession,
+            QuizSession childQuizSession,
+            QuizRetryRequest request
+    ) {
+        return QuizPlaySession.createRetryWrong(
+                request.getClientSessionId(),
+                childQuizSession.getId(),
+                userId,
+                childQuizSession.getSubjectId(),
+                parentPlaySession.getId(),
+                parentQuizSession.getId(),
+                parentPlaySession.getGeneration() + 1,
+                request.getQuestionShuffled(),
+                request.getOptionShuffled(),
+                request.getShuffleSeed()
+        );
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
@@ -47,6 +47,7 @@ public class QuizResultSubmitService {
     private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
     private static final String PLAY_TYPE_FIRST = "first";
     private static final String PLAY_TYPE_RETRY_ALL = "retry_all";
+    private static final String PLAY_TYPE_RETRY_WRONG = "retry_wrong";
     private static final String QUESTION_TYPE_MULTIPLE_CHOICE = "multiple_choice";
     private static final String QUESTION_TYPE_OX = "ox";
     private static final int ABUSE_MISMATCH_THRESHOLD_PCT = 30;
@@ -142,7 +143,9 @@ public class QuizResultSubmitService {
     }
 
     private boolean isSupportedPlayType(String playType) {
-        return PLAY_TYPE_FIRST.equals(playType) || PLAY_TYPE_RETRY_ALL.equals(playType);
+        return PLAY_TYPE_FIRST.equals(playType)
+                || PLAY_TYPE_RETRY_ALL.equals(playType)
+                || PLAY_TYPE_RETRY_WRONG.equals(playType);
     }
 
     private List<Question> findQuestions(Long userId, Long quizSessionId) {

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongServiceTest.java
@@ -89,7 +89,7 @@ class QuizResultRetryWrongServiceTest {
         QuestionOption wrongQuestionWrongOption = option(1003L, wrongQuestion.getId(), 2, "틀린 문제 오답", false);
         QuestionAnswer correctAnswer = answer(2001L, correctQuestion.getId(), "1");
         QuestionAnswer wrongAnswer = answer(2002L, wrongQuestion.getId(), "1");
-        QuizRetryRequest request = request("retry-wrong-client-session-id", null, null, "seed-1");
+        QuizRetryRequest request = request("retry-wrong-client-session-id", true, null, "seed-1");
         mockBaseData(userId, result, parentPlaySession, parentQuizSession);
         when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
                 .thenReturn(Optional.empty());

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongServiceTest.java
@@ -1,0 +1,491 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizResultRetryWrongServiceTest {
+
+    private QuizResultRepository quizResultRepository;
+    private QuizPlaySessionRepository quizPlaySessionRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private SubjectRepository subjectRepository;
+    private QuestionRepository questionRepository;
+    private QuestionOptionRepository questionOptionRepository;
+    private QuestionAnswerRepository questionAnswerRepository;
+    private QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private QuizSessionScopeRepository quizSessionScopeRepository;
+    private QuizResultRetryWrongService quizResultRetryWrongService;
+
+    @BeforeEach
+    void setUp() {
+        quizResultRepository = mock(QuizResultRepository.class);
+        quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        questionRepository = mock(QuestionRepository.class);
+        questionOptionRepository = mock(QuestionOptionRepository.class);
+        questionAnswerRepository = mock(QuestionAnswerRepository.class);
+        quizPlayAnswerRepository = mock(QuizPlayAnswerRepository.class);
+        quizSessionScopeRepository = mock(QuizSessionScopeRepository.class);
+        quizResultRetryWrongService = new QuizResultRetryWrongService(
+                quizResultRepository,
+                quizPlaySessionRepository,
+                quizSessionRepository,
+                subjectRepository,
+                questionRepository,
+                questionOptionRepository,
+                questionAnswerRepository,
+                quizPlayAnswerRepository,
+                quizSessionScopeRepository
+        );
+    }
+
+    @Test
+    void retryWrong_creates_child_quiz_session_and_retry_wrong_play_session() {
+        Long userId = 1L;
+        QuizSession parentQuizSession = quizSession(500L, "parent-quiz-session-id", userId, 10L, "completed", 2);
+        QuizPlaySession parentPlaySession = firstPlaySession(700L, "parent-play-session-id", parentQuizSession);
+        QuizResult result = result(3000L, "result-public-id", parentPlaySession, parentQuizSession, userId);
+        Question correctQuestion = question(901L, "correct-question-id", parentQuizSession, 1);
+        Question wrongQuestion = question(902L, "wrong-question-id", parentQuizSession, 2);
+        QuestionOption correctQuestionOption = option(1001L, correctQuestion.getId(), 1, "맞은 문제 정답", true);
+        QuestionOption wrongQuestionCorrectOption = option(1002L, wrongQuestion.getId(), 1, "틀린 문제 정답", true);
+        QuestionOption wrongQuestionWrongOption = option(1003L, wrongQuestion.getId(), 2, "틀린 문제 오답", false);
+        QuestionAnswer correctAnswer = answer(2001L, correctQuestion.getId(), "1");
+        QuestionAnswer wrongAnswer = answer(2002L, wrongQuestion.getId(), "1");
+        QuizRetryRequest request = request("retry-wrong-client-session-id", null, null, "seed-1");
+        mockBaseData(userId, result, parentPlaySession, parentQuizSession);
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.empty());
+        mockParentQuestionData(
+                parentQuizSession,
+                userId,
+                List.of(correctQuestion, wrongQuestion),
+                List.of(
+                        playAnswer(parentPlaySession.getId(), correctQuestion.getId(), userId, correctQuestionOption.getId(), true, false),
+                        playAnswer(parentPlaySession.getId(), wrongQuestion.getId(), userId, wrongQuestionWrongOption.getId(), false, false)
+                ),
+                List.of(correctQuestionOption, wrongQuestionCorrectOption, wrongQuestionWrongOption),
+                List.of(correctAnswer, wrongAnswer)
+        );
+        mockChildSaves();
+
+        QuizPlaySessionResponse response = quizResultRetryWrongService.retryWrong(userId, result.getPublicId(), request);
+
+        assertThat(response.getPlaySessionId()).isEqualTo(request.getClientSessionId());
+        assertThat(response.getQuizSessionId()).isNotEqualTo(parentQuizSession.getPublicId());
+        assertThat(response.getPlayType()).isEqualTo("retry_wrong");
+        assertThat(response.getStatus()).isEqualTo("in_progress");
+
+        ArgumentCaptor<QuizSession> quizSessionCaptor = ArgumentCaptor.forClass(QuizSession.class);
+        verify(quizSessionRepository).save(quizSessionCaptor.capture());
+        QuizSession childQuizSession = quizSessionCaptor.getValue();
+        assertThat(childQuizSession.getSubjectId()).isEqualTo(parentQuizSession.getSubjectId());
+        assertThat(childQuizSession.getQuestionCount()).isEqualTo(1);
+        assertThat(childQuizSession.getStatus()).isEqualTo("completed");
+        assertThat(childQuizSession.getGeneratedCount()).isEqualTo(1);
+        assertThat(childQuizSession.getPlayMode()).isEqualTo(parentQuizSession.getPlayMode());
+
+        ArgumentCaptor<Iterable<QuizSessionScope>> scopeCaptor = iterableCaptor();
+        verify(quizSessionScopeRepository).saveAll(scopeCaptor.capture());
+        List<QuizSessionScope> savedScopes = toList(scopeCaptor.getValue());
+        assertThat(savedScopes).hasSize(1);
+        assertThat(savedScopes.get(0).getQuizSessionId()).isEqualTo(childQuizSession.getId());
+        assertThat(savedScopes.get(0).getPartId()).isEqualTo(wrongQuestion.getPartId());
+
+        ArgumentCaptor<Question> questionCaptor = ArgumentCaptor.forClass(Question.class);
+        verify(questionRepository).save(questionCaptor.capture());
+        Question childQuestion = questionCaptor.getValue();
+        assertThat(childQuestion.getQuizSessionId()).isEqualTo(childQuizSession.getId());
+        assertThat(childQuestion.getBody()).isEqualTo(wrongQuestion.getBody());
+        assertThat(childQuestion.getDisplayOrder()).isEqualTo(1);
+
+        ArgumentCaptor<Iterable<QuestionOption>> optionCaptor = iterableCaptor();
+        verify(questionOptionRepository).saveAll(optionCaptor.capture());
+        List<QuestionOption> childOptions = toList(optionCaptor.getValue());
+        assertThat(childOptions).hasSize(2);
+        assertThat(childOptions)
+                .extracting(QuestionOption::getQuestionId)
+                .containsOnly(childQuestion.getId());
+
+        ArgumentCaptor<QuestionAnswer> answerCaptor = ArgumentCaptor.forClass(QuestionAnswer.class);
+        verify(questionAnswerRepository).save(answerCaptor.capture());
+        assertThat(answerCaptor.getValue().getQuestionId()).isEqualTo(childQuestion.getId());
+        assertThat(answerCaptor.getValue().getAnswerValue()).isEqualTo(wrongAnswer.getAnswerValue());
+
+        ArgumentCaptor<QuizPlaySession> playSessionCaptor = ArgumentCaptor.forClass(QuizPlaySession.class);
+        verify(quizPlaySessionRepository).save(playSessionCaptor.capture());
+        QuizPlaySession retryWrongPlaySession = playSessionCaptor.getValue();
+        assertThat(retryWrongPlaySession.getQuizSessionId()).isEqualTo(childQuizSession.getId());
+        assertThat(retryWrongPlaySession.getPlayType()).isEqualTo("retry_wrong");
+        assertThat(retryWrongPlaySession.getParentPlaySessionId()).isEqualTo(parentPlaySession.getId());
+        assertThat(retryWrongPlaySession.getParentQuizSessionId()).isEqualTo(parentQuizSession.getId());
+        assertThat(retryWrongPlaySession.getGeneration()).isEqualTo(1);
+        assertThat(retryWrongPlaySession.getQuestionShuffled()).isTrue();
+        assertThat(retryWrongPlaySession.getOptionShuffled()).isTrue();
+    }
+
+    @Test
+    void retryWrong_returns_existing_when_same_client_session_id_is_retried() {
+        Long userId = 1L;
+        QuizSession parentQuizSession = quizSession(500L, "parent-quiz-session-id", userId, 10L, "completed", 2);
+        QuizSession childQuizSession = quizSession(600L, "child-quiz-session-id", userId, 10L, "completed", 1);
+        QuizPlaySession parentPlaySession = firstPlaySession(700L, "parent-play-session-id", parentQuizSession);
+        QuizPlaySession existing = retryWrongPlaySession(
+                701L,
+                "retry-wrong-client-session-id",
+                childQuizSession,
+                parentPlaySession,
+                parentQuizSession
+        );
+        QuizResult result = result(3000L, "result-public-id", parentPlaySession, parentQuizSession, userId);
+        QuizRetryRequest request = request(existing.getClientSessionId(), null, null, null);
+        mockBaseData(userId, result, parentPlaySession, parentQuizSession);
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(childQuizSession.getId(), userId))
+                .thenReturn(Optional.of(childQuizSession));
+
+        QuizPlaySessionResponse response = quizResultRetryWrongService.retryWrong(userId, result.getPublicId(), request);
+
+        assertThat(response.getPlaySessionId()).isEqualTo(existing.getClientSessionId());
+        assertThat(response.getQuizSessionId()).isEqualTo(childQuizSession.getPublicId());
+        assertThat(response.getPlayType()).isEqualTo("retry_wrong");
+        verify(quizSessionRepository, never()).save(any());
+        verify(questionRepository, never()).save(any());
+    }
+
+    @Test
+    void retryWrong_throws_conflict_when_wrong_question_is_empty() {
+        Long userId = 1L;
+        QuizSession parentQuizSession = quizSession(500L, "parent-quiz-session-id", userId, 10L, "completed", 1);
+        QuizPlaySession parentPlaySession = firstPlaySession(700L, "parent-play-session-id", parentQuizSession);
+        QuizResult result = result(3000L, "result-public-id", parentPlaySession, parentQuizSession, userId);
+        Question question = question(901L, "question-id", parentQuizSession, 1);
+        QuestionOption option = option(1001L, question.getId(), 1, "정답", true);
+        QuestionAnswer answer = answer(2001L, question.getId(), "1");
+        QuizRetryRequest request = request("retry-wrong-client-session-id", null, null, null);
+        mockBaseData(userId, result, parentPlaySession, parentQuizSession);
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.empty());
+        mockParentQuestionData(
+                parentQuizSession,
+                userId,
+                List.of(question),
+                List.of(playAnswer(parentPlaySession.getId(), question.getId(), userId, option.getId(), true, false)),
+                List.of(option),
+                List.of(answer)
+        );
+
+        assertThatThrownBy(() -> quizResultRetryWrongService.retryWrong(userId, result.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    @Test
+    void retryWrong_throws_conflict_when_client_session_id_belongs_to_other_session() {
+        Long userId = 1L;
+        QuizSession parentQuizSession = quizSession(500L, "parent-quiz-session-id", userId, 10L, "completed", 1);
+        QuizPlaySession parentPlaySession = firstPlaySession(700L, "parent-play-session-id", parentQuizSession);
+        QuizPlaySession existing = firstPlaySession(701L, "retry-wrong-client-session-id", parentQuizSession);
+        QuizResult result = result(3000L, "result-public-id", parentPlaySession, parentQuizSession, userId);
+        QuizRetryRequest request = request(existing.getClientSessionId(), null, null, null);
+        mockBaseData(userId, result, parentPlaySession, parentQuizSession);
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> quizResultRetryWrongService.retryWrong(userId, result.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    private void mockBaseData(
+            Long userId,
+            QuizResult result,
+            QuizPlaySession parentPlaySession,
+            QuizSession parentQuizSession
+    ) {
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizPlaySessionRepository.findByIdAndUserId(parentPlaySession.getId(), userId))
+                .thenReturn(Optional.of(parentPlaySession));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(parentQuizSession.getId(), userId))
+                .thenReturn(Optional.of(parentQuizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(parentQuizSession.getSubjectId(), userId))
+                .thenReturn(Optional.of(subject(parentQuizSession.getSubjectId(), userId)));
+    }
+
+    private void mockParentQuestionData(
+            QuizSession parentQuizSession,
+            Long userId,
+            List<Question> questions,
+            List<QuizPlayAnswer> playAnswers,
+            List<QuestionOption> options,
+            List<QuestionAnswer> answers
+    ) {
+        List<Long> questionIds = questions.stream().map(Question::getId).toList();
+        when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(parentQuizSession.getId(), userId))
+                .thenReturn(questions);
+        when(quizPlayAnswerRepository.findAllByPlaySessionId(playAnswers.get(0).getPlaySessionId()))
+                .thenReturn(playAnswers);
+        when(questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(questionIds))
+                .thenReturn(options);
+        when(questionAnswerRepository.findAllByQuestionIdIn(questionIds))
+                .thenReturn(answers);
+    }
+
+    private void mockChildSaves() {
+        AtomicLong questionId = new AtomicLong(9000L);
+        when(quizSessionRepository.save(any(QuizSession.class)))
+                .thenAnswer(invocation -> {
+                    QuizSession quizSession = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(quizSession, "id", 600L);
+                    return quizSession;
+                });
+        when(quizSessionScopeRepository.saveAll(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(questionRepository.save(any(Question.class)))
+                .thenAnswer(invocation -> {
+                    Question question = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(question, "id", questionId.incrementAndGet());
+                    return question;
+                });
+        when(questionOptionRepository.saveAll(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(questionAnswerRepository.save(any(QuestionAnswer.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(quizPlaySessionRepository.save(any(QuizPlaySession.class)))
+                .thenAnswer(invocation -> {
+                    QuizPlaySession playSession = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(playSession, "id", 800L);
+                    return playSession;
+                });
+    }
+
+    private Subject subject(Long id, Long userId) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        return subject;
+    }
+
+    private QuizSession quizSession(
+            Long id,
+            String publicId,
+            Long userId,
+            Long subjectId,
+            String status,
+            Integer questionCount
+    ) {
+        QuizSession quizSession = QuizSession.create(
+                publicId,
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                questionCount,
+                "one_by_one",
+                true,
+                "per_question",
+                60,
+                "medium",
+                status,
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizPlaySession firstPlaySession(Long id, String clientSessionId, QuizSession quizSession) {
+        QuizPlaySession playSession = QuizPlaySession.createFirst(
+                clientSessionId,
+                quizSession.getId(),
+                quizSession.getUserId(),
+                quizSession.getSubjectId(),
+                false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+
+    private QuizPlaySession retryWrongPlaySession(
+            Long id,
+            String clientSessionId,
+            QuizSession childQuizSession,
+            QuizPlaySession parentPlaySession,
+            QuizSession parentQuizSession
+    ) {
+        QuizPlaySession playSession = QuizPlaySession.createRetryWrong(
+                clientSessionId,
+                childQuizSession.getId(),
+                childQuizSession.getUserId(),
+                childQuizSession.getSubjectId(),
+                parentPlaySession.getId(),
+                parentQuizSession.getId(),
+                parentPlaySession.getGeneration() + 1,
+                true,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+
+    private QuizResult result(
+            Long id,
+            String publicId,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Long userId
+    ) {
+        QuizResult result = QuizResult.create(
+                publicId,
+                playSession.getId(),
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                2,
+                1,
+                1,
+                0,
+                50,
+                430000,
+                1,
+                4,
+                false,
+                null,
+                true,
+                false
+        );
+        ReflectionTestUtils.setField(result, "id", id);
+        return result;
+    }
+
+    private Question question(Long id, String publicId, QuizSession quizSession, Integer displayOrder) {
+        Question question = newEntity(Question.class);
+        ReflectionTestUtils.setField(question, "id", id);
+        ReflectionTestUtils.setField(question, "publicId", publicId);
+        ReflectionTestUtils.setField(question, "quizSessionId", quizSession.getId());
+        ReflectionTestUtils.setField(question, "userId", quizSession.getUserId());
+        ReflectionTestUtils.setField(question, "subjectId", quizSession.getSubjectId());
+        ReflectionTestUtils.setField(question, "chapterId", 100L + displayOrder);
+        ReflectionTestUtils.setField(question, "partId", 200L + displayOrder);
+        ReflectionTestUtils.setField(question, "questionType", "multiple_choice");
+        ReflectionTestUtils.setField(question, "difficulty", "medium");
+        ReflectionTestUtils.setField(question, "summary", "핵심 개념 확인");
+        ReflectionTestUtils.setField(question, "body", "문제 " + displayOrder);
+        ReflectionTestUtils.setField(question, "correctExplanation", "정답 해설");
+        ReflectionTestUtils.setField(question, "incorrectExplanation", "오답 해설");
+        ReflectionTestUtils.setField(question, "displayOrder", displayOrder);
+        return question;
+    }
+
+    private QuestionOption option(Long id, Long questionId, Integer optionNumber, String content, Boolean correct) {
+        QuestionOption option = newEntity(QuestionOption.class);
+        ReflectionTestUtils.setField(option, "id", id);
+        ReflectionTestUtils.setField(option, "questionId", questionId);
+        ReflectionTestUtils.setField(option, "optionNumber", optionNumber);
+        ReflectionTestUtils.setField(option, "content", content);
+        ReflectionTestUtils.setField(option, "correct", correct);
+        return option;
+    }
+
+    private QuestionAnswer answer(Long id, Long questionId, String answerValue) {
+        QuestionAnswer answer = newEntity(QuestionAnswer.class);
+        ReflectionTestUtils.setField(answer, "id", id);
+        ReflectionTestUtils.setField(answer, "questionId", questionId);
+        ReflectionTestUtils.setField(answer, "answerValue", answerValue);
+        return answer;
+    }
+
+    private QuizPlayAnswer playAnswer(
+            Long playSessionId,
+            Long questionId,
+            Long userId,
+            Long selectedOptionId,
+            Boolean correctServer,
+            Boolean skipped
+    ) {
+        return QuizPlayAnswer.create(
+                playSessionId,
+                questionId,
+                userId,
+                selectedOptionId,
+                null,
+                correctServer,
+                correctServer,
+                skipped,
+                15000,
+                false
+        );
+    }
+
+    private QuizRetryRequest request(
+            String clientSessionId,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizRetryRequest request = new QuizRetryRequest();
+        ReflectionTestUtils.setField(request, "clientSessionId", clientSessionId);
+        ReflectionTestUtils.setField(request, "questionShuffled", questionShuffled);
+        ReflectionTestUtils.setField(request, "optionShuffled", optionShuffled);
+        ReflectionTestUtils.setField(request, "shuffleSeed", shuffleSeed);
+        return request;
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+
+    private <T> List<T> toList(Iterable<T> values) {
+        List<T> result = new ArrayList<>();
+        values.forEach(result::add);
+        return result;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <T> ArgumentCaptor<Iterable<T>> iterableCaptor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(Iterable.class);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
@@ -264,6 +264,41 @@ class QuizResultSubmitServiceTest {
     }
 
     @Test
+    void submit_creates_retry_wrong_result_with_review_reward() {
+        Long userId = 1L;
+        User user = user(userId, 13, 364, 3);
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = retryWrongPlaySession(702L, "retry-wrong-client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption correctOption = option(1000L, question.getId(), 1, "정답", true);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                "retry_wrong",
+                210000,
+                List.of(answerItem(question.getPublicId(), String.valueOf(correctOption.getId()), true, false))
+        );
+        mockSubmitData(user, subject, quizSession, playSession, List.of(question), List.of(correctOption), List.of(answer));
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.empty());
+        mockReward(user, playSession, quizSession, 1, 0, 3, false, null, 3);
+        when(quizResultRepository.save(any(QuizResult.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(userId, request);
+
+        assertThat(outcome.isCreated()).isTrue();
+        assertThat(outcome.getResponse().getPlaySessionId()).isEqualTo(playSession.getClientSessionId());
+        assertThat(outcome.getResponse().getRewards().getDotoriEarned()).isZero();
+        assertThat(outcome.getResponse().getRewards().getXpEarned()).isEqualTo(3);
+        assertThat(outcome.getResponse().getRewards().getCurrentDotoriBalance()).isEqualTo(13);
+        assertThat(outcome.getResponse().getRewards().getCurrentXpTotal()).isEqualTo(367);
+        verify(gamificationRewardService).applyQuizReward(user, playSession, quizSession, 1);
+    }
+
+    @Test
     void submit_throws_invalid_option_when_answer_question_is_missing() {
         Long userId = 1L;
         User user = user(userId, 12, 360, 3);
@@ -438,6 +473,23 @@ class QuizResultSubmitServiceTest {
                 userId,
                 subjectId,
                 false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+
+    private QuizPlaySession retryWrongPlaySession(Long id, String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        QuizPlaySession playSession = QuizPlaySession.createRetryWrong(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                700L,
+                500L,
+                1,
+                true,
                 true,
                 null
         );


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- HISTORY-004 중 틀린 문제만 다시풀기 범위 구현
- 부모 풀이 결과의 오답 문항만 복사해 새 자식 퀴즈 세트 생성
- 생성된 자식 퀴즈 세트에 `retry_wrong` 풀이 세션 시작

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `POST /api/v1/quiz-results/{resultId}/retry-wrong` 구현
- 부모 결과/풀이 세션/퀴즈 세션/과목 유효성 검증 추가
- 오답 문항 기반 자식 `quiz_sessions`, `quiz_session_scopes`, `questions`, `question_options`, `question_answers` 복사 저장
- `retry_wrong` 풀이 세션 생성 및 동일 `clientSessionId` 멱등 처리
- `retry_wrong` 결과 제출 허용 및 복습 보상 경로 연동
- 오답 복습 세션 생성/결과 제출 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.domain.quiz.service.QuizResultRetryWrongServiceTest --tests com.f1.quiket.domain.quiz.service.QuizResultSubmitServiceTest`
2. `./gradlew test`
3. `git diff --check`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #95

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 오답 복습은 AOAI 재생성 없이 부모 풀이의 오답 문항 데이터를 복사합니다
- 미선택 문항은 서버 채점 기준 `correctServer=false`라 오답 복습 대상에 포함됩니다
- 셔플은 기존 정책처럼 서버가 옵션값만 저장하고 실제 순서는 클라이언트가 처리합니다

---

## 🧑‍💻 Assignee

- @imclaremont
