### PR TITLE
[Feat] 과목 관리 기능 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/chapter/controller/ChapterController.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/controller/ChapterController.java
@@ -1,0 +1,41 @@
+package com.f1.quiket.domain.chapter.controller;
+
+import com.f1.quiket.domain.chapter.dto.ChapterNameUpdateRequest;
+import com.f1.quiket.domain.chapter.dto.ChapterResponse;
+import com.f1.quiket.domain.chapter.service.ChapterService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 챕터 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chapters")
+public class ChapterController {
+
+    private final ChapterService chapterService;
+
+    /**
+     * 챕터명 수정
+     */
+    @PatchMapping("/{chapterId}/name")
+    public ResponseEntity<ApiResponse<ChapterResponse>> updateChapterName(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String chapterId,
+            @Valid @RequestBody ChapterNameUpdateRequest request
+    ) {
+        ChapterResponse response = chapterService.updateChapterName(principal.getPublicId(), chapterId, request.getName());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/chapter/dto/ChapterNameUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/dto/ChapterNameUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.chapter.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 챕터명 수정 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class ChapterNameUpdateRequest {
+
+    /** 챕터명 */
+    @NotBlank(message = "챕터명을 입력해주세요")
+    @Size(max = 30, message = "챕터명은 30자 이하여야 합니다")
+    private String name;
+}

--- a/src/main/java/com/f1/quiket/domain/chapter/dto/ChapterResponse.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/dto/ChapterResponse.java
@@ -1,0 +1,35 @@
+package com.f1.quiket.domain.chapter.dto;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.subject.entity.Subject;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 챕터 응답 DTO
+ */
+@Getter
+@Builder
+public class ChapterResponse {
+
+    /** 챕터 식별자 */
+    private final String id;
+    /** 과목 식별자 */
+    private final String subjectId;
+    /** 챕터명 */
+    private final String name;
+    /** 표시 순서 */
+    private final Integer displayOrder;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static ChapterResponse of(Chapter chapter, Subject subject) {
+        return ChapterResponse.builder()
+                .id(chapter.getPublicId())
+                .subjectId(subject.getPublicId())
+                .name(chapter.getName())
+                .displayOrder(chapter.getDisplayOrder())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/chapter/entity/Chapter.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/entity/Chapter.java
@@ -44,4 +44,11 @@ public class Chapter extends BaseEntity {
 
     @Column(name = "display_order", nullable = false)
     Integer displayOrder;
+
+    /**
+     * 챕터명 변경
+     */
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
@@ -1,7 +1,9 @@
 package com.f1.quiket.domain.chapter.repository;
 
 import com.f1.quiket.domain.chapter.entity.Chapter;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +17,19 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
      * 사용자 챕터 목록 조회
      */
     List<Chapter> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 과목 챕터 목록 조회
+     */
+    List<Chapter> findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(Long subjectId);
+
+    /**
+     * 과목별 챕터 목록 조회
+     */
+    List<Chapter> findAllBySubjectIdInAndDeletedAtIsNull(Collection<Long> subjectIds);
+
+    /**
+     * 공개 식별자 기반 사용자 챕터 조회
+     */
+    Optional<Chapter> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
@@ -21,7 +21,10 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
     /**
      * 과목 챕터 목록 조회
      */
-    List<Chapter> findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(Long subjectId);
+    List<Chapter> findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(
+            Long subjectId,
+            Long userId
+    );
 
     /**
      * 과목별 챕터 목록 조회
@@ -32,10 +35,6 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
      * 공개 식별자 기반 사용자 챕터 조회
      */
     Optional<Chapter> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
-    List<Chapter> findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(
-            Long subjectId,
-            Long userId
-    );
 
     /**
      * 사용자 챕터 목록 조회 (PK 컬렉션 기반)

--- a/src/main/java/com/f1/quiket/domain/chapter/service/ChapterService.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/service/ChapterService.java
@@ -1,0 +1,42 @@
+package com.f1.quiket.domain.chapter.service;
+
+import com.f1.quiket.domain.chapter.dto.ChapterResponse;
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 챕터 비즈니스 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class ChapterService {
+
+    private final UserRepository userRepository;
+    private final ChapterRepository chapterRepository;
+    private final SubjectRepository subjectRepository;
+
+    /**
+     * 챕터명 수정
+     */
+    @Transactional
+    public ChapterResponse updateChapterName(String userPublicId, String chapterPublicId, String name) {
+        User user = userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+        Chapter chapter = chapterRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(chapterPublicId, user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+        Subject subject = subjectRepository.findById(chapter.getSubjectId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        chapter.updateName(name);
+        return ChapterResponse.of(chapter, subject);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.part.repository;
 
 import com.f1.quiket.domain.part.entity.Part;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -15,4 +16,19 @@ public interface PartRepository extends JpaRepository<Part, Long> {
      * 사용자 파트 목록 조회
      */
     List<Part> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 과목 파트 목록 조회
+     */
+    List<Part> findAllBySubjectIdAndDeletedAtIsNull(Long subjectId);
+
+    /**
+     * 챕터별 파트 목록 조회
+     */
+    List<Part> findAllByChapterIdInAndDeletedAtIsNull(Collection<Long> chapterIds);
+
+    /**
+     * 과목별 파트 목록 조회
+     */
+    List<Part> findAllBySubjectIdInAndDeletedAtIsNull(Collection<Long> subjectIds);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
@@ -15,4 +15,5 @@ public interface QuizPlaySessionRepository extends JpaRepository<QuizPlaySession
      * 사용자 풀이 세션 목록 조회
      */
     List<QuizPlaySession> findAllByUserId(Long userId);
+
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
@@ -15,4 +15,5 @@ public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
      * 사용자 결과 목록 조회
      */
     List<QuizResult> findAllByUserId(Long userId);
+
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
@@ -15,4 +15,9 @@ public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> 
      * 사용자 퀴즈 세션 목록 조회
      */
     List<QuizSession> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 과목 퀴즈 세션 목록 조회
+     */
+    List<QuizSession> findAllBySubjectIdAndDeletedAtIsNull(Long subjectId);
 }

--- a/src/main/java/com/f1/quiket/domain/subject/controller/CertificateController.java
+++ b/src/main/java/com/f1/quiket/domain/subject/controller/CertificateController.java
@@ -1,0 +1,36 @@
+package com.f1.quiket.domain.subject.controller;
+
+import com.f1.quiket.domain.subject.dto.CertificateResponse;
+import com.f1.quiket.domain.subject.service.CertificateService;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 자격증 마스터 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/certificates")
+public class CertificateController {
+
+    private final CertificateService certificateService;
+
+    /**
+     * 자격증 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CertificateResponse>>> getCertificates(
+            @RequestParam(name = "featured", required = false) Boolean featured,
+            @RequestParam(name = "keyword", required = false) String keyword
+    ) {
+        List<CertificateResponse> response = certificateService.getCertificates(featured, keyword);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/controller/SubjectController.java
+++ b/src/main/java/com/f1/quiket/domain/subject/controller/SubjectController.java
@@ -1,0 +1,153 @@
+package com.f1.quiket.domain.subject.controller;
+
+import com.f1.quiket.domain.subject.dto.SubjectCreateRequest;
+import com.f1.quiket.domain.subject.dto.QuizScopeResponse;
+import com.f1.quiket.domain.subject.dto.SubjectDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectDetailUpdateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleResponse;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleUpsertRequest;
+import com.f1.quiket.domain.subject.dto.SubjectNameUpdateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectPageResponse;
+import com.f1.quiket.domain.subject.dto.SubjectResponse;
+import com.f1.quiket.domain.subject.service.SubjectService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 과목 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/subjects")
+public class SubjectController {
+
+    private final SubjectService subjectService;
+
+    /**
+     * 내 과목 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<SubjectPageResponse>> getSubjects(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        SubjectPageResponse response = subjectService.getSubjects(principal.getPublicId(), page, size);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 과목 생성
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<SubjectResponse>> createSubject(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody SubjectCreateRequest request
+    ) {
+        SubjectResponse response = subjectService.createSubject(principal.getPublicId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(SuccessCode.CREATED, response));
+    }
+
+    /**
+     * 과목 상세 조회
+     */
+    @GetMapping("/{subjectId}")
+    public ResponseEntity<ApiResponse<SubjectDetailResponse>> getSubject(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId
+    ) {
+        SubjectDetailResponse response = subjectService.getSubject(principal.getPublicId(), subjectId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 퀴즈 출제 범위 조회
+     */
+    @GetMapping("/{subjectId}/quiz-scope")
+    public ResponseEntity<ApiResponse<QuizScopeResponse>> getQuizScope(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId
+    ) {
+        QuizScopeResponse response = subjectService.getQuizScope(principal.getPublicId(), subjectId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 과목 삭제
+     */
+    @DeleteMapping("/{subjectId}")
+    public ResponseEntity<ApiResponse<Void>> deleteSubject(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId
+    ) {
+        subjectService.deleteSubject(principal.getPublicId(), subjectId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
+    }
+
+    /**
+     * 과목명 수정
+     */
+    @PatchMapping("/{subjectId}/name")
+    public ResponseEntity<ApiResponse<SubjectResponse>> updateSubjectName(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId,
+            @Valid @RequestBody SubjectNameUpdateRequest request
+    ) {
+        SubjectResponse response = subjectService.updateSubjectName(principal.getPublicId(), subjectId, request.getName());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 과목 상세 수정
+     */
+    @PutMapping("/{subjectId}/details")
+    public ResponseEntity<ApiResponse<SubjectDetailResponse>> updateSubjectDetails(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId,
+            @Valid @RequestBody SubjectDetailUpdateRequest request
+    ) {
+        SubjectDetailResponse response = subjectService.updateSubjectDetails(principal.getPublicId(), subjectId, request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 시험 일정 등록 또는 수정
+     */
+    @PutMapping("/{subjectId}/exam-schedule")
+    public ResponseEntity<ApiResponse<SubjectExamScheduleResponse>> upsertSubjectExamSchedule(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId,
+            @Valid @RequestBody SubjectExamScheduleUpsertRequest request
+    ) {
+        SubjectExamScheduleResponse response = subjectService.upsertExamSchedule(principal.getPublicId(), subjectId, request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 시험 일정 삭제
+     */
+    @DeleteMapping("/{subjectId}/exam-schedule")
+    public ResponseEntity<ApiResponse<Void>> deleteSubjectExamSchedule(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId
+    ) {
+        subjectService.deleteExamSchedule(principal.getPublicId(), subjectId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/CertificateResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/CertificateResponse.java
@@ -1,0 +1,34 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.Certificate;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 자격증 응답 DTO
+ */
+@Getter
+@Builder
+public class CertificateResponse {
+
+    /** 자격증 식별자 */
+    private final Long id;
+    /** 자격증명 */
+    private final String name;
+    /** 자주 찾는 자격증 여부 */
+    private final Boolean featured;
+    /** 표시 순서 */
+    private final Integer displayOrder;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static CertificateResponse from(Certificate certificate) {
+        return CertificateResponse.builder()
+                .id(certificate.getId())
+                .name(certificate.getName())
+                .featured(certificate.getFeatured())
+                .displayOrder(certificate.getDisplayOrder())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/ChapterWithPartsResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/ChapterWithPartsResponse.java
@@ -1,0 +1,38 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 챕터와 파트 응답 DTO
+ */
+@Getter
+@Builder
+public class ChapterWithPartsResponse {
+
+    /** 챕터 식별자 */
+    private final String id;
+    /** 과목 식별자 */
+    private final String subjectId;
+    /** 챕터명 */
+    private final String name;
+    /** 표시 순서 */
+    private final Integer displayOrder;
+    /** 파트 목록 */
+    private final List<PartSummaryResponse> parts;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static ChapterWithPartsResponse of(Chapter chapter, String subjectPublicId, List<PartSummaryResponse> parts) {
+        return ChapterWithPartsResponse.builder()
+                .id(chapter.getPublicId())
+                .subjectId(subjectPublicId)
+                .name(chapter.getName())
+                .displayOrder(chapter.getDisplayOrder())
+                .parts(parts)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/PartSummaryResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/PartSummaryResponse.java
@@ -1,0 +1,35 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.part.entity.Part;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 파트 요약 응답 DTO
+ */
+@Getter
+@Builder
+public class PartSummaryResponse {
+
+    /** 파트 식별자 */
+    private final String id;
+    /** 챕터 식별자 */
+    private final String chapterId;
+    /** 파트명 */
+    private final String name;
+    /** 파트 번호 */
+    private final Integer partNumber;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static PartSummaryResponse of(Part part, Chapter chapter) {
+        return PartSummaryResponse.builder()
+                .id(part.getPublicId())
+                .chapterId(chapter.getPublicId())
+                .name(part.getName())
+                .partNumber(part.getPartNumber())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/QuizScopeResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/QuizScopeResponse.java
@@ -1,0 +1,20 @@
+package com.f1.quiket.domain.subject.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 출제 범위 응답 DTO
+ */
+@Getter
+@Builder
+public class QuizScopeResponse {
+
+    /** 과목 식별자 */
+    private final String subjectId;
+    /** 과목명 */
+    private final String subjectName;
+    /** 챕터 목록 */
+    private final List<ChapterWithPartsResponse> chapters;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectCreateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectCreateRequest.java
@@ -1,0 +1,36 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 과목 생성 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectCreateRequest {
+
+    /** 과목명 */
+    @NotBlank(message = "과목명을 입력해주세요")
+    @Size(max = 30, message = "과목명은 30자 이하여야 합니다")
+    private String name;
+
+    /** 학습 목적 */
+    @NotBlank(message = "학습 목적은 필수입니다")
+    private String purpose;
+
+    /** 시험 상세 */
+    @Valid
+    private SubjectExamDetailRequest examDetail;
+
+    /** 복습 상세 */
+    @Valid
+    private SubjectReviewDetailRequest reviewDetail;
+
+    /** 기타 상세 */
+    @Valid
+    private SubjectOtherDetailRequest otherDetail;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectDetailResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectDetailResponse.java
@@ -1,0 +1,29 @@
+package com.f1.quiket.domain.subject.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 상세 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectDetailResponse {
+
+    /** 과목 식별자 */
+    private final String id;
+    /** 과목명 */
+    private final String name;
+    /** 학습 목적 */
+    private final String purpose;
+    /** 목적별 상세 */
+    private final SubjectPurposeDetailResponse detail;
+    /** 생성 시각 */
+    private final LocalDateTime createdAt;
+    /** 시험 일정 */
+    private final SubjectExamScheduleResponse examSchedule;
+    /** 챕터 목록 */
+    private final List<ChapterWithPartsResponse> chapters;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectDetailUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectDetailUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.f1.quiket.domain.subject.dto;
+
+/**
+ * 과목 상세 수정 요청 DTO
+ */
+public class SubjectDetailUpdateRequest extends SubjectCreateRequest {
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamDetailRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamDetailRequest.java
@@ -1,0 +1,60 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 과목 시험 상세 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectExamDetailRequest {
+
+    /** 시험 유형 */
+    @NotBlank(message = "시험 유형은 필수입니다")
+    private String examType;
+
+    /** 대학 전공 계열 */
+    @Size(max = 30, message = "전공 계열은 30자 이하여야 합니다")
+    private String univMajorField;
+
+    /** 대학 전공명 */
+    @Size(max = 30, message = "전공명은 30자 이하여야 합니다")
+    private String univMajorName;
+
+    /** 대학 과목 유형 */
+    private String univCourseType;
+
+    /** 중고등 학년 */
+    private String mhGrade;
+
+    /** 중고등 과목 유형 */
+    @Size(max = 30, message = "과목 유형은 30자 이하여야 합니다")
+    private String mhSubjectType;
+
+    /** 자격증 식별자 */
+    private Long certificateId;
+
+    /** 직접 입력 자격증명 */
+    @Size(max = 100, message = "자격증명은 100자 이하여야 합니다")
+    private String certificateName;
+
+    /** 공무원 급수 */
+    private String civilRank;
+
+    /** 공무원 직렬 */
+    private String civilSeries;
+
+    /** 어학 언어 */
+    private String langType;
+
+    /** 어학 시험명 */
+    @Size(max = 30, message = "어학 시험명은 30자 이하여야 합니다")
+    private String langExamName;
+
+    /** 기타 시험명 */
+    @Size(max = 30, message = "기타 시험명은 30자 이하여야 합니다")
+    private String otherExamName;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamDetailResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamDetailResponse.java
@@ -1,0 +1,61 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.SubjectExamDetail;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 시험 상세 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectExamDetailResponse {
+
+    /** 시험 유형 */
+    private final String examType;
+    /** 대학 전공 계열 */
+    private final String univMajorField;
+    /** 대학 전공명 */
+    private final String univMajorName;
+    /** 대학 과목 유형 */
+    private final String univCourseType;
+    /** 중고등 학년 */
+    private final String mhGrade;
+    /** 중고등 과목 유형 */
+    private final String mhSubjectType;
+    /** 자격증 식별자 */
+    private final Long certificateId;
+    /** 직접 입력 자격증명 */
+    private final String certificateName;
+    /** 공무원 급수 */
+    private final String civilRank;
+    /** 공무원 직렬 */
+    private final String civilSeries;
+    /** 어학 언어 */
+    private final String langType;
+    /** 어학 시험명 */
+    private final String langExamName;
+    /** 기타 시험명 */
+    private final String otherExamName;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static SubjectExamDetailResponse from(SubjectExamDetail detail) {
+        return SubjectExamDetailResponse.builder()
+                .examType(detail.getExamType())
+                .univMajorField(detail.getUnivMajorField())
+                .univMajorName(detail.getUnivMajorName())
+                .univCourseType(detail.getUnivCourseType())
+                .mhGrade(detail.getMhGrade())
+                .mhSubjectType(detail.getMhSubjectType())
+                .certificateId(detail.getCertificateId())
+                .certificateName(detail.getCertificateName())
+                .civilRank(detail.getCivilRank())
+                .civilSeries(detail.getCivilSeries())
+                .langType(detail.getLangType())
+                .langExamName(detail.getLangExamName())
+                .otherExamName(detail.getOtherExamName())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamScheduleResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamScheduleResponse.java
@@ -1,0 +1,53 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.entity.SubjectExamSchedule;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 시험 일정 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectExamScheduleResponse {
+
+    /** 일정 식별자 */
+    private final String id;
+    /** 과목 식별자 */
+    private final String subjectId;
+    /** 시험명 */
+    private final String examName;
+    /** 시험일 */
+    private final LocalDate examDate;
+    /** D-Day */
+    private final Integer dDay;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static SubjectExamScheduleResponse of(SubjectExamSchedule schedule, Subject subject) {
+        String examName = schedule.getExamName();
+        return SubjectExamScheduleResponse.builder()
+                .id(schedule.getPublicId())
+                .subjectId(subject.getPublicId())
+                .examName(examName == null || examName.isBlank() ? subject.getName() : examName)
+                .examDate(schedule.getExamDate())
+                .dDay(calculateDDay(schedule.getExamDate()))
+                .build();
+    }
+
+    /**
+     * D-Day 산출
+     */
+    private static Integer calculateDDay(LocalDate examDate) {
+        long remainDays = ChronoUnit.DAYS.between(LocalDate.now(), examDate);
+        // 지난 시험일 제외
+        if (remainDays < 0) {
+            return null;
+        }
+        return Math.toIntExact(remainDays);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamScheduleUpsertRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamScheduleUpsertRequest.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 시험 일정 저장 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectExamScheduleUpsertRequest {
+
+    /** 시험명 */
+    @Size(max = 100, message = "시험명은 100자 이하여야 합니다")
+    private String examName;
+
+    /** 시험일 */
+    @NotNull(message = "시험 날짜는 필수입니다")
+    private LocalDate examDate;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectNameUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectNameUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 과목명 수정 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectNameUpdateRequest {
+
+    /** 과목명 */
+    @NotBlank(message = "과목명을 입력해주세요")
+    @Size(max = 30, message = "과목명은 30자 이하여야 합니다")
+    private String name;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectOtherDetailRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectOtherDetailRequest.java
@@ -1,0 +1,22 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 과목 기타 상세 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectOtherDetailRequest {
+
+    /** 이용 목적 */
+    @NotBlank(message = "이용 목적은 필수입니다")
+    private String usagePurpose;
+
+    /** 추가 설명 */
+    @Size(min = 1, max = 100, message = "추가 설명은 1자 이상 100자 이하여야 합니다")
+    private String description;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectOtherDetailResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectOtherDetailResponse.java
@@ -1,0 +1,28 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.SubjectOtherDetail;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 기타 상세 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectOtherDetailResponse {
+
+    /** 이용 목적 */
+    private final String usagePurpose;
+    /** 추가 설명 */
+    private final String description;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static SubjectOtherDetailResponse from(SubjectOtherDetail detail) {
+        return SubjectOtherDetailResponse.builder()
+                .usagePurpose(detail.getUsagePurpose())
+                .description(detail.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectPageResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectPageResponse.java
@@ -1,0 +1,26 @@
+package com.f1.quiket.domain.subject.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 페이지 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectPageResponse {
+
+    /** 현재 페이지 번호 */
+    private final Integer page;
+    /** 페이지 크기 */
+    private final Integer size;
+    /** 전체 건수 */
+    private final Long totalElements;
+    /** 전체 페이지 수 */
+    private final Integer totalPages;
+    /** 마지막 페이지 여부 */
+    private final Boolean last;
+    /** 과목 목록 */
+    private final List<SubjectSummaryResponse> content;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectPurposeDetailResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectPurposeDetailResponse.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.subject.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 목적별 상세 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectPurposeDetailResponse {
+
+    /** 시험 상세 */
+    private final SubjectExamDetailResponse examDetail;
+    /** 복습 상세 */
+    private final SubjectReviewDetailResponse reviewDetail;
+    /** 기타 상세 */
+    private final SubjectOtherDetailResponse otherDetail;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectResponse.java
@@ -1,0 +1,38 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.Subject;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 기본 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectResponse {
+
+    /** 과목 식별자 */
+    private final String id;
+    /** 과목명 */
+    private final String name;
+    /** 학습 목적 */
+    private final String purpose;
+    /** 목적별 상세 */
+    private final SubjectPurposeDetailResponse detail;
+    /** 생성 시각 */
+    private final LocalDateTime createdAt;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static SubjectResponse of(Subject subject, SubjectPurposeDetailResponse detail) {
+        return SubjectResponse.builder()
+                .id(subject.getPublicId())
+                .name(subject.getName())
+                .purpose(subject.getPurpose())
+                .detail(detail)
+                .createdAt(subject.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectReviewDetailRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectReviewDetailRequest.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 과목 복습 상세 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectReviewDetailRequest {
+
+    /** 학습 분야 */
+    @NotBlank(message = "분야는 필수입니다")
+    @Size(max = 30, message = "분야는 30자 이하여야 합니다")
+    private String field;
+
+    /** 학습 정도 */
+    @NotBlank(message = "학습 정도는 필수입니다")
+    private String studyLevel;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectReviewDetailResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectReviewDetailResponse.java
@@ -1,0 +1,28 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.SubjectReviewDetail;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 복습 상세 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectReviewDetailResponse {
+
+    /** 학습 분야 */
+    private final String field;
+    /** 학습 정도 */
+    private final String studyLevel;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static SubjectReviewDetailResponse from(SubjectReviewDetail detail) {
+        return SubjectReviewDetailResponse.builder()
+                .field(detail.getField())
+                .studyLevel(detail.getStudyLevel())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectSummaryResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.f1.quiket.domain.subject.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 요약 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectSummaryResponse {
+
+    /** 과목 식별자 */
+    private final String id;
+    /** 과목명 */
+    private final String name;
+    /** 학습 목적 */
+    private final String purpose;
+    /** 챕터 수 */
+    private final Integer chapterCount;
+    /** 파트 수 */
+    private final Integer partCount;
+    /** 마지막 활동 시각 */
+    private final LocalDateTime lastActivityAt;
+    /** 시험 일정 */
+    private final SubjectExamScheduleResponse examSchedule;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/Certificate.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/Certificate.java
@@ -1,0 +1,54 @@
+package com.f1.quiket.domain.subject.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 자격증 마스터 엔티티
+ */
+@Entity
+@Table(
+        name = "certificates",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_certificates_name", columnNames = "name")
+        },
+        indexes = {
+                @Index(name = "idx_certificates_is_featured_display_order", columnList = "is_featured, display_order")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Certificate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "name", length = 100, nullable = false)
+    String name;
+
+    @Column(name = "is_featured", nullable = false)
+    Boolean featured;
+
+    @Column(name = "display_order", nullable = false)
+    Integer displayOrder;
+
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/Subject.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/Subject.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.subject.entity;
 
 import com.f1.quiket.global.entity.BaseEntity;
+import com.f1.quiket.global.util.UuidV7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
@@ -41,4 +42,30 @@ public class Subject extends BaseEntity {
 
     @Column(name = "purpose", length = 20, nullable = false)
     String purpose;
+
+    /**
+     * 과목 생성
+     */
+    public static Subject create(Long userId, String name, String purpose) {
+        Subject subject = new Subject();
+        subject.publicId = UuidV7Generator.generate();
+        subject.userId = userId;
+        subject.name = name;
+        subject.purpose = purpose;
+        return subject;
+    }
+
+    /**
+     * 과목명 변경
+     */
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 과목 상세 유형 변경
+     */
+    public void updatePurpose(String purpose) {
+        this.purpose = purpose;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/subject/entity/SubjectExamDetail.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/SubjectExamDetail.java
@@ -1,0 +1,103 @@
+package com.f1.quiket.domain.subject.entity;
+
+import com.f1.quiket.domain.subject.dto.SubjectExamDetailRequest;
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 과목 시험 상세 엔티티
+ */
+@Entity
+@Table(
+        name = "subject_exam_details",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_subject_exam_details_subject_id", columnNames = "subject_id")
+        },
+        indexes = {
+                @Index(name = "idx_subject_exam_details_exam_type", columnList = "exam_type")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SubjectExamDetail extends BaseEntity {
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "exam_type", length = 20, nullable = false)
+    String examType;
+
+    @Column(name = "univ_major_field", length = 30)
+    String univMajorField;
+
+    @Column(name = "univ_major_name", length = 30)
+    String univMajorName;
+
+    @Column(name = "univ_course_type", length = 20)
+    String univCourseType;
+
+    @Column(name = "mh_grade", length = 10)
+    String mhGrade;
+
+    @Column(name = "mh_subject_type", length = 30)
+    String mhSubjectType;
+
+    @Column(name = "certificate_id")
+    Long certificateId;
+
+    @Column(name = "certificate_name", length = 100)
+    String certificateName;
+
+    @Column(name = "civil_rank", length = 20)
+    String civilRank;
+
+    @Column(name = "civil_series", length = 30)
+    String civilSeries;
+
+    @Column(name = "lang_type", length = 20)
+    String langType;
+
+    @Column(name = "lang_exam_name", length = 30)
+    String langExamName;
+
+    @Column(name = "other_exam_name", length = 30)
+    String otherExamName;
+
+    /**
+     * 시험 상세 생성
+     */
+    public static SubjectExamDetail create(Long subjectId, SubjectExamDetailRequest request) {
+        SubjectExamDetail detail = new SubjectExamDetail();
+        detail.subjectId = subjectId;
+        detail.update(request);
+        return detail;
+    }
+
+    /**
+     * 시험 상세 변경
+     */
+    public void update(SubjectExamDetailRequest request) {
+        this.examType = request.getExamType();
+        this.univMajorField = request.getUnivMajorField();
+        this.univMajorName = request.getUnivMajorName();
+        this.univCourseType = request.getUnivCourseType();
+        this.mhGrade = request.getMhGrade();
+        this.mhSubjectType = request.getMhSubjectType();
+        this.certificateId = request.getCertificateId();
+        this.certificateName = request.getCertificateName();
+        this.civilRank = request.getCivilRank();
+        this.civilSeries = request.getCivilSeries();
+        this.langType = request.getLangType();
+        this.langExamName = request.getLangExamName();
+        this.otherExamName = request.getOtherExamName();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/SubjectExamSchedule.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/SubjectExamSchedule.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.subject.entity;
 
 import com.f1.quiket.global.entity.BaseEntity;
+import com.f1.quiket.global.util.UuidV7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
@@ -46,4 +47,26 @@ public class SubjectExamSchedule extends BaseEntity {
 
     @Column(name = "exam_date", nullable = false)
     LocalDate examDate;
+
+    /**
+     * 시험 일정 생성
+     */
+    public static SubjectExamSchedule create(Long subjectId, Long userId, String examName, LocalDate examDate) {
+        SubjectExamSchedule schedule = new SubjectExamSchedule();
+        schedule.publicId = UuidV7Generator.generate();
+        schedule.subjectId = subjectId;
+        schedule.userId = userId;
+        schedule.examName = examName;
+        schedule.examDate = examDate;
+        return schedule;
+    }
+
+    /**
+     * 시험 일정 변경
+     */
+    public void update(String examName, LocalDate examDate) {
+        this.examName = examName;
+        this.examDate = examDate;
+        restore();
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/subject/entity/SubjectOtherDetail.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/SubjectOtherDetail.java
@@ -1,0 +1,55 @@
+package com.f1.quiket.domain.subject.entity;
+
+import com.f1.quiket.domain.subject.dto.SubjectOtherDetailRequest;
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 과목 기타 상세 엔티티
+ */
+@Entity
+@Table(
+        name = "subject_other_details",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_subject_other_details_subject_id", columnNames = "subject_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SubjectOtherDetail extends BaseEntity {
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "usage_purpose", length = 30, nullable = false)
+    String usagePurpose;
+
+    @Column(name = "description", length = 100)
+    String description;
+
+    /**
+     * 기타 상세 생성
+     */
+    public static SubjectOtherDetail create(Long subjectId, SubjectOtherDetailRequest request) {
+        SubjectOtherDetail detail = new SubjectOtherDetail();
+        detail.subjectId = subjectId;
+        detail.update(request);
+        return detail;
+    }
+
+    /**
+     * 기타 상세 변경
+     */
+    public void update(SubjectOtherDetailRequest request) {
+        this.usagePurpose = request.getUsagePurpose();
+        this.description = request.getDescription();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/SubjectReviewDetail.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/SubjectReviewDetail.java
@@ -1,0 +1,55 @@
+package com.f1.quiket.domain.subject.entity;
+
+import com.f1.quiket.domain.subject.dto.SubjectReviewDetailRequest;
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 과목 복습 상세 엔티티
+ */
+@Entity
+@Table(
+        name = "subject_review_details",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_subject_review_details_subject_id", columnNames = "subject_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SubjectReviewDetail extends BaseEntity {
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "field", length = 30, nullable = false)
+    String field;
+
+    @Column(name = "study_level", length = 30, nullable = false)
+    String studyLevel;
+
+    /**
+     * 복습 상세 생성
+     */
+    public static SubjectReviewDetail create(Long subjectId, SubjectReviewDetailRequest request) {
+        SubjectReviewDetail detail = new SubjectReviewDetail();
+        detail.subjectId = subjectId;
+        detail.update(request);
+        return detail;
+    }
+
+    /**
+     * 복습 상세 변경
+     */
+    public void update(SubjectReviewDetailRequest request) {
+        this.field = request.getField();
+        this.studyLevel = request.getStudyLevel();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/type/ExamType.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/type/ExamType.java
@@ -1,0 +1,29 @@
+package com.f1.quiket.domain.subject.entity.type;
+
+import java.util.Arrays;
+
+/**
+ * 시험 유형
+ */
+public enum ExamType {
+
+    UNIVERSITY("university"),
+    MIDDLE_HIGH("middle_high"),
+    CERTIFICATE("certificate"),
+    CIVIL_SERVICE("civil_service"),
+    LANGUAGE("language"),
+    OTHER_EXAM("other_exam");
+
+    private final String value;
+
+    ExamType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * 문자열 enum 검증
+     */
+    public static boolean contains(String value) {
+        return Arrays.stream(values()).anyMatch(type -> type.value.equals(value));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/type/StudyLevel.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/type/StudyLevel.java
@@ -1,0 +1,27 @@
+package com.f1.quiket.domain.subject.entity.type;
+
+import java.util.Arrays;
+
+/**
+ * 학습 정도
+ */
+public enum StudyLevel {
+
+    BEGINNER("beginner"),
+    CASUAL("casual"),
+    REGULAR("regular"),
+    EXPERT("expert");
+
+    private final String value;
+
+    StudyLevel(String value) {
+        this.value = value;
+    }
+
+    /**
+     * 문자열 enum 검증
+     */
+    public static boolean contains(String value) {
+        return Arrays.stream(values()).anyMatch(level -> level.value.equals(value));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/type/SubjectPurpose.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/type/SubjectPurpose.java
@@ -1,0 +1,33 @@
+package com.f1.quiket.domain.subject.entity.type;
+
+import java.util.Arrays;
+
+/**
+ * 과목 학습 목적
+ */
+public enum SubjectPurpose {
+
+    EXAM("exam"),
+    REVIEW("review"),
+    OTHER("other");
+
+    private final String value;
+
+    SubjectPurpose(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    /**
+     * 문자열 enum 변환
+     */
+    public static SubjectPurpose from(String value) {
+        return Arrays.stream(values())
+                .filter(purpose -> purpose.value.equals(value))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/type/UsagePurpose.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/type/UsagePurpose.java
@@ -1,0 +1,28 @@
+package com.f1.quiket.domain.subject.entity.type;
+
+import java.util.Arrays;
+
+/**
+ * 기타 이용 목적
+ */
+public enum UsagePurpose {
+
+    WORK("work"),
+    PERSONAL("personal"),
+    HOBBY("hobby"),
+    MEMORY("memory"),
+    OTHER("other");
+
+    private final String value;
+
+    UsagePurpose(String value) {
+        this.value = value;
+    }
+
+    /**
+     * 문자열 enum 검증
+     */
+    public static boolean contains(String value) {
+        return Arrays.stream(values()).anyMatch(purpose -> purpose.value.equals(value));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/repository/CertificateRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/CertificateRepository.java
@@ -1,0 +1,33 @@
+package com.f1.quiket.domain.subject.repository;
+
+import com.f1.quiket.domain.subject.entity.Certificate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 자격증 마스터 리포지토리
+ */
+@Repository
+public interface CertificateRepository extends JpaRepository<Certificate, Long> {
+
+    /**
+     * 전체 자격증 목록 조회
+     */
+    List<Certificate> findAllByOrderByDisplayOrderAscNameAsc();
+
+    /**
+     * 자주 찾는 자격증 목록 조회
+     */
+    List<Certificate> findAllByFeaturedTrueOrderByDisplayOrderAscNameAsc();
+
+    /**
+     * 자격증명 검색
+     */
+    List<Certificate> findAllByNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc(String keyword);
+
+    /**
+     * 자주 찾는 자격증명 검색
+     */
+    List<Certificate> findAllByFeaturedTrueAndNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc(String keyword);
+}

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamDetailRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamDetailRepository.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.subject.repository;
+
+import com.f1.quiket.domain.subject.entity.SubjectExamDetail;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 과목 시험 상세 리포지토리
+ */
+@Repository
+public interface SubjectExamDetailRepository extends JpaRepository<SubjectExamDetail, Long> {
+
+    /**
+     * 과목 시험 상세 조회
+     */
+    Optional<SubjectExamDetail> findBySubjectId(Long subjectId);
+
+    /**
+     * 과목 시험 상세 삭제
+     */
+    void deleteBySubjectId(Long subjectId);
+}

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamScheduleRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamScheduleRepository.java
@@ -4,6 +4,7 @@ import com.f1.quiket.domain.subject.entity.SubjectExamSchedule;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -27,4 +28,14 @@ public interface SubjectExamScheduleRepository extends JpaRepository<SubjectExam
      * 과목별 일정 목록 조회
      */
     List<SubjectExamSchedule> findAllBySubjectIdInAndDeletedAtIsNull(Collection<Long> subjectIds);
+
+    /**
+     * 과목 일정 조회
+     */
+    Optional<SubjectExamSchedule> findBySubjectIdAndDeletedAtIsNull(Long subjectId);
+
+    /**
+     * 과목 일정 전체 조회
+     */
+    Optional<SubjectExamSchedule> findBySubjectId(Long subjectId);
 }

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectOtherDetailRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectOtherDetailRepository.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.subject.repository;
+
+import com.f1.quiket.domain.subject.entity.SubjectOtherDetail;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 과목 기타 상세 리포지토리
+ */
+@Repository
+public interface SubjectOtherDetailRepository extends JpaRepository<SubjectOtherDetail, Long> {
+
+    /**
+     * 과목 기타 상세 조회
+     */
+    Optional<SubjectOtherDetail> findBySubjectId(Long subjectId);
+
+    /**
+     * 과목 기타 상세 삭제
+     */
+    void deleteBySubjectId(Long subjectId);
+}

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
@@ -28,11 +28,6 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
      * 공개 식별자 기반 사용자 과목 조회
      */
     Optional<Subject> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
-    
-    /**
-     * 사용자 과목 단건 조회
-     */
-    Optional<Subject> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
 
     /**
      * 사용자 과목 단건 조회 (PK 기반)

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
@@ -2,6 +2,9 @@ package com.f1.quiket.domain.subject.repository;
 
 import com.f1.quiket.domain.subject.entity.Subject;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +18,14 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
      * 사용자 과목 목록 조회
      */
     List<Subject> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 사용자 과목 페이지 조회
+     */
+    Page<Subject> findByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
+
+    /**
+     * 공개 식별자 기반 사용자 과목 조회
+     */
+    Optional<Subject> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectReviewDetailRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectReviewDetailRepository.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.subject.repository;
+
+import com.f1.quiket.domain.subject.entity.SubjectReviewDetail;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 과목 복습 상세 리포지토리
+ */
+@Repository
+public interface SubjectReviewDetailRepository extends JpaRepository<SubjectReviewDetail, Long> {
+
+    /**
+     * 과목 복습 상세 조회
+     */
+    Optional<SubjectReviewDetail> findBySubjectId(Long subjectId);
+
+    /**
+     * 과목 복습 상세 삭제
+     */
+    void deleteBySubjectId(Long subjectId);
+}

--- a/src/main/java/com/f1/quiket/domain/subject/service/CertificateService.java
+++ b/src/main/java/com/f1/quiket/domain/subject/service/CertificateService.java
@@ -1,0 +1,44 @@
+package com.f1.quiket.domain.subject.service;
+
+import com.f1.quiket.domain.subject.dto.CertificateResponse;
+import com.f1.quiket.domain.subject.entity.Certificate;
+import com.f1.quiket.domain.subject.repository.CertificateRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * 자격증 마스터 조회 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class CertificateService {
+
+    private final CertificateRepository certificateRepository;
+
+    /**
+     * 자격증 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<CertificateResponse> getCertificates(Boolean featured, String keyword) {
+        boolean featuredOnly = Boolean.TRUE.equals(featured);
+        List<Certificate> certificates;
+
+        // featured와 keyword 조합별 JPA 기본 메서드 사용
+        if (featuredOnly && StringUtils.hasText(keyword)) {
+            certificates = certificateRepository.findAllByFeaturedTrueAndNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc(keyword);
+        } else if (featuredOnly) {
+            certificates = certificateRepository.findAllByFeaturedTrueOrderByDisplayOrderAscNameAsc();
+        } else if (StringUtils.hasText(keyword)) {
+            certificates = certificateRepository.findAllByNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc(keyword);
+        } else {
+            certificates = certificateRepository.findAllByOrderByDisplayOrderAscNameAsc();
+        }
+
+        return certificates.stream()
+                .map(CertificateResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/f1/quiket/domain/subject/service/SubjectService.java
@@ -1,0 +1,445 @@
+package com.f1.quiket.domain.subject.service;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.dto.ChapterWithPartsResponse;
+import com.f1.quiket.domain.subject.dto.PartSummaryResponse;
+import com.f1.quiket.domain.subject.dto.QuizScopeResponse;
+import com.f1.quiket.domain.subject.dto.SubjectCreateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectDetailUpdateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectExamDetailRequest;
+import com.f1.quiket.domain.subject.dto.SubjectExamDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleResponse;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleUpsertRequest;
+import com.f1.quiket.domain.subject.dto.SubjectOtherDetailRequest;
+import com.f1.quiket.domain.subject.dto.SubjectOtherDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectPageResponse;
+import com.f1.quiket.domain.subject.dto.SubjectPurposeDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectResponse;
+import com.f1.quiket.domain.subject.dto.SubjectReviewDetailRequest;
+import com.f1.quiket.domain.subject.dto.SubjectReviewDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectSummaryResponse;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.entity.SubjectExamDetail;
+import com.f1.quiket.domain.subject.entity.SubjectExamSchedule;
+import com.f1.quiket.domain.subject.entity.SubjectOtherDetail;
+import com.f1.quiket.domain.subject.entity.SubjectReviewDetail;
+import com.f1.quiket.domain.subject.entity.type.ExamType;
+import com.f1.quiket.domain.subject.entity.type.StudyLevel;
+import com.f1.quiket.domain.subject.entity.type.SubjectPurpose;
+import com.f1.quiket.domain.subject.entity.type.UsagePurpose;
+import com.f1.quiket.domain.subject.repository.SubjectExamDetailRepository;
+import com.f1.quiket.domain.subject.repository.SubjectExamScheduleRepository;
+import com.f1.quiket.domain.subject.repository.SubjectOtherDetailRepository;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.subject.repository.SubjectReviewDetailRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * 과목 비즈니스 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class SubjectService {
+
+    private static final int MIN_PAGE = 0;
+    private static final int MIN_SIZE = 1;
+    private static final int MAX_SIZE = 100;
+
+    private final UserRepository userRepository;
+    private final SubjectRepository subjectRepository;
+    private final SubjectExamDetailRepository subjectExamDetailRepository;
+    private final SubjectReviewDetailRepository subjectReviewDetailRepository;
+    private final SubjectOtherDetailRepository subjectOtherDetailRepository;
+    private final SubjectExamScheduleRepository subjectExamScheduleRepository;
+    private final ChapterRepository chapterRepository;
+    private final PartRepository partRepository;
+    private final QuizSessionRepository quizSessionRepository;
+
+    /**
+     * 과목 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public SubjectPageResponse getSubjects(String userPublicId, int page, int size) {
+        User user = findUser(userPublicId);
+        PageRequest pageRequest = PageRequest.of(normalizePage(page), normalizeSize(size), Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Subject> subjectPage = subjectRepository.findByUserIdAndDeletedAtIsNull(user.getId(), pageRequest);
+        List<Subject> subjects = subjectPage.getContent();
+        List<Long> subjectIds = subjects.stream().map(Subject::getId).toList();
+
+        if (subjectIds.isEmpty()) {
+            return SubjectPageResponse.builder()
+                    .page(subjectPage.getNumber())
+                    .size(subjectPage.getSize())
+                    .totalElements(subjectPage.getTotalElements())
+                    .totalPages(subjectPage.getTotalPages())
+                    .last(subjectPage.isLast())
+                    .content(List.of())
+                    .build();
+        }
+
+        Map<Long, Long> chapterCounts = chapterRepository.findAllBySubjectIdInAndDeletedAtIsNull(subjectIds).stream()
+                .collect(Collectors.groupingBy(Chapter::getSubjectId, Collectors.counting()));
+        Map<Long, Long> partCounts = partRepository.findAllBySubjectIdInAndDeletedAtIsNull(subjectIds).stream()
+                .collect(Collectors.groupingBy(Part::getSubjectId, Collectors.counting()));
+        Map<Long, SubjectExamSchedule> schedules = subjectExamScheduleRepository.findAllBySubjectIdInAndDeletedAtIsNull(subjectIds).stream()
+                .collect(Collectors.toMap(SubjectExamSchedule::getSubjectId, Function.identity()));
+
+        List<SubjectSummaryResponse> content = subjects.stream()
+                .map(subject -> toSummary(subject, chapterCounts, partCounts, schedules))
+                .toList();
+
+        return SubjectPageResponse.builder()
+                .page(subjectPage.getNumber())
+                .size(subjectPage.getSize())
+                .totalElements(subjectPage.getTotalElements())
+                .totalPages(subjectPage.getTotalPages())
+                .last(subjectPage.isLast())
+                .content(content)
+                .build();
+    }
+
+    /**
+     * 과목 생성
+     */
+    @Transactional
+    public SubjectResponse createSubject(String userPublicId, SubjectCreateRequest request) {
+        User user = findUser(userPublicId);
+        SubjectPurpose purpose = validatePurpose(request);
+        Subject subject = subjectRepository.save(Subject.create(user.getId(), request.getName(), purpose.value()));
+        saveDetail(subject.getId(), purpose, request);
+        return SubjectResponse.of(subject, getPurposeDetail(subject));
+    }
+
+    /**
+     * 과목 상세 조회
+     */
+    @Transactional(readOnly = true)
+    public SubjectDetailResponse getSubject(String userPublicId, String subjectPublicId) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        return toDetail(subject);
+    }
+
+    /**
+     * 퀴즈 출제 범위 조회
+     */
+    @Transactional(readOnly = true)
+    public QuizScopeResponse getQuizScope(String userPublicId, String subjectPublicId) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        return QuizScopeResponse.builder()
+                .subjectId(subject.getPublicId())
+                .subjectName(subject.getName())
+                .chapters(getChapterWithParts(subject))
+                .build();
+    }
+
+    /**
+     * 과목명 수정
+     */
+    @Transactional
+    public SubjectResponse updateSubjectName(String userPublicId, String subjectPublicId, String name) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        subject.updateName(name);
+        return SubjectResponse.of(subject, getPurposeDetail(subject));
+    }
+
+    /**
+     * 과목 상세 수정
+     */
+    @Transactional
+    public SubjectDetailResponse updateSubjectDetails(String userPublicId, String subjectPublicId, SubjectDetailUpdateRequest request) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        SubjectPurpose purpose = validatePurpose(request);
+        subject.updatePurpose(purpose.value());
+        replaceDetails(subject.getId(), purpose, request);
+        return toDetail(subject);
+    }
+
+    /**
+     * 시험 일정 등록 또는 수정
+     */
+    @Transactional
+    public SubjectExamScheduleResponse upsertExamSchedule(String userPublicId, String subjectPublicId, SubjectExamScheduleUpsertRequest request) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        SubjectExamSchedule schedule = subjectExamScheduleRepository.findBySubjectId(subject.getId())
+                .map(existingSchedule -> {
+                    existingSchedule.update(normalizeBlank(request.getExamName()), request.getExamDate());
+                    return existingSchedule;
+                })
+                .orElseGet(() -> subjectExamScheduleRepository.save(
+                        SubjectExamSchedule.create(subject.getId(), user.getId(), normalizeBlank(request.getExamName()), request.getExamDate())
+                ));
+        return SubjectExamScheduleResponse.of(schedule, subject);
+    }
+
+    /**
+     * 시험 일정 삭제
+     */
+    @Transactional
+    public void deleteExamSchedule(String userPublicId, String subjectPublicId) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        SubjectExamSchedule schedule = subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+        schedule.delete();
+    }
+
+    /**
+     * 과목 삭제
+     */
+    @Transactional
+    public void deleteSubject(String userPublicId, String subjectPublicId) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+
+        // 하위 데이터 soft delete
+        subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId()).ifPresent(SubjectExamSchedule::delete);
+        chapterRepository.findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId()).forEach(Chapter::delete);
+        partRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId()).forEach(Part::delete);
+        quizSessionRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId()).forEach(session -> session.delete());
+
+        subject.delete();
+    }
+
+    /**
+     * 사용자 조회
+     */
+    private User findUser(String userPublicId) {
+        return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    /**
+     * 소유 과목 조회
+     */
+    private Subject findSubject(String subjectPublicId, Long userId) {
+        return subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subjectPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+    }
+
+    /**
+     * 과목 상세 응답 변환
+     */
+    private SubjectDetailResponse toDetail(Subject subject) {
+        List<ChapterWithPartsResponse> chapterResponses = getChapterWithParts(subject);
+
+        SubjectExamScheduleResponse scheduleResponse = subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId())
+                .map(schedule -> SubjectExamScheduleResponse.of(schedule, subject))
+                .orElse(null);
+
+        return SubjectDetailResponse.builder()
+                .id(subject.getPublicId())
+                .name(subject.getName())
+                .purpose(subject.getPurpose())
+                .detail(getPurposeDetail(subject))
+                .createdAt(subject.getCreatedAt())
+                .examSchedule(scheduleResponse)
+                .chapters(chapterResponses)
+                .build();
+    }
+
+    /**
+     * 챕터와 파트 응답 목록 생성
+     */
+    private List<ChapterWithPartsResponse> getChapterWithParts(Subject subject) {
+        List<Chapter> chapters = chapterRepository.findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId());
+        if (chapters.isEmpty()) {
+            return List.of();
+        }
+        Map<Long, Chapter> chapterMap = chapters.stream().collect(Collectors.toMap(Chapter::getId, Function.identity()));
+        Map<Long, List<Part>> partMap = partRepository.findAllByChapterIdInAndDeletedAtIsNull(chapters.stream().map(Chapter::getId).toList()).stream()
+                .sorted(Comparator.comparing(Part::getPartNumber).thenComparing(Part::getCreatedAt))
+                .collect(Collectors.groupingBy(Part::getChapterId));
+
+        return chapters.stream()
+                .map(chapter -> ChapterWithPartsResponse.of(
+                        chapter,
+                        subject.getPublicId(),
+                        partMap.getOrDefault(chapter.getId(), List.of()).stream()
+                                .map(part -> PartSummaryResponse.of(part, chapterMap.get(part.getChapterId())))
+                                .toList()
+                ))
+                .toList();
+    }
+
+    /**
+     * 과목 요약 응답 변환
+     */
+    private SubjectSummaryResponse toSummary(
+            Subject subject,
+            Map<Long, Long> chapterCounts,
+            Map<Long, Long> partCounts,
+            Map<Long, SubjectExamSchedule> schedules
+    ) {
+        SubjectExamSchedule schedule = schedules.get(subject.getId());
+        return SubjectSummaryResponse.builder()
+                .id(subject.getPublicId())
+                .name(subject.getName())
+                .purpose(subject.getPurpose())
+                .chapterCount(Math.toIntExact(chapterCounts.getOrDefault(subject.getId(), 0L)))
+                .partCount(Math.toIntExact(partCounts.getOrDefault(subject.getId(), 0L)))
+                .lastActivityAt(subject.getUpdatedAt())
+                .examSchedule(schedule == null ? null : SubjectExamScheduleResponse.of(schedule, subject))
+                .build();
+    }
+
+    /**
+     * 목적별 상세 조회
+     */
+    private SubjectPurposeDetailResponse getPurposeDetail(Subject subject) {
+        SubjectPurpose purpose = SubjectPurpose.from(subject.getPurpose());
+        if (purpose == SubjectPurpose.EXAM) {
+            return SubjectPurposeDetailResponse.builder()
+                    .examDetail(subjectExamDetailRepository.findBySubjectId(subject.getId())
+                            .map(SubjectExamDetailResponse::from)
+                            .orElse(null))
+                    .build();
+        }
+        if (purpose == SubjectPurpose.REVIEW) {
+            return SubjectPurposeDetailResponse.builder()
+                    .reviewDetail(subjectReviewDetailRepository.findBySubjectId(subject.getId())
+                            .map(SubjectReviewDetailResponse::from)
+                            .orElse(null))
+                    .build();
+        }
+        return SubjectPurposeDetailResponse.builder()
+                .otherDetail(subjectOtherDetailRepository.findBySubjectId(subject.getId())
+                        .map(SubjectOtherDetailResponse::from)
+                        .orElse(null))
+                .build();
+    }
+
+    /**
+     * 목적별 상세 저장
+     */
+    private void saveDetail(Long subjectId, SubjectPurpose purpose, SubjectCreateRequest request) {
+        if (purpose == SubjectPurpose.EXAM) {
+            SubjectExamDetailRequest detail = validateExamDetail(request.getExamDetail());
+            subjectExamDetailRepository.save(SubjectExamDetail.create(subjectId, detail));
+            return;
+        }
+        if (purpose == SubjectPurpose.REVIEW) {
+            SubjectReviewDetailRequest detail = validateReviewDetail(request.getReviewDetail());
+            subjectReviewDetailRepository.save(SubjectReviewDetail.create(subjectId, detail));
+            return;
+        }
+        SubjectOtherDetailRequest detail = validateOtherDetail(request.getOtherDetail());
+        subjectOtherDetailRepository.save(SubjectOtherDetail.create(subjectId, detail));
+    }
+
+    /**
+     * 목적별 상세 교체
+     */
+    private void replaceDetails(Long subjectId, SubjectPurpose purpose, SubjectCreateRequest request) {
+        if (purpose == SubjectPurpose.EXAM) {
+            SubjectExamDetailRequest detail = validateExamDetail(request.getExamDetail());
+            subjectReviewDetailRepository.deleteBySubjectId(subjectId);
+            subjectOtherDetailRepository.deleteBySubjectId(subjectId);
+            subjectExamDetailRepository.findBySubjectId(subjectId)
+                    .ifPresentOrElse(existingDetail -> existingDetail.update(detail),
+                            () -> subjectExamDetailRepository.save(SubjectExamDetail.create(subjectId, detail)));
+            return;
+        }
+        if (purpose == SubjectPurpose.REVIEW) {
+            SubjectReviewDetailRequest detail = validateReviewDetail(request.getReviewDetail());
+            subjectExamDetailRepository.deleteBySubjectId(subjectId);
+            subjectOtherDetailRepository.deleteBySubjectId(subjectId);
+            subjectReviewDetailRepository.findBySubjectId(subjectId)
+                    .ifPresentOrElse(existingDetail -> existingDetail.update(detail),
+                            () -> subjectReviewDetailRepository.save(SubjectReviewDetail.create(subjectId, detail)));
+            return;
+        }
+        SubjectOtherDetailRequest detail = validateOtherDetail(request.getOtherDetail());
+        subjectExamDetailRepository.deleteBySubjectId(subjectId);
+        subjectReviewDetailRepository.deleteBySubjectId(subjectId);
+        subjectOtherDetailRepository.findBySubjectId(subjectId)
+                .ifPresentOrElse(existingDetail -> existingDetail.update(detail),
+                        () -> subjectOtherDetailRepository.save(SubjectOtherDetail.create(subjectId, detail)));
+    }
+
+    /**
+     * 학습 목적 검증
+     */
+    private SubjectPurpose validatePurpose(SubjectCreateRequest request) {
+        try {
+            return SubjectPurpose.from(request.getPurpose());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "지원하지 않는 학습 목적입니다.");
+        }
+    }
+
+    /**
+     * 시험 상세 검증
+     */
+    private SubjectExamDetailRequest validateExamDetail(SubjectExamDetailRequest detail) {
+        if (detail == null || !StringUtils.hasText(detail.getExamType()) || !ExamType.contains(detail.getExamType())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "시험 상세 정보가 올바르지 않습니다.");
+        }
+        return detail;
+    }
+
+    /**
+     * 복습 상세 검증
+     */
+    private SubjectReviewDetailRequest validateReviewDetail(SubjectReviewDetailRequest detail) {
+        if (detail == null || !StudyLevel.contains(detail.getStudyLevel())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "복습 상세 정보가 올바르지 않습니다.");
+        }
+        return detail;
+    }
+
+    /**
+     * 기타 상세 검증
+     */
+    private SubjectOtherDetailRequest validateOtherDetail(SubjectOtherDetailRequest detail) {
+        if (detail == null || !UsagePurpose.contains(detail.getUsagePurpose())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "기타 상세 정보가 올바르지 않습니다.");
+        }
+        return detail;
+    }
+
+    /**
+     * 페이지 번호 보정
+     */
+    private int normalizePage(int page) {
+        return Math.max(page, MIN_PAGE);
+    }
+
+    /**
+     * 페이지 크기 보정
+     */
+    private int normalizeSize(int size) {
+        return Math.min(Math.max(size, MIN_SIZE), MAX_SIZE);
+    }
+
+    /**
+     * 빈 문자열 정규화
+     */
+    private String normalizeBlank(String value) {
+        return StringUtils.hasText(value) ? value : null;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/f1/quiket/domain/subject/service/SubjectService.java
@@ -137,7 +137,7 @@ public class SubjectService {
     public SubjectDetailResponse getSubject(String userPublicId, String subjectPublicId) {
         User user = findUser(userPublicId);
         Subject subject = findSubject(subjectPublicId, user.getId());
-        return toDetail(subject);
+        return toDetail(subject, user.getId());
     }
 
     /**
@@ -150,7 +150,7 @@ public class SubjectService {
         return QuizScopeResponse.builder()
                 .subjectId(subject.getPublicId())
                 .subjectName(subject.getName())
-                .chapters(getChapterWithParts(subject))
+                .chapters(getChapterWithParts(subject, user.getId()))
                 .build();
     }
 
@@ -175,7 +175,7 @@ public class SubjectService {
         SubjectPurpose purpose = validatePurpose(request);
         subject.updatePurpose(purpose.value());
         replaceDetails(subject.getId(), purpose, request);
-        return toDetail(subject);
+        return toDetail(subject, user.getId());
     }
 
     /**
@@ -218,7 +218,8 @@ public class SubjectService {
 
         // 하위 데이터 soft delete
         subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId()).ifPresent(SubjectExamSchedule::delete);
-        chapterRepository.findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId()).forEach(Chapter::delete);
+        chapterRepository.findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId(), user.getId())
+                .forEach(Chapter::delete);
         partRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId()).forEach(Part::delete);
         quizSessionRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId()).forEach(session -> session.delete());
 
@@ -244,8 +245,8 @@ public class SubjectService {
     /**
      * 과목 상세 응답 변환
      */
-    private SubjectDetailResponse toDetail(Subject subject) {
-        List<ChapterWithPartsResponse> chapterResponses = getChapterWithParts(subject);
+    private SubjectDetailResponse toDetail(Subject subject, Long userId) {
+        List<ChapterWithPartsResponse> chapterResponses = getChapterWithParts(subject, userId);
 
         SubjectExamScheduleResponse scheduleResponse = subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId())
                 .map(schedule -> SubjectExamScheduleResponse.of(schedule, subject))
@@ -265,8 +266,11 @@ public class SubjectService {
     /**
      * 챕터와 파트 응답 목록 생성
      */
-    private List<ChapterWithPartsResponse> getChapterWithParts(Subject subject) {
-        List<Chapter> chapters = chapterRepository.findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId());
+    private List<ChapterWithPartsResponse> getChapterWithParts(Subject subject, Long userId) {
+        List<Chapter> chapters = chapterRepository.findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(
+                subject.getId(),
+                userId
+        );
         if (chapters.isEmpty()) {
             return List.of();
         }

--- a/src/main/resources/db/migration/V13__add_deleted_at_to_subject_detail_tables.sql
+++ b/src/main/resources/db/migration/V13__add_deleted_at_to_subject_detail_tables.sql
@@ -1,0 +1,10 @@
+-- subject 상세 테이블 soft delete 컬럼 정합성 보강
+ALTER TABLE subject_exam_details
+    ADD COLUMN deleted_at DATETIME(3) NULL COMMENT '삭제 시각' AFTER updated_at;
+
+ALTER TABLE subject_review_details
+    ADD COLUMN deleted_at DATETIME(3) NULL COMMENT '삭제 시각' AFTER updated_at;
+
+ALTER TABLE subject_other_details
+    ADD COLUMN deleted_at DATETIME(3) NULL COMMENT '삭제 시각' AFTER updated_at;
+

--- a/src/test/java/com/f1/quiket/domain/chapter/controller/ChapterControllerTest.java
+++ b/src/test/java/com/f1/quiket/domain/chapter/controller/ChapterControllerTest.java
@@ -1,0 +1,61 @@
+package com.f1.quiket.domain.chapter.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.chapter.dto.ChapterNameUpdateRequest;
+import com.f1.quiket.domain.chapter.dto.ChapterResponse;
+import com.f1.quiket.domain.chapter.service.ChapterService;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ChapterControllerTest {
+
+    private ChapterService chapterService;
+    private ChapterController chapterController;
+    private UserPrincipal principal;
+
+    @BeforeEach
+    void setUp() {
+        chapterService = mock(ChapterService.class);
+        chapterController = new ChapterController(chapterService);
+        principal = principal("user-public-id");
+    }
+
+    @Test
+    void updateChapterName_returns_ok_response() {
+        ChapterNameUpdateRequest request = new ChapterNameUpdateRequest();
+        ReflectionTestUtils.setField(request, "name", "트랜잭션");
+
+        ChapterResponse response = ChapterResponse.builder()
+                .id("chapter-public-id")
+                .subjectId("subject-public-id")
+                .name("트랜잭션")
+                .displayOrder(1)
+                .build();
+        when(chapterService.updateChapterName(principal.getPublicId(), "chapter-public-id", "트랜잭션")).thenReturn(response);
+
+        ResponseEntity<ApiResponse<ChapterResponse>> result = chapterController.updateChapterName(principal, "chapter-public-id", request);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(chapterService).updateChapterName(principal.getPublicId(), "chapter-public-id", "트랜잭션");
+    }
+
+    private UserPrincipal principal(String userPublicId) {
+        User user = User.create(userPublicId, "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return UserPrincipal.from(user);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/chapter/service/ChapterServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/chapter/service/ChapterServiceTest.java
@@ -1,0 +1,121 @@
+package com.f1.quiket.domain.chapter.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.chapter.dto.ChapterResponse;
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ChapterServiceTest {
+
+    private UserRepository userRepository;
+    private ChapterRepository chapterRepository;
+    private SubjectRepository subjectRepository;
+    private ChapterService chapterService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        chapterRepository = mock(ChapterRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        chapterService = new ChapterService(userRepository, chapterRepository, subjectRepository);
+    }
+
+    @Test
+    void updateChapterName_returns_updated_response() {
+        User user = user(1L, "user-public-id");
+        Chapter chapter = chapter(10L, "chapter-public-id", 100L, 1L, "기존 챕터", 1);
+        Subject subject = subject(100L, "subject-public-id", 1L, "데이터베이스");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(chapterRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(chapter.getPublicId(), user.getId())).thenReturn(Optional.of(chapter));
+        when(subjectRepository.findById(chapter.getSubjectId())).thenReturn(Optional.of(subject));
+
+        ChapterResponse response = chapterService.updateChapterName(user.getPublicId(), chapter.getPublicId(), "트랜잭션");
+
+        assertThat(response.getId()).isEqualTo(chapter.getPublicId());
+        assertThat(response.getSubjectId()).isEqualTo(subject.getPublicId());
+        assertThat(response.getName()).isEqualTo("트랜잭션");
+        assertThat(chapter.getName()).isEqualTo("트랜잭션");
+    }
+
+    @Test
+    void updateChapterName_throws_auth_user_not_found_when_user_missing() {
+        when(userRepository.findByPublicIdAndDeletedAtIsNull("missing-user")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chapterService.updateChapterName("missing-user", "chapter-public-id", "트랜잭션"))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
+    }
+
+    @Test
+    void updateChapterName_throws_not_found_when_chapter_missing() {
+        User user = user(1L, "user-public-id");
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(chapterRepository.findByPublicIdAndUserIdAndDeletedAtIsNull("missing-chapter", user.getId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chapterService.updateChapterName(user.getPublicId(), "missing-chapter", "트랜잭션"))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    @Test
+    void updateChapterName_throws_not_found_when_subject_missing() {
+        User user = user(1L, "user-public-id");
+        Chapter chapter = chapter(10L, "chapter-public-id", 100L, 1L, "기존 챕터", 1);
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(chapterRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(chapter.getPublicId(), user.getId())).thenReturn(Optional.of(chapter));
+        when(subjectRepository.findById(chapter.getSubjectId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chapterService.updateChapterName(user.getPublicId(), chapter.getPublicId(), "트랜잭션"))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    private User user(Long id, String publicId) {
+        User user = User.create(publicId, "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Chapter chapter(Long id, String publicId, Long subjectId, Long userId, String name, Integer displayOrder) {
+        Chapter chapter = newEntity(Chapter.class);
+        ReflectionTestUtils.setField(chapter, "id", id);
+        ReflectionTestUtils.setField(chapter, "publicId", publicId);
+        ReflectionTestUtils.setField(chapter, "subjectId", subjectId);
+        ReflectionTestUtils.setField(chapter, "userId", userId);
+        ReflectionTestUtils.setField(chapter, "name", name);
+        ReflectionTestUtils.setField(chapter, "displayOrder", displayOrder);
+        return chapter;
+    }
+
+    private Subject subject(Long id, String publicId, Long userId, String name) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/subject/controller/CertificateControllerTest.java
+++ b/src/test/java/com/f1/quiket/domain/subject/controller/CertificateControllerTest.java
@@ -1,0 +1,44 @@
+package com.f1.quiket.domain.subject.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.subject.dto.CertificateResponse;
+import com.f1.quiket.domain.subject.service.CertificateService;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class CertificateControllerTest {
+
+    private CertificateService certificateService;
+    private CertificateController certificateController;
+
+    @BeforeEach
+    void setUp() {
+        certificateService = mock(CertificateService.class);
+        certificateController = new CertificateController(certificateService);
+    }
+
+    @Test
+    void getCertificates_returns_ok_response() {
+        List<CertificateResponse> response = List.of(
+                CertificateResponse.builder().id(1L).name("정보처리기사").featured(true).displayOrder(1).build()
+        );
+        when(certificateService.getCertificates(true, "정보")).thenReturn(response);
+
+        ResponseEntity<ApiResponse<List<CertificateResponse>>> result = certificateController.getCertificates(true, "정보");
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(certificateService).getCertificates(true, "정보");
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/subject/controller/SubjectControllerTest.java
+++ b/src/test/java/com/f1/quiket/domain/subject/controller/SubjectControllerTest.java
@@ -1,0 +1,223 @@
+package com.f1.quiket.domain.subject.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.subject.dto.QuizScopeResponse;
+import com.f1.quiket.domain.subject.dto.SubjectCreateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectDetailUpdateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleResponse;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleUpsertRequest;
+import com.f1.quiket.domain.subject.dto.SubjectNameUpdateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectPageResponse;
+import com.f1.quiket.domain.subject.dto.SubjectResponse;
+import com.f1.quiket.domain.subject.dto.SubjectSummaryResponse;
+import com.f1.quiket.domain.subject.service.SubjectService;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class SubjectControllerTest {
+
+    private SubjectService subjectService;
+    private SubjectController subjectController;
+    private UserPrincipal principal;
+
+    @BeforeEach
+    void setUp() {
+        subjectService = mock(SubjectService.class);
+        subjectController = new SubjectController(subjectService);
+        principal = principal("user-public-id");
+    }
+
+    @Test
+    void getSubjects_returns_ok_response() {
+        SubjectPageResponse response = SubjectPageResponse.builder()
+                .page(0)
+                .size(10)
+                .totalElements(1L)
+                .totalPages(1)
+                .last(true)
+                .content(List.of(SubjectSummaryResponse.builder()
+                        .id("subject-public-id")
+                        .name("데이터베이스")
+                        .purpose("exam")
+                        .build()))
+                .build();
+        when(subjectService.getSubjects(principal.getPublicId(), 0, 10)).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectPageResponse>> result = subjectController.getSubjects(principal, 0, 10);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).getSubjects(principal.getPublicId(), 0, 10);
+    }
+
+    @Test
+    void createSubject_returns_created_response() {
+        SubjectCreateRequest request = new SubjectCreateRequest();
+        ReflectionTestUtils.setField(request, "name", "데이터베이스");
+        ReflectionTestUtils.setField(request, "purpose", "exam");
+
+        SubjectResponse response = SubjectResponse.builder()
+                .id("subject-public-id")
+                .name("데이터베이스")
+                .purpose("exam")
+                .createdAt(LocalDateTime.now())
+                .build();
+        when(subjectService.createSubject(principal.getPublicId(), request)).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectResponse>> result = subjectController.createSubject(principal, request);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.CREATED.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).createSubject(principal.getPublicId(), request);
+    }
+
+    @Test
+    void getSubject_returns_ok_response() {
+        SubjectDetailResponse response = SubjectDetailResponse.builder()
+                .id("subject-public-id")
+                .name("데이터베이스")
+                .purpose("exam")
+                .build();
+        when(subjectService.getSubject(principal.getPublicId(), "subject-public-id")).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectDetailResponse>> result = subjectController.getSubject(principal, "subject-public-id");
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).getSubject(principal.getPublicId(), "subject-public-id");
+    }
+
+    @Test
+    void getQuizScope_returns_ok_response() {
+        QuizScopeResponse response = QuizScopeResponse.builder()
+                .subjectId("subject-public-id")
+                .subjectName("데이터베이스")
+                .chapters(List.of())
+                .build();
+        when(subjectService.getQuizScope(principal.getPublicId(), "subject-public-id")).thenReturn(response);
+
+        ResponseEntity<ApiResponse<QuizScopeResponse>> result = subjectController.getQuizScope(principal, "subject-public-id");
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).getQuizScope(principal.getPublicId(), "subject-public-id");
+    }
+
+    @Test
+    void deleteSubject_returns_ok_response() {
+        ResponseEntity<ApiResponse<Void>> result = subjectController.deleteSubject(principal, "subject-public-id");
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isNull();
+        verify(subjectService).deleteSubject(principal.getPublicId(), "subject-public-id");
+    }
+
+    @Test
+    void updateSubjectName_returns_ok_response() {
+        SubjectNameUpdateRequest request = new SubjectNameUpdateRequest();
+        ReflectionTestUtils.setField(request, "name", "운영체제");
+
+        SubjectResponse response = SubjectResponse.builder()
+                .id("subject-public-id")
+                .name("운영체제")
+                .purpose("exam")
+                .build();
+        when(subjectService.updateSubjectName(principal.getPublicId(), "subject-public-id", "운영체제")).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectResponse>> result = subjectController.updateSubjectName(principal, "subject-public-id", request);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).updateSubjectName(principal.getPublicId(), "subject-public-id", "운영체제");
+    }
+
+    @Test
+    void updateSubjectDetails_returns_ok_response() {
+        SubjectDetailUpdateRequest request = new SubjectDetailUpdateRequest();
+        ReflectionTestUtils.setField(request, "name", "운영체제");
+        ReflectionTestUtils.setField(request, "purpose", "review");
+
+        SubjectDetailResponse response = SubjectDetailResponse.builder()
+                .id("subject-public-id")
+                .name("운영체제")
+                .purpose("review")
+                .build();
+        when(subjectService.updateSubjectDetails(principal.getPublicId(), "subject-public-id", request)).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectDetailResponse>> result = subjectController.updateSubjectDetails(principal, "subject-public-id", request);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).updateSubjectDetails(principal.getPublicId(), "subject-public-id", request);
+    }
+
+    @Test
+    void upsertSubjectExamSchedule_returns_ok_response() {
+        SubjectExamScheduleUpsertRequest request = new SubjectExamScheduleUpsertRequest();
+        ReflectionTestUtils.setField(request, "examName", "정보처리기사");
+        ReflectionTestUtils.setField(request, "examDate", LocalDate.now().plusDays(30));
+
+        SubjectExamScheduleResponse response = SubjectExamScheduleResponse.builder()
+                .id("schedule-public-id")
+                .subjectId("subject-public-id")
+                .examName("정보처리기사")
+                .examDate(LocalDate.now().plusDays(30))
+                .dDay(30)
+                .build();
+        when(subjectService.upsertExamSchedule(principal.getPublicId(), "subject-public-id", request)).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectExamScheduleResponse>> result = subjectController.upsertSubjectExamSchedule(principal, "subject-public-id", request);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).upsertExamSchedule(principal.getPublicId(), "subject-public-id", request);
+    }
+
+    @Test
+    void deleteSubjectExamSchedule_returns_ok_response() {
+        ResponseEntity<ApiResponse<Void>> result = subjectController.deleteSubjectExamSchedule(principal, "subject-public-id");
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isNull();
+        verify(subjectService).deleteExamSchedule(principal.getPublicId(), "subject-public-id");
+    }
+
+    private UserPrincipal principal(String userPublicId) {
+        User user = User.create(userPublicId, "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return UserPrincipal.from(user);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/subject/service/CertificateServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/subject/service/CertificateServiceTest.java
@@ -1,0 +1,91 @@
+package com.f1.quiket.domain.subject.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.subject.dto.CertificateResponse;
+import com.f1.quiket.domain.subject.entity.Certificate;
+import com.f1.quiket.domain.subject.repository.CertificateRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class CertificateServiceTest {
+
+    private CertificateRepository certificateRepository;
+    private CertificateService certificateService;
+
+    @BeforeEach
+    void setUp() {
+        certificateRepository = mock(CertificateRepository.class);
+        certificateService = new CertificateService(certificateRepository);
+    }
+
+    @Test
+    void getCertificates_uses_featured_and_keyword_query() {
+        Certificate certificate = certificate(1L, "정보처리기사", true, 1);
+        when(certificateRepository.findAllByFeaturedTrueAndNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc("정보"))
+                .thenReturn(List.of(certificate));
+
+        List<CertificateResponse> response = certificateService.getCertificates(true, "정보");
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getId()).isEqualTo(1L);
+        assertThat(response.get(0).getName()).isEqualTo("정보처리기사");
+        assertThat(response.get(0).getFeatured()).isTrue();
+        verify(certificateRepository).findAllByFeaturedTrueAndNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc("정보");
+        verifyNoMoreInteractions(certificateRepository);
+    }
+
+    @Test
+    void getCertificates_uses_featured_only_query() {
+        when(certificateRepository.findAllByFeaturedTrueOrderByDisplayOrderAscNameAsc())
+                .thenReturn(List.of(certificate(2L, "SQLD", true, 2)));
+
+        List<CertificateResponse> response = certificateService.getCertificates(true, null);
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getName()).isEqualTo("SQLD");
+        verify(certificateRepository).findAllByFeaturedTrueOrderByDisplayOrderAscNameAsc();
+        verifyNoMoreInteractions(certificateRepository);
+    }
+
+    @Test
+    void getCertificates_uses_keyword_only_query() {
+        when(certificateRepository.findAllByNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc("SQL"))
+                .thenReturn(List.of(certificate(3L, "SQLD", false, 3)));
+
+        List<CertificateResponse> response = certificateService.getCertificates(false, "SQL");
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getFeatured()).isFalse();
+        verify(certificateRepository).findAllByNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc("SQL");
+        verifyNoMoreInteractions(certificateRepository);
+    }
+
+    @Test
+    void getCertificates_uses_all_query_when_no_filter() {
+        when(certificateRepository.findAllByOrderByDisplayOrderAscNameAsc())
+                .thenReturn(List.of(certificate(4L, "네트워크관리사", false, 4)));
+
+        List<CertificateResponse> response = certificateService.getCertificates(null, " ");
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getDisplayOrder()).isEqualTo(4);
+        verify(certificateRepository).findAllByOrderByDisplayOrderAscNameAsc();
+        verifyNoMoreInteractions(certificateRepository);
+    }
+
+    private Certificate certificate(Long id, String name, Boolean featured, Integer displayOrder) {
+        Certificate certificate = org.springframework.beans.BeanUtils.instantiateClass(Certificate.class);
+        ReflectionTestUtils.setField(certificate, "id", id);
+        ReflectionTestUtils.setField(certificate, "name", name);
+        ReflectionTestUtils.setField(certificate, "featured", featured);
+        ReflectionTestUtils.setField(certificate, "displayOrder", displayOrder);
+        return certificate;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/subject/service/SubjectServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/subject/service/SubjectServiceTest.java
@@ -1,0 +1,227 @@
+package com.f1.quiket.domain.subject.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleResponse;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleUpsertRequest;
+import com.f1.quiket.domain.subject.dto.SubjectPageResponse;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.entity.SubjectExamSchedule;
+import com.f1.quiket.domain.subject.repository.SubjectExamDetailRepository;
+import com.f1.quiket.domain.subject.repository.SubjectExamScheduleRepository;
+import com.f1.quiket.domain.subject.repository.SubjectOtherDetailRepository;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.subject.repository.SubjectReviewDetailRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class SubjectServiceTest {
+
+    private UserRepository userRepository;
+    private SubjectRepository subjectRepository;
+    private SubjectExamDetailRepository subjectExamDetailRepository;
+    private SubjectReviewDetailRepository subjectReviewDetailRepository;
+    private SubjectOtherDetailRepository subjectOtherDetailRepository;
+    private SubjectExamScheduleRepository subjectExamScheduleRepository;
+    private ChapterRepository chapterRepository;
+    private PartRepository partRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private SubjectService subjectService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        subjectExamDetailRepository = mock(SubjectExamDetailRepository.class);
+        subjectReviewDetailRepository = mock(SubjectReviewDetailRepository.class);
+        subjectOtherDetailRepository = mock(SubjectOtherDetailRepository.class);
+        subjectExamScheduleRepository = mock(SubjectExamScheduleRepository.class);
+        chapterRepository = mock(ChapterRepository.class);
+        partRepository = mock(PartRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+
+        subjectService = new SubjectService(
+                userRepository,
+                subjectRepository,
+                subjectExamDetailRepository,
+                subjectReviewDetailRepository,
+                subjectOtherDetailRepository,
+                subjectExamScheduleRepository,
+                chapterRepository,
+                partRepository,
+                quizSessionRepository
+        );
+    }
+
+    @Test
+    void getSubjects_returns_empty_page_with_normalized_page_and_size() {
+        User user = user(1L, "user-public-id");
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+
+        Page<Subject> page = new PageImpl<>(List.of(), org.springframework.data.domain.PageRequest.of(0, 100), 0);
+        when(subjectRepository.findByUserIdAndDeletedAtIsNull(eq(user.getId()), any(Pageable.class))).thenReturn(page);
+
+        SubjectPageResponse response = subjectService.getSubjects(user.getPublicId(), -1, 999);
+
+        assertThat(response.getPage()).isEqualTo(0);
+        assertThat(response.getSize()).isEqualTo(100);
+        assertThat(response.getContent()).isEmpty();
+        verify(subjectRepository).findByUserIdAndDeletedAtIsNull(eq(user.getId()), any(Pageable.class));
+        verifyNoInteractions(chapterRepository, partRepository, subjectExamScheduleRepository);
+    }
+
+    @Test
+    void upsertExamSchedule_creates_new_schedule_with_normalized_exam_name() {
+        User user = user(1L, "user-public-id");
+        Subject subject = subject(10L, "subject-public-id", user.getId(), "데이터베이스");
+        SubjectExamScheduleUpsertRequest request = new SubjectExamScheduleUpsertRequest();
+        ReflectionTestUtils.setField(request, "examName", " ");
+        ReflectionTestUtils.setField(request, "examDate", LocalDate.now().plusDays(7));
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), user.getId())).thenReturn(Optional.of(subject));
+        when(subjectExamScheduleRepository.findBySubjectId(subject.getId())).thenReturn(Optional.empty());
+        when(subjectExamScheduleRepository.save(any(SubjectExamSchedule.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        SubjectExamScheduleResponse response = subjectService.upsertExamSchedule(user.getPublicId(), subject.getPublicId(), request);
+
+        ArgumentCaptor<SubjectExamSchedule> captor = ArgumentCaptor.forClass(SubjectExamSchedule.class);
+        verify(subjectExamScheduleRepository).save(captor.capture());
+        assertThat(captor.getValue().getExamName()).isNull();
+        assertThat(captor.getValue().getExamDate()).isEqualTo(request.getExamDate());
+
+        assertThat(response.getSubjectId()).isEqualTo(subject.getPublicId());
+        assertThat(response.getExamName()).isEqualTo(subject.getName());
+        assertThat(response.getExamDate()).isEqualTo(request.getExamDate());
+    }
+
+    @Test
+    void deleteExamSchedule_throws_not_found_when_schedule_missing() {
+        User user = user(1L, "user-public-id");
+        Subject subject = subject(10L, "subject-public-id", user.getId(), "데이터베이스");
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), user.getId())).thenReturn(Optional.of(subject));
+        when(subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> subjectService.deleteExamSchedule(user.getPublicId(), subject.getPublicId()))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    @Test
+    void deleteSubject_soft_deletes_subject_and_children() {
+        User user = user(1L, "user-public-id");
+        Subject subject = subject(10L, "subject-public-id", user.getId(), "데이터베이스");
+        SubjectExamSchedule schedule = schedule(100L, "schedule-public-id", subject.getId(), user.getId(), "기말고사", LocalDate.now().plusDays(2));
+        Chapter chapter = chapter(200L, "chapter-public-id", subject.getId(), user.getId(), "트랜잭션", 1);
+        Part part = part(300L, "part-public-id", chapter.getId(), subject.getId(), user.getId(), "락", 1);
+        QuizSession quizSession = quizSession(400L, "quiz-public-id", user.getId(), subject.getId());
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), user.getId())).thenReturn(Optional.of(subject));
+        when(subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId())).thenReturn(Optional.of(schedule));
+        when(chapterRepository.findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId(), user.getId()))
+                .thenReturn(List.of(chapter));
+        when(partRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId())).thenReturn(List.of(part));
+        when(quizSessionRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId())).thenReturn(List.of(quizSession));
+
+        subjectService.deleteSubject(user.getPublicId(), subject.getPublicId());
+
+        assertThat(schedule.getDeletedAt()).isNotNull();
+        assertThat(chapter.getDeletedAt()).isNotNull();
+        assertThat(part.getDeletedAt()).isNotNull();
+        assertThat(quizSession.getDeletedAt()).isNotNull();
+        assertThat(subject.getDeletedAt()).isNotNull();
+    }
+
+    private User user(Long id, String publicId) {
+        User user = User.create(publicId, "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Subject subject(Long id, String publicId, Long userId, String name) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private SubjectExamSchedule schedule(Long id, String publicId, Long subjectId, Long userId, String examName, LocalDate examDate) {
+        SubjectExamSchedule schedule = newEntity(SubjectExamSchedule.class);
+        ReflectionTestUtils.setField(schedule, "id", id);
+        ReflectionTestUtils.setField(schedule, "publicId", publicId);
+        ReflectionTestUtils.setField(schedule, "subjectId", subjectId);
+        ReflectionTestUtils.setField(schedule, "userId", userId);
+        ReflectionTestUtils.setField(schedule, "examName", examName);
+        ReflectionTestUtils.setField(schedule, "examDate", examDate);
+        return schedule;
+    }
+
+    private Chapter chapter(Long id, String publicId, Long subjectId, Long userId, String name, Integer displayOrder) {
+        Chapter chapter = newEntity(Chapter.class);
+        ReflectionTestUtils.setField(chapter, "id", id);
+        ReflectionTestUtils.setField(chapter, "publicId", publicId);
+        ReflectionTestUtils.setField(chapter, "subjectId", subjectId);
+        ReflectionTestUtils.setField(chapter, "userId", userId);
+        ReflectionTestUtils.setField(chapter, "name", name);
+        ReflectionTestUtils.setField(chapter, "displayOrder", displayOrder);
+        return chapter;
+    }
+
+    private Part part(Long id, String publicId, Long chapterId, Long subjectId, Long userId, String name, Integer partNumber) {
+        Part part = newEntity(Part.class);
+        ReflectionTestUtils.setField(part, "id", id);
+        ReflectionTestUtils.setField(part, "publicId", publicId);
+        ReflectionTestUtils.setField(part, "chapterId", chapterId);
+        ReflectionTestUtils.setField(part, "subjectId", subjectId);
+        ReflectionTestUtils.setField(part, "userId", userId);
+        ReflectionTestUtils.setField(part, "name", name);
+        ReflectionTestUtils.setField(part, "partNumber", partNumber);
+        return part;
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId) {
+        QuizSession quizSession = newEntity(QuizSession.class);
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        ReflectionTestUtils.setField(quizSession, "publicId", publicId);
+        ReflectionTestUtils.setField(quizSession, "userId", userId);
+        ReflectionTestUtils.setField(quizSession, "subjectId", subjectId);
+        ReflectionTestUtils.setField(quizSession, "status", "completed");
+        return quizSession;
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}


### PR DESCRIPTION
## 📌 Description

  - 과목 관리 기능(과목 추가, 수정/삭제, 시험 일정, 챕터명 수정, 자격증 목록 조회) 백엔드 API를 구현했습니다.
  - 과목 생성/수정 시 학습 목적 및 목적별 상세 메타정보를 저장하도록 구성했습니다.
  - 과목 상세 조회에서 수정 화면 초기값(과목명/유형/시험 일정/챕터 정보)을 사용할 수 있도록 응답 구조를 제공합니다.
  - 과목 삭제 시 과목/시험일정/챕터/파트/퀴즈세션 soft delete 처리 로직을 포함합니다.
  - Subject/Chapter/Certificate 영역 테스트 코드와 Postman 컬렉션을 추가했습니다.

  ---

  ## ✅ Changes

  - `SubjectController`, `SubjectService` 구현
    - 과목 목록/생성/상세/퀴즈범위 조회
    - 과목명 수정, 과목 유형(상세) 수정
    - 시험 일정 등록/수정(Upsert), 삭제
    - 과목 삭제
  - `ChapterController`, `ChapterService` 구현
    - 챕터명 수정
  - `CertificateController`, `CertificateService` 구현
    - 자격증 목록 조회(`featured`, `keyword` 필터)
  - Subject 도메인 DTO/Entity/Repository 추가
    - 목적별 상세: `SubjectExamDetail`, `SubjectReviewDetail`, `SubjectOtherDetail`
    - 시험 일정: `SubjectExamSchedule`
    - 자격증 마스터: `Certificate`
  - 마이그레이션 추가
    - `V13__add_deleted_at_to_subject_detail_tables.sql`
  - 테스트 추가
    - `SubjectControllerTest`
    - `ChapterControllerTest`
    - `CertificateControllerTest`
    - `SubjectServiceTest`
    - `ChapterServiceTest`
    - `CertificateServiceTest`
  - API 요청용 Postman 컬렉션 추가
    - `docs/postman/subject-chapter-certificate.postman_collection.json`

  ---

  ## 🧪 How to Test

  1. DB 마이그레이션 적용 후 애플리케이션 실행
     - `./gradlew bootRun` (또는 배포 환경 기준 실행)
  2. 과목 관리 API 수동 검증
     - Postman 컬렉션 `docs/postman/subject-chapter-certificate.postman_collection.json` import
     - `baseUrl`, `accessToken`, `subjectId`, `chapterId` 변수 설정 후 요청 실행
  3. 테스트 실행
     - `./gradlew test --tests "com.f1.quiket.domain.subject.controller.SubjectControllerTest" --tests  com.f1.quiket.domain.chapter.controller.ChapterControllerTest" --tests
  "com.f1.quiket.domain.subject.controller.CertificateControllerTest" --tests "com.f1.quiket.domain.subject.service.SubjectServiceTest" --tests
  "com.f1.quiket.domain.chapter.service.ChapterServiceTest" --tests "com.f1.quiket.domain.subject.service.CertificateServiceTest"`

  ---

  ## 🔗 Related Issue

  Closes #33

  ---

  ## 📝 Notes

  - 과목명 검증: `@NotBlank`, `@Size(max=30)` 적용
  - 시험명 미입력 시 과목명으로 대체, 지난 시험일 D-Day 미표시 처리
  - 본 PR에 `subject_*_details` 테이블 `deleted_at` 컬럼 보강 마이그레이션(V13) 포함

  ---

  ## 👤 Assignee

  - @ja2hoon