### PR TITLE
[Feat] 캐릭터 성장 XP 정책 보완

### DIFF
--- a/src/main/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculator.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculator.java
@@ -1,9 +1,34 @@
 package com.f1.quiket.domain.gamification.service;
 
+/**
+ * 게임화 레벨 계산 유틸 — GAMIF-002 캐릭터 성장 & XP 정책 기준.
+ *
+ * <p>총 10레벨(만렙) 구조이며 레벨별 누적 XP 하한은 명세를 그대로 옮긴 값이다.
+ * 만렙(Lv.10) 도달 후엔 추가 XP가 누적되지 않는 정책이라 적립측에서
+ * {@link #MAX_LEVEL_MIN_XP}를 상한으로 사용한다.</p>
+ */
 public final class GamificationLevelCalculator {
 
+    /**
+     * 명세 GAMIF-002 — 만렙 차수.
+     */
     public static final int MAX_LEVEL = 10;
 
+    /**
+     * 명세 GAMIF-002 — 레벨별 누적 XP 하한(레벨 시작값).
+     * <ul>
+     *     <li>Lv.1: 0 ~ 99</li>
+     *     <li>Lv.2: 100 ~ 349</li>
+     *     <li>Lv.3: 350 ~ 849</li>
+     *     <li>Lv.4: 850 ~ 1,749</li>
+     *     <li>Lv.5: 1,750 ~ 3,249</li>
+     *     <li>Lv.6: 3,250 ~ 5,749</li>
+     *     <li>Lv.7: 5,750 ~ 9,749</li>
+     *     <li>Lv.8: 9,750 ~ 16,249</li>
+     *     <li>Lv.9: 16,250 ~ 26,249</li>
+     *     <li>Lv.10: 26,250 이상 (만렙)</li>
+     * </ul>
+     */
     private static final int[] LEVEL_MIN_XP = {
             0,
             100,
@@ -16,6 +41,12 @@ public final class GamificationLevelCalculator {
             16250,
             26250
     };
+
+    /**
+     * 명세 GAMIF-002 — 만렙(Lv.10) 진입 누적 XP. 누적 XP가 이 값 이상이면 만렙이며,
+     * 만렙 도달 후엔 추가 XP를 누적하지 않는다.
+     */
+    public static final int MAX_LEVEL_MIN_XP = LEVEL_MIN_XP[MAX_LEVEL - 1];
 
     private GamificationLevelCalculator() {
     }

--- a/src/main/java/com/f1/quiket/domain/gamification/service/GamificationRewardService.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/GamificationRewardService.java
@@ -43,11 +43,14 @@ public class GamificationRewardService {
 
         int dotoriEarned = calculateDotoriEarned(playSession, normalizedCorrectCount);
         int baseXp = normalizedCorrectCount * xpPerCorrect(quizSession.getDifficulty(), playSession.getPlayType());
-        int earnedXp = calculateEarnedXp(baseXp, streakMultiplier);
+        int rawEarnedXp = calculateEarnedXp(baseXp, streakMultiplier);
 
         int dotoriBefore = user.getDotoriBalance();
         int xpBefore = user.getXpTotal();
         int levelBefore = user.getCurrentLevel();
+        // 명세 GAMIF-002 — 만렙(Lv.10) 도달 후엔 추가 XP 누적 X.
+        // 만렙 진입선까지의 잔여 분만큼만 적립하여, 응답·로그·user.xpTotal이 모두 같은 값으로 정렬되도록 한다.
+        int earnedXp = capByMaxLevelXp(xpBefore, rawEarnedXp);
         int dotoriAfter = dotoriBefore + dotoriEarned;
         int xpAfter = xpBefore + earnedXp;
         int levelAfter = GamificationLevelCalculator.levelOf(xpAfter);
@@ -94,6 +97,10 @@ public class GamificationRewardService {
         return userStreakLogRepository.save(UserStreakLog.create(userId, today, streakCount, multiplierOf(streakCount)));
     }
 
+    /**
+     * 명세 GAMIF-001 — 도토리는 첫 풀이(first)에 한해 정답 1문항당 +1 적립한다.
+     * retry_all / retry_wrong은 XP만 적립하고 도토리는 0이다.
+     */
     private int calculateDotoriEarned(QuizPlaySession playSession, int correctCount) {
         if (!PLAY_TYPE_FIRST.equals(playSession.getPlayType())) {
             return 0;
@@ -101,6 +108,14 @@ public class GamificationRewardService {
         return correctCount;
     }
 
+    /**
+     * 명세 GAMIF-002 — 난이도별 정답 1문항당 적립 XP.
+     * <ul>
+     *     <li>첫 풀이(first): easy 3 / medium 4 / hard 5</li>
+     *     <li>복습(retry_all, retry_wrong): easy 2 / medium 3 / hard 4</li>
+     * </ul>
+     * <p>알 수 없는 난이도 값은 medium 기준으로 매핑한다.</p>
+     */
     private int xpPerCorrect(String difficulty, String playType) {
         if (PLAY_TYPE_FIRST.equals(playType)) {
             return switch (difficulty) {
@@ -116,6 +131,17 @@ public class GamificationRewardService {
         };
     }
 
+    /**
+     * 명세 GAMIF-002 — 연속 학습 일일 보너스 배수.
+     * <ul>
+     *     <li>1일: *1.0</li>
+     *     <li>2일: *1.1</li>
+     *     <li>3~5일: *1.2</li>
+     *     <li>6~13일: *1.5</li>
+     *     <li>14~29일: *2.0</li>
+     *     <li>30일 이상: *2.5</li>
+     * </ul>
+     */
     private BigDecimal multiplierOf(int streakCount) {
         if (streakCount >= 30) {
             return BigDecimal.valueOf(2.5);
@@ -140,6 +166,16 @@ public class GamificationRewardService {
                 .multiply(streakMultiplier)
                 .setScale(0, RoundingMode.DOWN)
                 .intValue();
+    }
+
+    /**
+     * 명세 GAMIF-002 — 만렙(Lv.10) 도달 후엔 XP 누적이 멈춘다.
+     * xpBefore가 만렙 진입선({@link GamificationLevelCalculator#MAX_LEVEL_MIN_XP}) 이상이면 0,
+     * 그렇지 않으면 진입선까지의 잔여 분과 rawEarnedXp 중 작은 값을 실제 적립값으로 사용한다.
+     */
+    private int capByMaxLevelXp(int xpBefore, int rawEarnedXp) {
+        int remainingToMax = Math.max(GamificationLevelCalculator.MAX_LEVEL_MIN_XP - xpBefore, 0);
+        return Math.min(rawEarnedXp, remainingToMax);
     }
 
     private void saveRewardLogs(

--- a/src/main/java/com/f1/quiket/domain/user/entity/type/UserLevel.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/type/UserLevel.java
@@ -5,7 +5,10 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 사용자 레벨 명칭
+ * 명세 GAMIF-002 — 사용자 레벨별 다람쥐 명칭.
+ *
+ * <p>Lv.1~Lv.10 매핑은 캐릭터 성장 정책의 단일 정답 소스로, 레벨 구간 XP는
+ * {@link com.f1.quiket.domain.gamification.service.GamificationLevelCalculator}에 정의되어 있다.</p>
  */
 @Getter
 @RequiredArgsConstructor

--- a/src/test/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculatorTest.java
+++ b/src/test/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculatorTest.java
@@ -1,0 +1,89 @@
+package com.f1.quiket.domain.gamification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * 명세 GAMIF-002 — 레벨 구간 경계값과 만렙 진입선이 정책과 일치하는지 단언한다.
+ */
+class GamificationLevelCalculatorTest {
+
+    @Test
+    void levelOf_maps_each_band_min_xp_to_expected_level() {
+        assertThat(GamificationLevelCalculator.levelOf(0)).isEqualTo(1);
+        assertThat(GamificationLevelCalculator.levelOf(99)).isEqualTo(1);
+        assertThat(GamificationLevelCalculator.levelOf(100)).isEqualTo(2);
+        assertThat(GamificationLevelCalculator.levelOf(349)).isEqualTo(2);
+        assertThat(GamificationLevelCalculator.levelOf(350)).isEqualTo(3);
+        assertThat(GamificationLevelCalculator.levelOf(849)).isEqualTo(3);
+        assertThat(GamificationLevelCalculator.levelOf(850)).isEqualTo(4);
+        assertThat(GamificationLevelCalculator.levelOf(1749)).isEqualTo(4);
+        assertThat(GamificationLevelCalculator.levelOf(1750)).isEqualTo(5);
+        assertThat(GamificationLevelCalculator.levelOf(3249)).isEqualTo(5);
+        assertThat(GamificationLevelCalculator.levelOf(3250)).isEqualTo(6);
+        assertThat(GamificationLevelCalculator.levelOf(5749)).isEqualTo(6);
+        assertThat(GamificationLevelCalculator.levelOf(5750)).isEqualTo(7);
+        assertThat(GamificationLevelCalculator.levelOf(9749)).isEqualTo(7);
+        assertThat(GamificationLevelCalculator.levelOf(9750)).isEqualTo(8);
+        assertThat(GamificationLevelCalculator.levelOf(16249)).isEqualTo(8);
+        assertThat(GamificationLevelCalculator.levelOf(16250)).isEqualTo(9);
+        assertThat(GamificationLevelCalculator.levelOf(26249)).isEqualTo(9);
+        assertThat(GamificationLevelCalculator.levelOf(26250)).isEqualTo(10);
+        assertThat(GamificationLevelCalculator.levelOf(99999)).isEqualTo(10);
+    }
+
+    @Test
+    void levelOf_normalizes_null_and_negative_xp_to_level_1() {
+        assertThat(GamificationLevelCalculator.levelOf(null)).isEqualTo(1);
+        assertThat(GamificationLevelCalculator.levelOf(-500)).isEqualTo(1);
+    }
+
+    @Test
+    void max_level_min_xp_matches_specification() {
+        // 명세 GAMIF-002 — Lv.10: 26,250 XP 이상 (만렙)
+        assertThat(GamificationLevelCalculator.MAX_LEVEL_MIN_XP).isEqualTo(26250);
+        assertThat(GamificationLevelCalculator.MAX_LEVEL).isEqualTo(10);
+    }
+
+    @Test
+    void current_level_min_xp_returns_band_start_for_each_level() {
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(1)).isZero();
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(2)).isEqualTo(100);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(3)).isEqualTo(350);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(4)).isEqualTo(850);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(5)).isEqualTo(1750);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(6)).isEqualTo(3250);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(7)).isEqualTo(5750);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(8)).isEqualTo(9750);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(9)).isEqualTo(16250);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(10)).isEqualTo(26250);
+    }
+
+    @Test
+    void next_level_returns_null_when_max_level() {
+        assertThat(GamificationLevelCalculator.nextLevel(10)).isNull();
+        assertThat(GamificationLevelCalculator.nextLevelRequiredXp(10)).isNull();
+    }
+
+    @Test
+    void next_level_required_xp_returns_next_band_start() {
+        assertThat(GamificationLevelCalculator.nextLevel(1)).isEqualTo(2);
+        assertThat(GamificationLevelCalculator.nextLevelRequiredXp(1)).isEqualTo(100);
+        assertThat(GamificationLevelCalculator.nextLevelRequiredXp(9)).isEqualTo(26250);
+    }
+
+    @Test
+    void progress_pct_clamps_to_0_and_100() {
+        // 경계 — 현재 레벨 시작값
+        assertThat(GamificationLevelCalculator.progressPct(0, 1)).isZero();
+        assertThat(GamificationLevelCalculator.progressPct(100, 2)).isZero();
+        // 다음 레벨 진입 직전(현재 레벨 마지막 1XP 전) → 99%
+        assertThat(GamificationLevelCalculator.progressPct(99, 1)).isEqualTo(99);
+        // 만렙은 항상 100
+        assertThat(GamificationLevelCalculator.progressPct(26250, 10)).isEqualTo(100);
+        assertThat(GamificationLevelCalculator.progressPct(99999, 10)).isEqualTo(100);
+        // 레벨/XP 불일치(데이터 손상) 시 음수 → 0으로 클램프
+        assertThat(GamificationLevelCalculator.progressPct(0, 3)).isZero();
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
@@ -131,6 +131,8 @@ class GamificationRewardServiceTest {
     @Test
     void applyQuizReward_blocks_xp_after_max_level_reached() {
         // 명세 GAMIF-002 — 만렙(Lv.10) 도달 후 추가 풀이는 XP 누적 X.
+        // 단, 명세 예외 "만렙 도달 후 추가 풀이: 레벨업 모달 노출 X, 일반 도토리 모달만 노출"에 따라
+        // 도토리는 first 풀이라면 정상 적립되어야 한다 — XP만 cap 대상이고 도토리는 GAMIF-001 정책 그대로 동작.
         User user = user(1L, 0, GamificationLevelCalculator.MAX_LEVEL_MIN_XP, 10);
         QuizSession quizSession = quizSession(500L, user.getId(), 20L, "hard");
         QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
@@ -142,10 +144,49 @@ class GamificationRewardServiceTest {
 
         assertThat(result.xpEarned()).isZero();
         assertThat(result.leveledUp()).isFalse();
+        assertThat(result.newLevel()).isNull();
         assertThat(user.getXpTotal()).isEqualTo(GamificationLevelCalculator.MAX_LEVEL_MIN_XP);
         assertThat(user.getCurrentLevel()).isEqualTo(10);
 
-        // 적립값이 0이면 UserXpLog는 남기지 않는다 (saveRewardLogs 조건)
+        // 도토리는 first 풀이 정답 3개 → +3 정상 적립
+        assertThat(result.dotoriEarned()).isEqualTo(3);
+        assertThat(user.getDotoriBalance()).isEqualTo(3);
+        ArgumentCaptor<UserDotoriLog> dotoriCaptor = ArgumentCaptor.forClass(UserDotoriLog.class);
+        verify(userDotoriLogRepository).save(dotoriCaptor.capture());
+        assertThat(dotoriCaptor.getValue().getAmount()).isEqualTo(3);
+        assertThat(dotoriCaptor.getValue().getBalanceAfter()).isEqualTo(3);
+
+        // XP 적립값이 0이면 UserXpLog는 남기지 않는다 (saveRewardLogs 조건)
+        verify(userXpLogRepository, never()).save(any(UserXpLog.class));
+    }
+
+    @Test
+    void applyQuizReward_records_streak_but_no_logs_when_zero_correct() {
+        // 명세 GAMIF-001/002 — 정답이 0개라도 학습 행동(풀이 제출) 자체는 발생했으므로 streak는 기록한다.
+        // 다만 적립값이 0인 도토리/XP 로그는 saveRewardLogs 조건상 저장되지 않는다.
+        User user = user(1L, 0, 0, 1);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "medium");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        LocalDate today = today();
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today))
+                .thenReturn(Optional.empty());
+        when(userStreakLogRepository.findTopByUserIdAndStudyDateBeforeOrderByStudyDateDesc(user.getId(), today))
+                .thenReturn(Optional.empty());
+        when(userStreakLogRepository.save(any(UserStreakLog.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 0);
+
+        assertThat(result.dotoriEarned()).isZero();
+        assertThat(result.xpEarned()).isZero();
+        assertThat(result.leveledUp()).isFalse();
+        assertThat(result.newLevel()).isNull();
+        assertThat(user.getDotoriBalance()).isZero();
+        assertThat(user.getXpTotal()).isZero();
+        assertThat(user.getCurrentLevel()).isEqualTo(1);
+
+        verify(userStreakLogRepository).save(any(UserStreakLog.class));
+        verify(userDotoriLogRepository, never()).save(any(UserDotoriLog.class));
         verify(userXpLogRepository, never()).save(any(UserXpLog.class));
     }
 

--- a/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
@@ -3,6 +3,7 @@ package com.f1.quiket.domain.gamification.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -102,6 +103,72 @@ class GamificationRewardServiceTest {
     }
 
     @Test
+    void applyQuizReward_caps_xp_to_max_level_when_user_approaches_max() {
+        // 명세 GAMIF-002 — 만렙 도달 후 추가 XP 누적 X. 진입선까지의 잔여 분만 적립.
+        User user = user(1L, 0, GamificationLevelCalculator.MAX_LEVEL_MIN_XP - 2, 9);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "hard");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        LocalDate today = today();
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today))
+                .thenReturn(Optional.of(UserStreakLog.create(user.getId(), today, 1, BigDecimal.valueOf(1.0))));
+
+        // first hard 정답 1개 → raw 5XP, 잔여 2XP만 적립되어야 함
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 1);
+
+        assertThat(result.xpEarned()).isEqualTo(2);
+        assertThat(user.getXpTotal()).isEqualTo(GamificationLevelCalculator.MAX_LEVEL_MIN_XP);
+        assertThat(user.getCurrentLevel()).isEqualTo(10);
+        assertThat(result.leveledUp()).isTrue();
+        assertThat(result.newLevel()).isEqualTo(10);
+
+        ArgumentCaptor<UserXpLog> xpCaptor = ArgumentCaptor.forClass(UserXpLog.class);
+        verify(userXpLogRepository).save(xpCaptor.capture());
+        // 로그 적립 값도 cap 후 값과 일치 (응답·로그·user.xpTotal 일관성)
+        assertThat(xpCaptor.getValue().getEarnedXp()).isEqualTo(2);
+        assertThat(xpCaptor.getValue().getXpAfter()).isEqualTo(GamificationLevelCalculator.MAX_LEVEL_MIN_XP);
+    }
+
+    @Test
+    void applyQuizReward_blocks_xp_after_max_level_reached() {
+        // 명세 GAMIF-002 — 만렙(Lv.10) 도달 후 추가 풀이는 XP 누적 X.
+        User user = user(1L, 0, GamificationLevelCalculator.MAX_LEVEL_MIN_XP, 10);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "hard");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        LocalDate today = today();
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today))
+                .thenReturn(Optional.of(UserStreakLog.create(user.getId(), today, 1, BigDecimal.valueOf(1.0))));
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 3);
+
+        assertThat(result.xpEarned()).isZero();
+        assertThat(result.leveledUp()).isFalse();
+        assertThat(user.getXpTotal()).isEqualTo(GamificationLevelCalculator.MAX_LEVEL_MIN_XP);
+        assertThat(user.getCurrentLevel()).isEqualTo(10);
+
+        // 적립값이 0이면 UserXpLog는 남기지 않는다 (saveRewardLogs 조건)
+        verify(userXpLogRepository, never()).save(any(UserXpLog.class));
+    }
+
+    @Test
+    void applyQuizReward_uses_first_play_xp_table_by_difficulty() {
+        // 명세 GAMIF-002 — 첫 풀이 정답 1문항당 easy 3 / medium 4 / hard 5 XP
+        assertThat(firstPlayXpForCorrect("easy", 2)).isEqualTo(6);
+        assertThat(firstPlayXpForCorrect("medium", 2)).isEqualTo(8);
+        assertThat(firstPlayXpForCorrect("hard", 2)).isEqualTo(10);
+    }
+
+    @Test
+    void applyQuizReward_uses_retry_xp_table_by_difficulty() {
+        // 명세 GAMIF-002 — 전체 다시풀기/오답 복습 정답 1문항당 easy 2 / medium 3 / hard 4 XP
+        assertThat(retryPlayXpForCorrect("retry_all", "easy", 2)).isEqualTo(4);
+        assertThat(retryPlayXpForCorrect("retry_all", "medium", 2)).isEqualTo(6);
+        assertThat(retryPlayXpForCorrect("retry_all", "hard", 2)).isEqualTo(8);
+        assertThat(retryPlayXpForCorrect("retry_wrong", "easy", 2)).isEqualTo(4);
+        assertThat(retryPlayXpForCorrect("retry_wrong", "medium", 2)).isEqualTo(6);
+        assertThat(retryPlayXpForCorrect("retry_wrong", "hard", 2)).isEqualTo(8);
+    }
+
+    @Test
     void applyQuizReward_applies_consecutive_streak_multiplier() {
         User user = user(1L, 0, 0, 1);
         QuizSession quizSession = quizSession(500L, user.getId(), 20L, "medium");
@@ -123,6 +190,64 @@ class GamificationRewardServiceTest {
         verify(userStreakLogRepository).save(streakCaptor.capture());
         assertThat(streakCaptor.getValue().getStreakCount()).isEqualTo(3);
         assertThat(streakCaptor.getValue().getMultiplier()).isEqualByComparingTo(BigDecimal.valueOf(1.2));
+    }
+
+    private int firstPlayXpForCorrect(String difficulty, int correctCount) {
+        User user = user(1L, 0, 0, 1);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, difficulty);
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        stubTodayStreak(user.getId());
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, correctCount);
+        return result.xpEarned();
+    }
+
+    private int retryPlayXpForCorrect(String playType, String difficulty, int correctCount) {
+        User user = user(1L, 0, 0, 1);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, difficulty);
+        QuizPlaySession playSession = retryPlaySession(700L, playType, quizSession);
+        stubTodayStreak(user.getId());
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, correctCount);
+        return result.xpEarned();
+    }
+
+    private void stubTodayStreak(Long userId) {
+        LocalDate today = today();
+        when(userStreakLogRepository.findByUserIdAndStudyDate(userId, today))
+                .thenReturn(Optional.of(UserStreakLog.create(userId, today, 1, BigDecimal.valueOf(1.0))));
+    }
+
+    private QuizPlaySession retryPlaySession(Long id, String playType, QuizSession quizSession) {
+        QuizPlaySession playSession;
+        if ("retry_all".equals(playType)) {
+            playSession = QuizPlaySession.createRetryAll(
+                    "client-session-" + id,
+                    quizSession.getId(),
+                    quizSession.getUserId(),
+                    quizSession.getSubjectId(),
+                    false,
+                    true,
+                    null
+            );
+        } else if ("retry_wrong".equals(playType)) {
+            playSession = QuizPlaySession.createRetryWrong(
+                    "client-session-" + id,
+                    quizSession.getId(),
+                    quizSession.getUserId(),
+                    quizSession.getSubjectId(),
+                    999L,
+                    quizSession.getId(),
+                    1,
+                    false,
+                    true,
+                    null
+            );
+        } else {
+            throw new IllegalArgumentException("unsupported playType for retry helper: " + playType);
+        }
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
     }
 
     private LocalDate today() {

--- a/src/test/java/com/f1/quiket/domain/user/entity/type/UserLevelTest.java
+++ b/src/test/java/com/f1/quiket/domain/user/entity/type/UserLevelTest.java
@@ -1,0 +1,34 @@
+package com.f1.quiket.domain.user.entity.type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * 명세 GAMIF-002 — 레벨별 다람쥐 명칭 매핑이 정책과 일치하는지 단언한다.
+ */
+class UserLevelTest {
+
+    @Test
+    void titleOf_matches_specification_for_each_level() {
+        assertThat(UserLevel.titleOf(1)).isEqualTo("첫걸음 다람쥐");
+        assertThat(UserLevel.titleOf(2)).isEqualTo("결심한 다람쥐");
+        assertThat(UserLevel.titleOf(3)).isEqualTo("펜굴리는 다람쥐");
+        assertThat(UserLevel.titleOf(4)).isEqualTo("노력형 다람쥐");
+        assertThat(UserLevel.titleOf(5)).isEqualTo("열공 다람쥐");
+        assertThat(UserLevel.titleOf(6)).isEqualTo("똑똑한 다람쥐");
+        assertThat(UserLevel.titleOf(7)).isEqualTo("박식한 다람쥐");
+        assertThat(UserLevel.titleOf(8)).isEqualTo("통달한 다람쥐");
+        assertThat(UserLevel.titleOf(9)).isEqualTo("현자 다람쥐");
+        assertThat(UserLevel.titleOf(10)).isEqualTo("레전드 다람쥐");
+    }
+
+    @Test
+    void titleOf_clamps_out_of_range_levels_to_band_edges() {
+        assertThat(UserLevel.titleOf(null)).isEqualTo("첫걸음 다람쥐");
+        assertThat(UserLevel.titleOf(0)).isEqualTo("첫걸음 다람쥐");
+        assertThat(UserLevel.titleOf(-3)).isEqualTo("첫걸음 다람쥐");
+        assertThat(UserLevel.titleOf(11)).isEqualTo("레전드 다람쥐");
+        assertThat(UserLevel.titleOf(999)).isEqualTo("레전드 다람쥐");
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- GAMIF-002 캐릭터 성장 및 XP 정책을 명세 기준으로 보완했습니다
- 만렙(Lv.10) 도달 후 XP 누적이 멈추도록 적립 측에 상한을 적용했습니다
- 레벨 구간·난이도별 XP·레벨 명칭·연속 학습 배수 등 기존 코드의 정책 매핑에 GAMIF-002 출처 Javadoc을 명시했습니다
- 명세와 코드가 어긋나지 않도록 단언 테스트를 신규/보강했습니다

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

### 만렙 XP 누적 상한
- `GamificationLevelCalculator`에 만렙 진입선 상수 `MAX_LEVEL_MIN_XP(=26,250)` 노출
- `GamificationRewardService.applyQuizReward`에서 `rawEarnedXp`를 `min(rawEarnedXp, MAX_LEVEL_MIN_XP - xpBefore)`로 cap
- 결과: 만렙 이후 추가 풀이 시 `earnedXp = 0`, `user.xpTotal` 동결, `QuizResultResponse.rewards`·`UserXpLog`·`User.xpTotal`이 모두 cap 후 값으로 정렬

### 정책 출처 Javadoc 보강
- `GamificationLevelCalculator` 클래스/필드: 레벨 구간 표(Lv.1 0~99, … Lv.10 26,250+), 만렙 진입선 의도
- `GamificationRewardService.xpPerCorrect`: 난이도별 first(easy 3 / medium 4 / hard 5)·retry(easy 2 / medium 3 / hard 4) XP 표
- `GamificationRewardService.multiplierOf`: 연속 학습 일일 보너스 배수(1.0/1.1/1.2/1.5/2.0/2.5)
- `GamificationRewardService.calculateDotoriEarned`: 첫 풀이 한정 +1/문항 도토리 정책(GAMIF-001) 명시
- `UserLevel`: Lv.1~Lv.10 다람쥐 명칭이 GAMIF-002 단일 정답 소스임을 명시

### 테스트
- `GamificationLevelCalculatorTest` (신규): 레벨 구간 경계 전체·`MAX_LEVEL_MIN_XP`/`MAX_LEVEL`·`currentLevelMinXp`/`nextLevel`/`nextLevelRequiredXp`/`progressPct` 클램핑 검증
- `UserLevelTest` (신규): Lv.1~Lv.10 명칭 매핑·범위 밖 입력 클램핑 검증
- `GamificationRewardServiceTest` 보강:
  - 만렙 진입 직전(잔여 2XP) 풀이의 cap 적용 + `UserXpLog.earnedXp`/`xpAfter` 정렬
  - 만렙 도달 후 풀이의 `earnedXp=0` + `UserXpLog` 미기록(현 `saveRewardLogs` 조건과 일관)
  - 난이도별 first XP 표(easy 3 / medium 4 / hard 5)
  - 난이도별 `retry_all`·`retry_wrong` XP 표(easy 2 / medium 3 / hard 4)

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. \`./gradlew test --tests com.f1.quiket.domain.gamification.service.GamificationRewardServiceTest --tests com.f1.quiket.domain.gamification.service.GamificationLevelCalculatorTest --tests com.f1.quiket.domain.user.entity.type.UserLevelTest\`
2. \`./gradlew check\`
3. 운영 시나리오 스모크 (옵션)
   - xpTotal=26,248 사용자 → first hard 정답 1개 풀이 → 실제 적립 +2XP, level=10, leveledUp=true
   - xpTotal=26,250 사용자 → first hard 정답 3개 풀이 → earnedXp=0, level/xpTotal 동결

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #97

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- **자료 업로드 +10XP 적립은 본 PR scope 외**입니다. 강의 업로드 도메인(`RecentActivityType.LECTURE_UPLOADED`·`UserXpLog.lecture_upload_id` 컬럼만 정의됨, 업로드 흐름 미구현) 구현 시 같은 이슈에서 후속 처리합니다.
- **연속 학습 배수 정책은 그대로 유지**합니다. 보상 모달 노출 정책은 클라이언트 책임이라 서버 변경 없음.
- 만렙 cap이 적용되어도 `dotori_earned`/도토리 적립은 명세대로 first 풀이에 한해 정상 적립됩니다. cap은 XP에만 적용.
- 명세 GAMIF-002 "만렙 후속 동기부여(랭킹 등)"은 후속 버전 논의 대상이라 본 PR scope 외.

---

## 🧑‍💻 Assignee

- @imclaremont