### PR TITLE
[Chore] 네 번째 운영 배포

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,17 +181,17 @@ return ResponseEntity.status(errorCode.getStatus())
 
 ### 머지 전략
 
-- 작업 브랜치(`type/#issue-number-description`, 예: `feat/#123-login-api`) → `develop`: Squash merge 사용
-- `develop` → `main`: Merge commit 사용
-- 작업 브랜치 내부 커밋은 리뷰 편의를 위해 원자적으로 작성
-- `main` 병합 커밋은 릴리즈 단위 추적 목적
+- 작업 브랜치(`type/#issue-number-description`, 예: `feat/#123-login-api`) → `develop`: Merge commit 사용
+- `develop` → `main`: Squash merge 사용
+- `develop`에는 작업 PR 단위 히스토리를 보존해 리뷰·추적 용이성 확보
+- `main`은 릴리즈 단위 1커밋으로 압축해 운영 히스토리를 깔끔히 유지
 
 ### Git 메시지 컨벤션
 
 - 커밋 메시지: `type: 한국어 핵심`
 - PR 제목: `[Type] 한국어 핵심`
-- Squash merge 커밋 메시지: `[Type] 한국어 핵심 (#PR번호)`
-- `develop` → `main` Merge commit 메시지: `[Release] 버전/날짜 배포`
+- 작업 브랜치 → `develop` Merge commit 메시지: `[Type] 한국어 핵심 (#PR번호)` (GitHub 기본 형식)
+- `develop` → `main` Squash merge 커밋 메시지: `[Release] 버전/날짜 배포`
 
 ### 이슈 및 PR 제목
 

--- a/src/main/java/com/f1/quiket/domain/chapter/controller/ChapterController.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/controller/ChapterController.java
@@ -1,0 +1,41 @@
+package com.f1.quiket.domain.chapter.controller;
+
+import com.f1.quiket.domain.chapter.dto.ChapterNameUpdateRequest;
+import com.f1.quiket.domain.chapter.dto.ChapterResponse;
+import com.f1.quiket.domain.chapter.service.ChapterService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 챕터 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chapters")
+public class ChapterController {
+
+    private final ChapterService chapterService;
+
+    /**
+     * 챕터명 수정
+     */
+    @PatchMapping("/{chapterId}/name")
+    public ResponseEntity<ApiResponse<ChapterResponse>> updateChapterName(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String chapterId,
+            @Valid @RequestBody ChapterNameUpdateRequest request
+    ) {
+        ChapterResponse response = chapterService.updateChapterName(principal.getPublicId(), chapterId, request.getName());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/chapter/dto/ChapterNameUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/dto/ChapterNameUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.chapter.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 챕터명 수정 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class ChapterNameUpdateRequest {
+
+    /** 챕터명 */
+    @NotBlank(message = "챕터명을 입력해주세요")
+    @Size(max = 30, message = "챕터명은 30자 이하여야 합니다")
+    private String name;
+}

--- a/src/main/java/com/f1/quiket/domain/chapter/dto/ChapterResponse.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/dto/ChapterResponse.java
@@ -1,0 +1,35 @@
+package com.f1.quiket.domain.chapter.dto;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.subject.entity.Subject;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 챕터 응답 DTO
+ */
+@Getter
+@Builder
+public class ChapterResponse {
+
+    /** 챕터 식별자 */
+    private final String id;
+    /** 과목 식별자 */
+    private final String subjectId;
+    /** 챕터명 */
+    private final String name;
+    /** 표시 순서 */
+    private final Integer displayOrder;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static ChapterResponse of(Chapter chapter, Subject subject) {
+        return ChapterResponse.builder()
+                .id(chapter.getPublicId())
+                .subjectId(subject.getPublicId())
+                .name(chapter.getName())
+                .displayOrder(chapter.getDisplayOrder())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/chapter/entity/Chapter.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/entity/Chapter.java
@@ -44,4 +44,11 @@ public class Chapter extends BaseEntity {
 
     @Column(name = "display_order", nullable = false)
     Integer displayOrder;
+
+    /**
+     * 챕터명 변경
+     */
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
@@ -1,7 +1,9 @@
 package com.f1.quiket.domain.chapter.repository;
 
 import com.f1.quiket.domain.chapter.entity.Chapter;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +17,19 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
      * 사용자 챕터 목록 조회
      */
     List<Chapter> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 과목 챕터 목록 조회
+     */
+    List<Chapter> findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(Long subjectId);
+
+    /**
+     * 과목별 챕터 목록 조회
+     */
+    List<Chapter> findAllBySubjectIdInAndDeletedAtIsNull(Collection<Long> subjectIds);
+
+    /**
+     * 공개 식별자 기반 사용자 챕터 조회
+     */
+    Optional<Chapter> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
@@ -21,7 +21,10 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
     /**
      * 과목 챕터 목록 조회
      */
-    List<Chapter> findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(Long subjectId);
+    List<Chapter> findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(
+            Long subjectId,
+            Long userId
+    );
 
     /**
      * 과목별 챕터 목록 조회
@@ -32,10 +35,6 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
      * 공개 식별자 기반 사용자 챕터 조회
      */
     Optional<Chapter> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
-    List<Chapter> findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(
-            Long subjectId,
-            Long userId
-    );
 
     /**
      * 사용자 챕터 목록 조회 (PK 컬렉션 기반)

--- a/src/main/java/com/f1/quiket/domain/chapter/service/ChapterService.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/service/ChapterService.java
@@ -1,0 +1,42 @@
+package com.f1.quiket.domain.chapter.service;
+
+import com.f1.quiket.domain.chapter.dto.ChapterResponse;
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 챕터 비즈니스 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class ChapterService {
+
+    private final UserRepository userRepository;
+    private final ChapterRepository chapterRepository;
+    private final SubjectRepository subjectRepository;
+
+    /**
+     * 챕터명 수정
+     */
+    @Transactional
+    public ChapterResponse updateChapterName(String userPublicId, String chapterPublicId, String name) {
+        User user = userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+        Chapter chapter = chapterRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(chapterPublicId, user.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+        Subject subject = subjectRepository.findById(chapter.getSubjectId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+
+        chapter.updateName(name);
+        return ChapterResponse.of(chapter, subject);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/controller/GamificationController.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/controller/GamificationController.java
@@ -1,0 +1,29 @@
+package com.f1.quiket.domain.gamification.controller;
+
+import com.f1.quiket.domain.gamification.dto.GamificationResponse;
+import com.f1.quiket.domain.gamification.service.GamificationService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/gamification")
+public class GamificationController {
+
+    private final GamificationService gamificationService;
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<GamificationResponse>> getMyGamification(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        GamificationResponse response = gamificationService.getMyGamification(principal.getPublicId());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/dto/GamificationResponse.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/dto/GamificationResponse.java
@@ -1,0 +1,39 @@
+package com.f1.quiket.domain.gamification.dto;
+
+import com.f1.quiket.domain.gamification.service.GamificationLevelCalculator;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.entity.type.UserLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GamificationResponse {
+
+    private final Integer dotoriBalance;
+    private final Integer xpTotal;
+    private final Integer currentLevel;
+    private final String currentLevelName;
+    private final Integer maxLevel;
+    private final Integer nextLevel;
+    private final String nextLevelName;
+    private final Integer currentLevelMinXp;
+    private final Integer nextLevelRequiredXp;
+    private final Integer levelProgressPct;
+
+    public static GamificationResponse from(User user) {
+        Integer nextLevel = GamificationLevelCalculator.nextLevel(user.getCurrentLevel());
+        return GamificationResponse.builder()
+                .dotoriBalance(user.getDotoriBalance())
+                .xpTotal(user.getXpTotal())
+                .currentLevel(user.getCurrentLevel())
+                .currentLevelName(UserLevel.titleOf(user.getCurrentLevel()))
+                .maxLevel(GamificationLevelCalculator.MAX_LEVEL)
+                .nextLevel(nextLevel)
+                .nextLevelName(nextLevel == null ? null : UserLevel.titleOf(nextLevel))
+                .currentLevelMinXp(GamificationLevelCalculator.currentLevelMinXp(user.getCurrentLevel()))
+                .nextLevelRequiredXp(GamificationLevelCalculator.nextLevelRequiredXp(user.getCurrentLevel()))
+                .levelProgressPct(GamificationLevelCalculator.progressPct(user.getXpTotal(), user.getCurrentLevel()))
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/entity/UserDotoriLog.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/entity/UserDotoriLog.java
@@ -1,0 +1,76 @@
+package com.f1.quiket.domain.gamification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "user_dotori_logs",
+        indexes = {
+                @Index(name = "idx_user_dotori_logs_user_id_created_at", columnList = "user_id, created_at"),
+                @Index(name = "idx_user_dotori_logs_play_session_id", columnList = "play_session_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserDotoriLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "play_session_id")
+    Long playSessionId;
+
+    @Column(name = "change_type", length = 20, nullable = false)
+    String changeType;
+
+    @Column(name = "amount", nullable = false)
+    Integer amount;
+
+    @Column(name = "balance_before", nullable = false)
+    Integer balanceBefore;
+
+    @Column(name = "balance_after", nullable = false)
+    Integer balanceAfter;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    public static UserDotoriLog createQuizEarn(
+            Long userId,
+            Long playSessionId,
+            Integer amount,
+            Integer balanceBefore,
+            Integer balanceAfter
+    ) {
+        UserDotoriLog log = new UserDotoriLog();
+        log.userId = userId;
+        log.playSessionId = playSessionId;
+        log.changeType = "earn_quiz";
+        log.amount = amount;
+        log.balanceBefore = balanceBefore;
+        log.balanceAfter = balanceAfter;
+        return log;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/entity/UserStreakLog.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/entity/UserStreakLog.java
@@ -1,0 +1,72 @@
+package com.f1.quiket.domain.gamification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "user_streak_logs",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_user_streak_logs_user_study_date", columnNames = {"user_id", "study_date"})
+        },
+        indexes = {
+                @Index(name = "idx_user_streak_logs_user_id_study_date", columnList = "user_id, study_date")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserStreakLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "study_date", nullable = false)
+    LocalDate studyDate;
+
+    @Column(name = "streak_count", nullable = false)
+    Integer streakCount;
+
+    @Column(name = "multiplier", precision = 3, scale = 1, nullable = false)
+    BigDecimal multiplier;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    public static UserStreakLog create(
+            Long userId,
+            LocalDate studyDate,
+            Integer streakCount,
+            BigDecimal multiplier
+    ) {
+        UserStreakLog log = new UserStreakLog();
+        log.userId = userId;
+        log.studyDate = studyDate;
+        log.streakCount = streakCount;
+        log.multiplier = multiplier;
+        return log;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/entity/UserXpLog.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/entity/UserXpLog.java
@@ -1,0 +1,101 @@
+package com.f1.quiket.domain.gamification.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "user_xp_logs",
+        indexes = {
+                @Index(name = "idx_user_xp_logs_user_id_created_at", columnList = "user_id, created_at"),
+                @Index(name = "idx_user_xp_logs_play_session_id", columnList = "play_session_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class UserXpLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "play_session_id")
+    Long playSessionId;
+
+    @Column(name = "lecture_upload_id")
+    Long lectureUploadId;
+
+    @Column(name = "xp_type", length = 30, nullable = false)
+    String xpType;
+
+    @Column(name = "base_xp", nullable = false)
+    Integer baseXp;
+
+    @Column(name = "streak_multiplier", precision = 3, scale = 1, nullable = false)
+    BigDecimal streakMultiplier;
+
+    @Column(name = "earned_xp", nullable = false)
+    Integer earnedXp;
+
+    @Column(name = "xp_before", nullable = false)
+    Integer xpBefore;
+
+    @Column(name = "xp_after", nullable = false)
+    Integer xpAfter;
+
+    @Column(name = "level_before", nullable = false)
+    Integer levelBefore;
+
+    @Column(name = "level_after", nullable = false)
+    Integer levelAfter;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    public static UserXpLog createQuizReward(
+            Long userId,
+            Long playSessionId,
+            String xpType,
+            Integer baseXp,
+            BigDecimal streakMultiplier,
+            Integer earnedXp,
+            Integer xpBefore,
+            Integer xpAfter,
+            Integer levelBefore,
+            Integer levelAfter
+    ) {
+        UserXpLog log = new UserXpLog();
+        log.userId = userId;
+        log.playSessionId = playSessionId;
+        log.xpType = xpType;
+        log.baseXp = baseXp;
+        log.streakMultiplier = streakMultiplier;
+        log.earnedXp = earnedXp;
+        log.xpBefore = xpBefore;
+        log.xpAfter = xpAfter;
+        log.levelBefore = levelBefore;
+        log.levelAfter = levelAfter;
+        return log;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/repository/UserDotoriLogRepository.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/repository/UserDotoriLogRepository.java
@@ -1,0 +1,9 @@
+package com.f1.quiket.domain.gamification.repository;
+
+import com.f1.quiket.domain.gamification.entity.UserDotoriLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserDotoriLogRepository extends JpaRepository<UserDotoriLog, Long> {
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/repository/UserStreakLogRepository.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/repository/UserStreakLogRepository.java
@@ -1,0 +1,15 @@
+package com.f1.quiket.domain.gamification.repository;
+
+import com.f1.quiket.domain.gamification.entity.UserStreakLog;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserStreakLogRepository extends JpaRepository<UserStreakLog, Long> {
+
+    Optional<UserStreakLog> findByUserIdAndStudyDate(Long userId, LocalDate studyDate);
+
+    Optional<UserStreakLog> findTopByUserIdAndStudyDateBeforeOrderByStudyDateDesc(Long userId, LocalDate studyDate);
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/repository/UserXpLogRepository.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/repository/UserXpLogRepository.java
@@ -1,0 +1,9 @@
+package com.f1.quiket.domain.gamification.repository;
+
+import com.f1.quiket.domain.gamification.entity.UserXpLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserXpLogRepository extends JpaRepository<UserXpLog, Long> {
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculator.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculator.java
@@ -1,0 +1,75 @@
+package com.f1.quiket.domain.gamification.service;
+
+public final class GamificationLevelCalculator {
+
+    public static final int MAX_LEVEL = 10;
+
+    private static final int[] LEVEL_MIN_XP = {
+            0,
+            100,
+            350,
+            850,
+            1750,
+            3250,
+            5750,
+            9750,
+            16250,
+            26250
+    };
+
+    private GamificationLevelCalculator() {
+    }
+
+    public static int levelOf(Integer xpTotal) {
+        int normalizedXp = normalizeXp(xpTotal);
+        for (int index = LEVEL_MIN_XP.length - 1; index >= 0; index--) {
+            if (normalizedXp >= LEVEL_MIN_XP[index]) {
+                return index + 1;
+            }
+        }
+        return 1;
+    }
+
+    public static int currentLevelMinXp(Integer currentLevel) {
+        return LEVEL_MIN_XP[normalizeLevel(currentLevel) - 1];
+    }
+
+    public static Integer nextLevel(Integer currentLevel) {
+        int normalizedLevel = normalizeLevel(currentLevel);
+        if (normalizedLevel >= MAX_LEVEL) {
+            return null;
+        }
+        return normalizedLevel + 1;
+    }
+
+    public static Integer nextLevelRequiredXp(Integer currentLevel) {
+        Integer nextLevel = nextLevel(currentLevel);
+        if (nextLevel == null) {
+            return null;
+        }
+        return LEVEL_MIN_XP[nextLevel - 1];
+    }
+
+    public static int progressPct(Integer xpTotal, Integer currentLevel) {
+        int normalizedLevel = normalizeLevel(currentLevel);
+        if (normalizedLevel >= MAX_LEVEL) {
+            return 100;
+        }
+
+        int minXp = currentLevelMinXp(normalizedLevel);
+        int nextMinXp = nextLevelRequiredXp(normalizedLevel);
+        int progressPct = (normalizeXp(xpTotal) - minXp) * 100 / (nextMinXp - minXp);
+        return Math.max(0, Math.min(progressPct, 100));
+    }
+
+    private static int normalizeXp(Integer xpTotal) {
+        return Math.max(xpTotal == null ? 0 : xpTotal, 0);
+    }
+
+    private static int normalizeLevel(Integer currentLevel) {
+        if (currentLevel == null || currentLevel < 1) {
+            return 1;
+        }
+        return Math.min(currentLevel, MAX_LEVEL);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculator.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculator.java
@@ -1,9 +1,34 @@
 package com.f1.quiket.domain.gamification.service;
 
+/**
+ * 게임화 레벨 계산 유틸 — GAMIF-002 캐릭터 성장 & XP 정책 기준.
+ *
+ * <p>총 10레벨(만렙) 구조이며 레벨별 누적 XP 하한은 명세를 그대로 옮긴 값이다.
+ * 만렙(Lv.10) 도달 후엔 추가 XP가 누적되지 않는 정책이라 적립측에서
+ * {@link #MAX_LEVEL_MIN_XP}를 상한으로 사용한다.</p>
+ */
 public final class GamificationLevelCalculator {
 
+    /**
+     * 명세 GAMIF-002 — 만렙 차수.
+     */
     public static final int MAX_LEVEL = 10;
 
+    /**
+     * 명세 GAMIF-002 — 레벨별 누적 XP 하한(레벨 시작값).
+     * <ul>
+     *     <li>Lv.1: 0 ~ 99</li>
+     *     <li>Lv.2: 100 ~ 349</li>
+     *     <li>Lv.3: 350 ~ 849</li>
+     *     <li>Lv.4: 850 ~ 1,749</li>
+     *     <li>Lv.5: 1,750 ~ 3,249</li>
+     *     <li>Lv.6: 3,250 ~ 5,749</li>
+     *     <li>Lv.7: 5,750 ~ 9,749</li>
+     *     <li>Lv.8: 9,750 ~ 16,249</li>
+     *     <li>Lv.9: 16,250 ~ 26,249</li>
+     *     <li>Lv.10: 26,250 이상 (만렙)</li>
+     * </ul>
+     */
     private static final int[] LEVEL_MIN_XP = {
             0,
             100,
@@ -16,6 +41,12 @@ public final class GamificationLevelCalculator {
             16250,
             26250
     };
+
+    /**
+     * 명세 GAMIF-002 — 만렙(Lv.10) 진입 누적 XP. 누적 XP가 이 값 이상이면 만렙이며,
+     * 만렙 도달 후엔 추가 XP를 누적하지 않는다.
+     */
+    public static final int MAX_LEVEL_MIN_XP = LEVEL_MIN_XP[MAX_LEVEL - 1];
 
     private GamificationLevelCalculator() {
     }

--- a/src/main/java/com/f1/quiket/domain/gamification/service/GamificationRewardService.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/GamificationRewardService.java
@@ -43,11 +43,14 @@ public class GamificationRewardService {
 
         int dotoriEarned = calculateDotoriEarned(playSession, normalizedCorrectCount);
         int baseXp = normalizedCorrectCount * xpPerCorrect(quizSession.getDifficulty(), playSession.getPlayType());
-        int earnedXp = calculateEarnedXp(baseXp, streakMultiplier);
+        int rawEarnedXp = calculateEarnedXp(baseXp, streakMultiplier);
 
         int dotoriBefore = user.getDotoriBalance();
         int xpBefore = user.getXpTotal();
         int levelBefore = user.getCurrentLevel();
+        // 명세 GAMIF-002 — 만렙(Lv.10) 도달 후엔 추가 XP 누적 X.
+        // 만렙 진입선까지의 잔여 분만큼만 적립하여, 응답·로그·user.xpTotal이 모두 같은 값으로 정렬되도록 한다.
+        int earnedXp = capByMaxLevelXp(xpBefore, rawEarnedXp);
         int dotoriAfter = dotoriBefore + dotoriEarned;
         int xpAfter = xpBefore + earnedXp;
         int levelAfter = GamificationLevelCalculator.levelOf(xpAfter);
@@ -94,6 +97,10 @@ public class GamificationRewardService {
         return userStreakLogRepository.save(UserStreakLog.create(userId, today, streakCount, multiplierOf(streakCount)));
     }
 
+    /**
+     * 명세 GAMIF-001 — 도토리는 첫 풀이(first)에 한해 정답 1문항당 +1 적립한다.
+     * retry_all / retry_wrong은 XP만 적립하고 도토리는 0이다.
+     */
     private int calculateDotoriEarned(QuizPlaySession playSession, int correctCount) {
         if (!PLAY_TYPE_FIRST.equals(playSession.getPlayType())) {
             return 0;
@@ -101,6 +108,14 @@ public class GamificationRewardService {
         return correctCount;
     }
 
+    /**
+     * 명세 GAMIF-002 — 난이도별 정답 1문항당 적립 XP.
+     * <ul>
+     *     <li>첫 풀이(first): easy 3 / medium 4 / hard 5</li>
+     *     <li>복습(retry_all, retry_wrong): easy 2 / medium 3 / hard 4</li>
+     * </ul>
+     * <p>알 수 없는 난이도 값은 medium 기준으로 매핑한다.</p>
+     */
     private int xpPerCorrect(String difficulty, String playType) {
         if (PLAY_TYPE_FIRST.equals(playType)) {
             return switch (difficulty) {
@@ -116,6 +131,17 @@ public class GamificationRewardService {
         };
     }
 
+    /**
+     * 명세 GAMIF-002 — 연속 학습 일일 보너스 배수.
+     * <ul>
+     *     <li>1일: *1.0</li>
+     *     <li>2일: *1.1</li>
+     *     <li>3~5일: *1.2</li>
+     *     <li>6~13일: *1.5</li>
+     *     <li>14~29일: *2.0</li>
+     *     <li>30일 이상: *2.5</li>
+     * </ul>
+     */
     private BigDecimal multiplierOf(int streakCount) {
         if (streakCount >= 30) {
             return BigDecimal.valueOf(2.5);
@@ -140,6 +166,16 @@ public class GamificationRewardService {
                 .multiply(streakMultiplier)
                 .setScale(0, RoundingMode.DOWN)
                 .intValue();
+    }
+
+    /**
+     * 명세 GAMIF-002 — 만렙(Lv.10) 도달 후엔 XP 누적이 멈춘다.
+     * xpBefore가 만렙 진입선({@link GamificationLevelCalculator#MAX_LEVEL_MIN_XP}) 이상이면 0,
+     * 그렇지 않으면 진입선까지의 잔여 분과 rawEarnedXp 중 작은 값을 실제 적립값으로 사용한다.
+     */
+    private int capByMaxLevelXp(int xpBefore, int rawEarnedXp) {
+        int remainingToMax = Math.max(GamificationLevelCalculator.MAX_LEVEL_MIN_XP - xpBefore, 0);
+        return Math.min(rawEarnedXp, remainingToMax);
     }
 
     private void saveRewardLogs(

--- a/src/main/java/com/f1/quiket/domain/gamification/service/GamificationRewardService.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/GamificationRewardService.java
@@ -1,0 +1,183 @@
+package com.f1.quiket.domain.gamification.service;
+
+import com.f1.quiket.domain.gamification.entity.UserDotoriLog;
+import com.f1.quiket.domain.gamification.entity.UserStreakLog;
+import com.f1.quiket.domain.gamification.entity.UserXpLog;
+import com.f1.quiket.domain.gamification.repository.UserDotoriLogRepository;
+import com.f1.quiket.domain.gamification.repository.UserStreakLogRepository;
+import com.f1.quiket.domain.gamification.repository.UserXpLogRepository;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.user.entity.User;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GamificationRewardService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final String PLAY_TYPE_FIRST = "first";
+    private static final String XP_TYPE_QUIZ_CORRECT = "quiz_correct";
+    private static final String XP_TYPE_QUIZ_RETRY = "quiz_retry";
+
+    private final UserXpLogRepository userXpLogRepository;
+    private final UserDotoriLogRepository userDotoriLogRepository;
+    private final UserStreakLogRepository userStreakLogRepository;
+
+    public QuizRewardResult applyQuizReward(
+            User user,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Integer correctCount
+    ) {
+        int normalizedCorrectCount = Math.max(correctCount == null ? 0 : correctCount, 0);
+        UserStreakLog streakLog = findOrCreateTodayStreak(user.getId());
+        BigDecimal streakMultiplier = streakLog.getMultiplier();
+
+        int dotoriEarned = calculateDotoriEarned(playSession, normalizedCorrectCount);
+        int baseXp = normalizedCorrectCount * xpPerCorrect(quizSession.getDifficulty(), playSession.getPlayType());
+        int earnedXp = calculateEarnedXp(baseXp, streakMultiplier);
+
+        int dotoriBefore = user.getDotoriBalance();
+        int xpBefore = user.getXpTotal();
+        int levelBefore = user.getCurrentLevel();
+        int dotoriAfter = dotoriBefore + dotoriEarned;
+        int xpAfter = xpBefore + earnedXp;
+        int levelAfter = GamificationLevelCalculator.levelOf(xpAfter);
+        boolean leveledUp = levelAfter > levelBefore;
+
+        user.applyQuizReward(dotoriEarned, earnedXp, levelAfter);
+        saveRewardLogs(
+                user,
+                playSession,
+                dotoriEarned,
+                dotoriBefore,
+                dotoriAfter,
+                baseXp,
+                streakMultiplier,
+                earnedXp,
+                xpBefore,
+                xpAfter,
+                levelBefore,
+                levelAfter
+        );
+
+        return new QuizRewardResult(
+                dotoriEarned,
+                earnedXp,
+                leveledUp,
+                leveledUp ? levelAfter : null,
+                user.getDotoriBalance(),
+                user.getXpTotal()
+        );
+    }
+
+    private UserStreakLog findOrCreateTodayStreak(Long userId) {
+        LocalDate today = LocalDate.now(KST);
+        return userStreakLogRepository.findByUserIdAndStudyDate(userId, today)
+                .orElseGet(() -> createTodayStreak(userId, today));
+    }
+
+    private UserStreakLog createTodayStreak(Long userId, LocalDate today) {
+        int streakCount = userStreakLogRepository.findTopByUserIdAndStudyDateBeforeOrderByStudyDateDesc(userId, today)
+                .map(previous -> previous.getStudyDate().equals(today.minusDays(1))
+                        ? previous.getStreakCount() + 1
+                        : 1)
+                .orElse(1);
+        return userStreakLogRepository.save(UserStreakLog.create(userId, today, streakCount, multiplierOf(streakCount)));
+    }
+
+    private int calculateDotoriEarned(QuizPlaySession playSession, int correctCount) {
+        if (!PLAY_TYPE_FIRST.equals(playSession.getPlayType())) {
+            return 0;
+        }
+        return correctCount;
+    }
+
+    private int xpPerCorrect(String difficulty, String playType) {
+        if (PLAY_TYPE_FIRST.equals(playType)) {
+            return switch (difficulty) {
+                case "easy" -> 3;
+                case "hard" -> 5;
+                default -> 4;
+            };
+        }
+        return switch (difficulty) {
+            case "easy" -> 2;
+            case "hard" -> 4;
+            default -> 3;
+        };
+    }
+
+    private BigDecimal multiplierOf(int streakCount) {
+        if (streakCount >= 30) {
+            return BigDecimal.valueOf(2.5);
+        }
+        if (streakCount >= 14) {
+            return BigDecimal.valueOf(2.0);
+        }
+        if (streakCount >= 6) {
+            return BigDecimal.valueOf(1.5);
+        }
+        if (streakCount >= 3) {
+            return BigDecimal.valueOf(1.2);
+        }
+        if (streakCount == 2) {
+            return BigDecimal.valueOf(1.1);
+        }
+        return BigDecimal.valueOf(1.0);
+    }
+
+    private int calculateEarnedXp(int baseXp, BigDecimal streakMultiplier) {
+        return BigDecimal.valueOf(baseXp)
+                .multiply(streakMultiplier)
+                .setScale(0, RoundingMode.DOWN)
+                .intValue();
+    }
+
+    private void saveRewardLogs(
+            User user,
+            QuizPlaySession playSession,
+            int dotoriEarned,
+            int dotoriBefore,
+            int dotoriAfter,
+            int baseXp,
+            BigDecimal streakMultiplier,
+            int earnedXp,
+            int xpBefore,
+            int xpAfter,
+            int levelBefore,
+            int levelAfter
+    ) {
+        if (dotoriEarned > 0) {
+            userDotoriLogRepository.save(UserDotoriLog.createQuizEarn(
+                    user.getId(),
+                    playSession.getId(),
+                    dotoriEarned,
+                    dotoriBefore,
+                    dotoriAfter
+            ));
+        }
+        if (earnedXp > 0) {
+            userXpLogRepository.save(UserXpLog.createQuizReward(
+                    user.getId(),
+                    playSession.getId(),
+                    PLAY_TYPE_FIRST.equals(playSession.getPlayType()) ? XP_TYPE_QUIZ_CORRECT : XP_TYPE_QUIZ_RETRY,
+                    baseXp,
+                    streakMultiplier,
+                    earnedXp,
+                    xpBefore,
+                    xpAfter,
+                    levelBefore,
+                    levelAfter
+            ));
+        }
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/service/GamificationService.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/GamificationService.java
@@ -1,0 +1,24 @@
+package com.f1.quiket.domain.gamification.service;
+
+import com.f1.quiket.domain.gamification.dto.GamificationResponse;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GamificationService {
+
+    private final UserRepository userRepository;
+
+    public GamificationResponse getMyGamification(String userPublicId) {
+        User user = userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+        return GamificationResponse.from(user);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/gamification/service/QuizRewardResult.java
+++ b/src/main/java/com/f1/quiket/domain/gamification/service/QuizRewardResult.java
@@ -1,0 +1,11 @@
+package com.f1.quiket.domain.gamification.service;
+
+public record QuizRewardResult(
+        Integer dotoriEarned,
+        Integer xpEarned,
+        Boolean leveledUp,
+        Integer newLevel,
+        Integer currentDotoriBalance,
+        Integer currentXpTotal
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.part.repository;
 
 import com.f1.quiket.domain.part.entity.Part;
+import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -15,4 +16,19 @@ public interface PartRepository extends JpaRepository<Part, Long> {
      * 사용자 파트 목록 조회
      */
     List<Part> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 과목 파트 목록 조회
+     */
+    List<Part> findAllBySubjectIdAndDeletedAtIsNull(Long subjectId);
+
+    /**
+     * 챕터별 파트 목록 조회
+     */
+    List<Part> findAllByChapterIdInAndDeletedAtIsNull(Collection<Long> chapterIds);
+
+    /**
+     * 과목별 파트 목록 조회
+     */
+    List<Part> findAllBySubjectIdInAndDeletedAtIsNull(Collection<Long> subjectIds);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
@@ -7,6 +7,7 @@ import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
 import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
 import com.f1.quiket.domain.quiz.service.QuizResultQueryService;
 import com.f1.quiket.domain.quiz.service.QuizResultRetryAllService;
+import com.f1.quiket.domain.quiz.service.QuizResultRetryWrongService;
 import com.f1.quiket.domain.quiz.service.QuizResultSubmitService;
 import com.f1.quiket.global.auth.UserPrincipal;
 import com.f1.quiket.global.response.ApiResponse;
@@ -34,6 +35,7 @@ public class QuizResultController {
     private final QuizResultSubmitService quizResultSubmitService;
     private final QuizResultQueryService quizResultQueryService;
     private final QuizResultRetryAllService quizResultRetryAllService;
+    private final QuizResultRetryWrongService quizResultRetryWrongService;
 
     /**
      * 퀴즈 결과 제출
@@ -72,6 +74,25 @@ public class QuizResultController {
             @Valid @RequestBody QuizRetryRequest request
     ) {
         QuizPlaySessionResponse response = quizResultRetryAllService.retryAll(
+                principal.getUserId(),
+                resultPublicId,
+                request
+        );
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(SuccessCode.CREATED, response));
+    }
+
+    /**
+     * 틀린 문제만 다시풀기 시작
+     */
+    @PostMapping("/{resultId}/retry-wrong")
+    public ResponseEntity<ApiResponse<QuizPlaySessionResponse>> retryWrongQuestions(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("resultId") String resultPublicId,
+            @Valid @RequestBody QuizRetryRequest request
+    ) {
+        QuizPlaySessionResponse response = quizResultRetryWrongService.retryWrong(
                 principal.getUserId(),
                 resultPublicId,
                 request

--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
@@ -1,0 +1,44 @@
+package com.f1.quiket.domain.quiz.controller;
+
+import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
+import com.f1.quiket.domain.quiz.service.QuizResultSubmitService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 퀴즈 결과 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/quiz-results")
+public class QuizResultController {
+
+    private final QuizResultSubmitService quizResultSubmitService;
+
+    /**
+     * 퀴즈 결과 제출
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<QuizResultResponse>> submitQuizResult(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody QuizResultSubmitRequest request
+    ) {
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(principal.getUserId(), request);
+
+        return ResponseEntity
+                .status(outcome.isCreated() ? HttpStatus.CREATED : HttpStatus.OK)
+                .body(ApiResponse.success(outcome.isCreated() ? SuccessCode.CREATED : SuccessCode.OK, outcome.getResponse()));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
@@ -3,6 +3,7 @@ package com.f1.quiket.domain.quiz.controller;
 import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
+import com.f1.quiket.domain.quiz.service.QuizResultQueryService;
 import com.f1.quiket.domain.quiz.service.QuizResultSubmitService;
 import com.f1.quiket.global.auth.UserPrincipal;
 import com.f1.quiket.global.response.ApiResponse;
@@ -12,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class QuizResultController {
 
     private final QuizResultSubmitService quizResultSubmitService;
+    private final QuizResultQueryService quizResultQueryService;
 
     /**
      * 퀴즈 결과 제출
@@ -40,5 +44,17 @@ public class QuizResultController {
         return ResponseEntity
                 .status(outcome.isCreated() ? HttpStatus.CREATED : HttpStatus.OK)
                 .body(ApiResponse.success(outcome.isCreated() ? SuccessCode.CREATED : SuccessCode.OK, outcome.getResponse()));
+    }
+
+    /**
+     * 과거 퀴즈 결과 상세 조회
+     */
+    @GetMapping("/{resultId}")
+    public ResponseEntity<ApiResponse<QuizResultResponse>> getQuizResult(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("resultId") String resultPublicId
+    ) {
+        QuizResultResponse response = quizResultQueryService.getQuizResult(principal.getUserId(), resultPublicId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
@@ -1,9 +1,12 @@
 package com.f1.quiket.domain.quiz.controller;
 
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
 import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
+import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
 import com.f1.quiket.domain.quiz.service.QuizResultQueryService;
+import com.f1.quiket.domain.quiz.service.QuizResultRetryAllService;
 import com.f1.quiket.domain.quiz.service.QuizResultSubmitService;
 import com.f1.quiket.global.auth.UserPrincipal;
 import com.f1.quiket.global.response.ApiResponse;
@@ -30,6 +33,7 @@ public class QuizResultController {
 
     private final QuizResultSubmitService quizResultSubmitService;
     private final QuizResultQueryService quizResultQueryService;
+    private final QuizResultRetryAllService quizResultRetryAllService;
 
     /**
      * 퀴즈 결과 제출
@@ -56,5 +60,24 @@ public class QuizResultController {
     ) {
         QuizResultResponse response = quizResultQueryService.getQuizResult(principal.getUserId(), resultPublicId);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 전체 다시풀기 시작
+     */
+    @PostMapping("/{resultId}/retry-all")
+    public ResponseEntity<ApiResponse<QuizPlaySessionResponse>> retryAllQuestions(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("resultId") String resultPublicId,
+            @Valid @RequestBody QuizRetryRequest request
+    ) {
+        QuizPlaySessionResponse response = quizResultRetryAllService.retryAll(
+                principal.getUserId(),
+                resultPublicId,
+                request
+        );
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(SuccessCode.CREATED, response));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizSessionController.java
@@ -3,8 +3,11 @@ package com.f1.quiket.domain.quiz.controller;
 import com.f1.quiket.domain.quiz.dto.QuizCreateRequest;
 import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
 import com.f1.quiket.domain.quiz.dto.QuizGenerationStatusResponse;
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizPlayStartRequest;
 import com.f1.quiket.domain.quiz.dto.QuizSessionResponse;
 import com.f1.quiket.domain.quiz.service.QuizGenerationStatusService;
+import com.f1.quiket.domain.quiz.service.QuizPlaySessionStartService;
 import com.f1.quiket.domain.quiz.service.QuizSessionCreateService;
 import com.f1.quiket.domain.quiz.service.QuizSessionQueryService;
 import com.f1.quiket.global.auth.UserPrincipal;
@@ -33,6 +36,7 @@ public class QuizSessionController {
     private final QuizSessionCreateService quizSessionCreateService;
     private final QuizGenerationStatusService quizGenerationStatusService;
     private final QuizSessionQueryService quizSessionQueryService;
+    private final QuizPlaySessionStartService quizPlaySessionStartService;
 
     /**
      * 퀴즈 생성 요청
@@ -86,5 +90,25 @@ public class QuizSessionController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 퀴즈 풀이 세션 시작
+     */
+    @PostMapping("/{quizSessionId}/play-sessions")
+    public ResponseEntity<ApiResponse<QuizPlaySessionResponse>> startPlaySession(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("quizSessionId") String quizSessionPublicId,
+            @Valid @RequestBody QuizPlayStartRequest request
+    ) {
+        QuizPlaySessionResponse response = quizPlaySessionStartService.start(
+                principal.getUserId(),
+                quizSessionPublicId,
+                request
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(SuccessCode.CREATED, response));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAiGeneratedOption.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAiGeneratedOption.java
@@ -1,0 +1,12 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizAiGeneratedOption {
+
+    private Integer optionNumber;
+    private String content;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAiGeneratedQuestion.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAiGeneratedQuestion.java
@@ -1,0 +1,21 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizAiGeneratedQuestion {
+
+    private String partId;
+    private String questionType;
+    private String difficulty;
+    private String summary;
+    private String body;
+    private List<QuizAiGeneratedOption> options = new ArrayList<>();
+    private String answerValue;
+    private String correctExplanation;
+    private String incorrectExplanation;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAiGenerationPrompt.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAiGenerationPrompt.java
@@ -1,0 +1,7 @@
+package com.f1.quiket.domain.quiz.dto;
+
+public record QuizAiGenerationPrompt(
+        String systemMessage,
+        String userMessage
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAiGenerationRequest.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAiGenerationRequest.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.subject.entity.Subject;
+import java.util.List;
+
+public record QuizAiGenerationRequest(
+        Subject subject,
+        List<Part> parts,
+        String quizType,
+        Integer choiceCount,
+        Integer questionCount,
+        String playMode,
+        Boolean timerEnabled,
+        String timerScope,
+        Integer timerSeconds,
+        String difficulty
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAiGenerationResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAiGenerationResponse.java
@@ -1,0 +1,13 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizAiGenerationResponse {
+
+    private List<QuizAiGeneratedQuestion> questions = new ArrayList<>();
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAnswerSubmitItem.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizAnswerSubmitItem.java
@@ -1,0 +1,33 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizAnswerSubmitItem {
+
+    @NotBlank(message = "문항 ID는 필수입니다")
+    @Size(max = 36, message = "문항 ID는 36자 이하여야 합니다")
+    private String questionId;
+
+    @Size(max = 36, message = "선택지 ID는 36자 이하여야 합니다")
+    private String selectedOptionId;
+
+    @Size(max = 10, message = "선택값은 10자 이하여야 합니다")
+    private String selectedValue;
+
+    private Boolean correctClient;
+
+    @NotNull(message = "스킵 여부는 필수입니다")
+    private Boolean skipped;
+
+    @Min(value = 0, message = "문항 풀이 시간은 0 이상이어야 합니다")
+    private Integer answerElapsedMs;
+
+    private Boolean marked;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationAcceptedResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationAcceptedResponse.java
@@ -1,5 +1,6 @@
 package com.f1.quiket.domain.quiz.dto;
 
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,12 +18,20 @@ public class QuizGenerationAcceptedResponse {
     private final Integer estimatedSeconds;
 
     public static QuizGenerationAcceptedResponse from(QuizSession quizSession) {
-        // TODO: estimatedSeconds — AI 생성 도입 후 출제 범위/문제수 기반 추정값 산출 후속 이슈에서 대체
         return QuizGenerationAcceptedResponse.builder()
                 .quizSessionId(quizSession.getPublicId())
                 .jobId(quizSession.getJobId())
                 .status(quizSession.getStatus())
                 .estimatedSeconds(null)
+                .build();
+    }
+
+    public static QuizGenerationAcceptedResponse from(QuizSession quizSession, QuizGenerationJob generationJob) {
+        return QuizGenerationAcceptedResponse.builder()
+                .quizSessionId(quizSession.getPublicId())
+                .jobId(quizSession.getJobId())
+                .status(generationJob.getStatus())
+                .estimatedSeconds(generationJob.getEstimatedSeconds())
                 .build();
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationStatusResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizGenerationStatusResponse.java
@@ -1,8 +1,10 @@
 package com.f1.quiket.domain.quiz.dto;
 
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.util.StringUtils;
 
 /**
  * 퀴즈 생성 상태 응답 DTO
@@ -25,7 +27,6 @@ public class QuizGenerationStatusResponse {
     private final String failReason;
 
     public static QuizGenerationStatusResponse from(QuizSession quizSession) {
-        // TODO: AI 생성 도입 후 estimatedSeconds 산출
         return QuizGenerationStatusResponse.builder()
                 .quizSessionId(quizSession.getPublicId())
                 .jobId(quizSession.getJobId())
@@ -37,7 +38,26 @@ public class QuizGenerationStatusResponse {
                 .build();
     }
 
-    // TODO: progressPct — AI 생성 도입 후 quiz_generation_jobs.progress_pct 실제 진행률 사용. 현재는 상태별 placeholder
+    public static QuizGenerationStatusResponse from(QuizSession quizSession, QuizGenerationJob generationJob) {
+        return QuizGenerationStatusResponse.builder()
+                .quizSessionId(quizSession.getPublicId())
+                .jobId(quizSession.getJobId())
+                .status(generationJob.getStatus())
+                .estimatedSeconds(generationJob.getEstimatedSeconds())
+                .progressPct(generationJob.getProgressPct())
+                .generatedCount(quizSession.getGeneratedCount())
+                .failReason(resolveFailReason(quizSession, generationJob))
+                .build();
+    }
+
+    private static String resolveFailReason(QuizSession quizSession, QuizGenerationJob generationJob) {
+        if (StringUtils.hasText(generationJob.getFailReason())) {
+            return generationJob.getFailReason();
+        }
+        return quizSession.getFailReason();
+    }
+
+    // TODO: 이전 생성 세션 호환용 fallback
     private static Integer resolveProgressPct(String status) {
         return switch (status) {
             case STATUS_PENDING -> 0;

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlaySessionResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlaySessionResponse.java
@@ -1,0 +1,35 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizPlaySessionResponse {
+
+    private final String playSessionId;
+    private final String clientSessionId;
+    private final String quizSessionId;
+    private final String playType;
+    private final String status;
+    private final Boolean questionShuffled;
+    private final Boolean optionShuffled;
+    private final String shuffleSeed;
+    private final Integer lastQuestionIndex;
+
+    public static QuizPlaySessionResponse of(QuizPlaySession playSession, QuizSession quizSession) {
+        return QuizPlaySessionResponse.builder()
+                .playSessionId(playSession.getClientSessionId())
+                .clientSessionId(playSession.getClientSessionId())
+                .quizSessionId(quizSession.getPublicId())
+                .playType(playSession.getPlayType())
+                .status(playSession.getStatus())
+                .questionShuffled(playSession.getQuestionShuffled())
+                .optionShuffled(playSession.getOptionShuffled())
+                .shuffleSeed(playSession.getShuffleSeed())
+                .lastQuestionIndex(playSession.getLastQuestionIndex())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlaySessionResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlaySessionResponse.java
@@ -14,10 +14,6 @@ public class QuizPlaySessionResponse {
     private final String quizSessionId;
     private final String playType;
     private final String status;
-    private final Boolean questionShuffled;
-    private final Boolean optionShuffled;
-    private final String shuffleSeed;
-    private final Integer lastQuestionIndex;
 
     public static QuizPlaySessionResponse of(QuizPlaySession playSession, QuizSession quizSession) {
         return QuizPlaySessionResponse.builder()
@@ -26,10 +22,6 @@ public class QuizPlaySessionResponse {
                 .quizSessionId(quizSession.getPublicId())
                 .playType(playSession.getPlayType())
                 .status(playSession.getStatus())
-                .questionShuffled(playSession.getQuestionShuffled())
-                .optionShuffled(playSession.getOptionShuffled())
-                .shuffleSeed(playSession.getShuffleSeed())
-                .lastQuestionIndex(playSession.getLastQuestionIndex())
                 .build();
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlayStartRequest.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlayStartRequest.java
@@ -1,0 +1,30 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizPlayStartRequest {
+
+    @NotBlank(message = "풀이 세션 ID는 필수입니다")
+    @Size(max = 36, message = "풀이 세션 ID는 36자 이하여야 합니다")
+    private String clientSessionId;
+
+    @NotBlank(message = "풀이 유형은 필수입니다")
+    @Pattern(regexp = "first|retry_all|retry_wrong", message = "풀이 유형이 올바르지 않습니다")
+    private String playType;
+
+    @Size(max = 36, message = "부모 풀이 세션 ID는 36자 이하여야 합니다")
+    private String parentPlaySessionId;
+
+    private Boolean questionShuffled;
+
+    private Boolean optionShuffled;
+
+    @Size(max = 100, message = "셔플 시드는 100자 이하여야 합니다")
+    private String shuffleSeed;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultResponse.java
@@ -4,6 +4,7 @@ import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
 import com.f1.quiket.domain.quiz.entity.QuizResult;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
@@ -36,6 +37,7 @@ public class QuizResultResponse {
             QuizPlaySession playSession,
             QuizSession quizSession,
             Subject subject,
+            User user,
             List<QuizReviewItemResponse> reviewItems
     ) {
         return QuizResultResponse.builder()
@@ -52,7 +54,7 @@ public class QuizResultResponse {
                 .elapsedMs(result.getElapsedMs())
                 .scoreMatched(result.getScoreMatched())
                 .abuseFlagged(result.getAbuseFlagged())
-                .rewards(QuizRewardSummaryResponse.from(result))
+                .rewards(QuizRewardSummaryResponse.of(result, user))
                 .reviewItems(reviewItems)
                 .retryAvailable(QuizRetryAvailableResponse.from(result.getWrongCount()))
                 .createdAt(result.getCreatedAt())

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultResponse.java
@@ -1,0 +1,61 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.subject.entity.Subject;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizResultResponse {
+
+    private final String resultId;
+    private final String playSessionId;
+    private final String quizSessionId;
+    private final String subjectId;
+    private final String subjectName;
+    private final Integer totalCount;
+    private final Integer correctCount;
+    private final Integer wrongCount;
+    private final Integer skipCount;
+    private final Integer accuracyPct;
+    private final Integer elapsedMs;
+    private final Boolean scoreMatched;
+    private final Boolean abuseFlagged;
+    private final QuizRewardSummaryResponse rewards;
+    private final List<QuizReviewItemResponse> reviewItems;
+    private final QuizRetryAvailableResponse retryAvailable;
+    private final LocalDateTime createdAt;
+
+    public static QuizResultResponse of(
+            QuizResult result,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            List<QuizReviewItemResponse> reviewItems
+    ) {
+        return QuizResultResponse.builder()
+                .resultId(result.getPublicId())
+                .playSessionId(playSession.getClientSessionId())
+                .quizSessionId(quizSession.getPublicId())
+                .subjectId(subject.getPublicId())
+                .subjectName(subject.getName())
+                .totalCount(result.getTotalCount())
+                .correctCount(result.getCorrectCount())
+                .wrongCount(result.getWrongCount())
+                .skipCount(result.getSkipCount())
+                .accuracyPct(result.getAccuracyPct())
+                .elapsedMs(result.getElapsedMs())
+                .scoreMatched(result.getScoreMatched())
+                .abuseFlagged(result.getAbuseFlagged())
+                .rewards(QuizRewardSummaryResponse.from(result))
+                .reviewItems(reviewItems)
+                .retryAvailable(QuizRetryAvailableResponse.from(result.getWrongCount()))
+                .createdAt(result.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultSubmitOutcome.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultSubmitOutcome.java
@@ -1,0 +1,12 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class QuizResultSubmitOutcome {
+
+    private final QuizResultResponse response;
+    private final boolean created;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultSubmitRequest.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultSubmitRequest.java
@@ -1,0 +1,47 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizResultSubmitRequest {
+
+    @NotBlank(message = "풀이 세션 ID는 필수입니다")
+    @Size(max = 36, message = "풀이 세션 ID는 36자 이하여야 합니다")
+    private String clientSessionId;
+
+    @NotBlank(message = "퀴즈 세션 ID는 필수입니다")
+    @Size(max = 36, message = "퀴즈 세션 ID는 36자 이하여야 합니다")
+    private String quizSessionId;
+
+    @NotBlank(message = "풀이 유형은 필수입니다")
+    @Pattern(regexp = "first|retry_all|retry_wrong", message = "풀이 유형이 올바르지 않습니다")
+    private String playType;
+
+    @Size(max = 36, message = "부모 풀이 세션 ID는 36자 이하여야 합니다")
+    private String parentPlaySessionId;
+
+    @NotNull(message = "풀이 시간은 필수입니다")
+    @Min(value = 0, message = "풀이 시간은 0 이상이어야 합니다")
+    private Integer elapsedMs;
+
+    private Boolean questionShuffled;
+
+    private Boolean optionShuffled;
+
+    @Size(max = 100, message = "셔플 시드는 100자 이하여야 합니다")
+    private String shuffleSeed;
+
+    @Valid
+    @NotEmpty(message = "답안 목록은 필수입니다")
+    private List<QuizAnswerSubmitItem> answers;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRetryAvailableResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRetryAvailableResponse.java
@@ -1,0 +1,21 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizRetryAvailableResponse {
+
+    private final Boolean retryAll;
+    private final Boolean retryWrong;
+    private final Integer wrongCount;
+
+    public static QuizRetryAvailableResponse from(Integer wrongCount) {
+        return QuizRetryAvailableResponse.builder()
+                .retryAll(true)
+                .retryWrong(wrongCount > 0)
+                .wrongCount(wrongCount)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRetryRequest.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRetryRequest.java
@@ -1,0 +1,22 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuizRetryRequest {
+
+    @NotBlank(message = "풀이 세션 ID는 필수입니다")
+    @Size(max = 36, message = "풀이 세션 ID는 36자 이하여야 합니다")
+    private String clientSessionId;
+
+    private Boolean questionShuffled;
+
+    private Boolean optionShuffled;
+
+    @Size(max = 100, message = "셔플 시드는 100자 이하여야 합니다")
+    private String shuffleSeed;
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizReviewItemResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizReviewItemResponse.java
@@ -1,0 +1,51 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizReviewItemResponse {
+
+    private final String questionId;
+    private final Integer displayOrder;
+    private final String summary;
+    private final String body;
+    private final List<QuestionOptionResponse> options;
+    private final String selectedOptionId;
+    private final String selectedValue;
+    private final String answerValue;
+    private final Boolean correctServer;
+    private final Boolean skipped;
+    private final String correctExplanation;
+    private final String incorrectExplanation;
+
+    public static QuizReviewItemResponse of(
+            Question question,
+            List<QuestionOption> options,
+            QuestionAnswer answer,
+            QuizPlayAnswer playAnswer
+    ) {
+        return QuizReviewItemResponse.builder()
+                .questionId(question.getPublicId())
+                .displayOrder(question.getDisplayOrder())
+                .summary(question.getSummary())
+                .body(question.getBody())
+                .options(options.stream()
+                        .map(QuestionOptionResponse::from)
+                        .toList())
+                .selectedOptionId(playAnswer.getSelectedOptionId() == null ? null : String.valueOf(playAnswer.getSelectedOptionId()))
+                .selectedValue(playAnswer.getSelectedValue())
+                .answerValue(answer.getAnswerValue())
+                .correctServer(playAnswer.getCorrectServer())
+                .skipped(playAnswer.getSkipped())
+                .correctExplanation(question.getCorrectExplanation())
+                .incorrectExplanation(question.getIncorrectExplanation())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRewardSummaryResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRewardSummaryResponse.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.quiz.dto;
 
 import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,13 +13,17 @@ public class QuizRewardSummaryResponse {
     private final Integer xpEarned;
     private final Boolean leveledUp;
     private final Integer newLevel;
+    private final Integer currentDotoriBalance;
+    private final Integer currentXpTotal;
 
-    public static QuizRewardSummaryResponse from(QuizResult result) {
+    public static QuizRewardSummaryResponse of(QuizResult result, User user) {
         return QuizRewardSummaryResponse.builder()
                 .dotoriEarned(result.getDotoriEarned())
                 .xpEarned(result.getXpEarned())
                 .leveledUp(result.getLeveledUp())
                 .newLevel(result.getNewLevel())
+                .currentDotoriBalance(user.getDotoriBalance())
+                .currentXpTotal(user.getXpTotal())
                 .build();
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRewardSummaryResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRewardSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuizRewardSummaryResponse {
+
+    private final Integer dotoriEarned;
+    private final Integer xpEarned;
+    private final Boolean leveledUp;
+    private final Integer newLevel;
+
+    public static QuizRewardSummaryResponse from(QuizResult result) {
+        return QuizRewardSummaryResponse.builder()
+                .dotoriEarned(result.getDotoriEarned())
+                .xpEarned(result.getXpEarned())
+                .leveledUp(result.getLeveledUp())
+                .newLevel(result.getNewLevel())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/Question.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/Question.java
@@ -79,4 +79,36 @@ public class Question {
 
     @Column(name = "display_order", nullable = false)
     Integer displayOrder;
+
+    public static Question create(
+            String publicId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            Long chapterId,
+            Long partId,
+            String questionType,
+            String difficulty,
+            String body,
+            String summary,
+            String correctExplanation,
+            String incorrectExplanation,
+            Integer displayOrder
+    ) {
+        Question question = new Question();
+        question.publicId = publicId;
+        question.quizSessionId = quizSessionId;
+        question.userId = userId;
+        question.subjectId = subjectId;
+        question.chapterId = chapterId;
+        question.partId = partId;
+        question.questionType = questionType;
+        question.difficulty = difficulty;
+        question.body = body;
+        question.summary = summary;
+        question.correctExplanation = correctExplanation;
+        question.incorrectExplanation = incorrectExplanation;
+        question.displayOrder = displayOrder;
+        return question;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionAnswer.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionAnswer.java
@@ -37,4 +37,11 @@ public class QuestionAnswer {
 
     @Column(name = "answer_value", length = 10, nullable = false)
     String answerValue;
+
+    public static QuestionAnswer create(Long questionId, String answerValue) {
+        QuestionAnswer answer = new QuestionAnswer();
+        answer.questionId = questionId;
+        answer.answerValue = answerValue;
+        return answer;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionOption.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuestionOption.java
@@ -49,4 +49,18 @@ public class QuestionOption {
 
     @Column(name = "is_correct", nullable = false)
     Boolean correct;
+
+    public static QuestionOption create(
+            Long questionId,
+            Integer optionNumber,
+            String content,
+            Boolean correct
+    ) {
+        QuestionOption option = new QuestionOption();
+        option.questionId = questionId;
+        option.optionNumber = optionNumber;
+        option.content = content;
+        option.correct = correct;
+        return option;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizGenerationJob.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizGenerationJob.java
@@ -1,0 +1,156 @@
+package com.f1.quiket.domain.quiz.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(
+        name = "quiz_generation_jobs",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_quiz_generation_jobs_session_id", columnNames = "quiz_session_id")
+        },
+        indexes = {
+                @Index(name = "idx_quiz_generation_jobs_user_id_status", columnList = "user_id, status"),
+                @Index(name = "idx_quiz_generation_jobs_timeout_at", columnList = "timeout_at")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuizGenerationJob {
+
+    private static final String STATUS_PENDING = "pending";
+    private static final String STATUS_IN_PROGRESS = "in_progress";
+    private static final String STATUS_COMPLETED = "completed";
+    private static final String STATUS_FAILED = "failed";
+    private static final String STATUS_TIMEOUT = "timeout";
+    private static final int PROGRESS_PENDING = 0;
+    private static final int PROGRESS_STARTED = 10;
+    private static final int PROGRESS_DONE = 100;
+    private static final long TIMEOUT_MINUTES = 10L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "quiz_session_id", nullable = false)
+    Long quizSessionId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "status", length = 20, nullable = false)
+    String status = STATUS_PENDING;
+
+    @Column(name = "progress_pct", nullable = false)
+    Integer progressPct = PROGRESS_PENDING;
+
+    @Column(name = "estimated_seconds")
+    Integer estimatedSeconds;
+
+    @Column(name = "estimated_finish_at")
+    LocalDateTime estimatedFinishAt;
+
+    @Column(name = "started_at")
+    LocalDateTime startedAt;
+
+    @Column(name = "completed_at")
+    LocalDateTime completedAt;
+
+    @Column(name = "timeout_at")
+    LocalDateTime timeoutAt;
+
+    @Column(name = "retry_count", nullable = false)
+    Integer retryCount = 0;
+
+    @Column(name = "is_retryable", nullable = false)
+    boolean retryable = true;
+
+    @Column(name = "fail_code", length = 50)
+    String failCode;
+
+    @Column(name = "fail_reason", length = 500)
+    String failReason;
+
+    @Column(name = "mq_message_id", length = 100)
+    String mqMessageId;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+
+    public static QuizGenerationJob create(Long quizSessionId, Long userId, Integer estimatedSeconds) {
+        QuizGenerationJob job = new QuizGenerationJob();
+        job.quizSessionId = quizSessionId;
+        job.userId = userId;
+        job.estimatedSeconds = estimatedSeconds;
+        return job;
+    }
+
+    public void assignMqMessageId(String mqMessageId) {
+        this.mqMessageId = mqMessageId;
+    }
+
+    public void markInProgress() {
+        LocalDateTime now = LocalDateTime.now();
+        this.status = STATUS_IN_PROGRESS;
+        this.progressPct = PROGRESS_STARTED;
+        this.startedAt = now;
+        this.timeoutAt = now.plusMinutes(TIMEOUT_MINUTES);
+        if (this.estimatedSeconds != null) {
+            this.estimatedFinishAt = now.plusSeconds(this.estimatedSeconds);
+        }
+    }
+
+    public void markCompleted() {
+        this.status = STATUS_COMPLETED;
+        this.progressPct = PROGRESS_DONE;
+        this.completedAt = LocalDateTime.now();
+        this.failCode = null;
+        this.failReason = null;
+        this.retryable = false;
+    }
+
+    public void markFailed(String failCode, String failReason, boolean retryable) {
+        this.status = STATUS_FAILED;
+        this.progressPct = PROGRESS_DONE;
+        this.completedAt = LocalDateTime.now();
+        this.failCode = failCode;
+        this.failReason = failReason;
+        this.retryable = retryable;
+    }
+
+    public void markTimeout(String failReason) {
+        this.status = STATUS_TIMEOUT;
+        this.progressPct = PROGRESS_DONE;
+        this.completedAt = LocalDateTime.now();
+        this.failCode = "timeout";
+        this.failReason = failReason;
+        this.retryable = true;
+    }
+
+    public void increaseRetryCount() {
+        this.retryCount++;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizGenerationJob.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizGenerationJob.java
@@ -153,4 +153,10 @@ public class QuizGenerationJob {
     public void increaseRetryCount() {
         this.retryCount++;
     }
+
+    public boolean isTerminalStatus() {
+        return STATUS_COMPLETED.equals(this.status)
+                || STATUS_FAILED.equals(this.status)
+                || STATUS_TIMEOUT.equals(this.status);
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlayAnswer.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlayAnswer.java
@@ -1,0 +1,109 @@
+package com.f1.quiket.domain.quiz.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+/**
+ * 퀴즈 풀이 답안 엔티티
+ */
+@Entity
+@Table(
+        name = "quiz_play_answers",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_quiz_play_answers_session_question", columnNames = {"play_session_id", "question_id"})
+        },
+        indexes = {
+                @Index(name = "idx_quiz_play_answers_question_id", columnList = "question_id"),
+                @Index(name = "idx_quiz_play_answers_user_id", columnList = "user_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class QuizPlayAnswer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "play_session_id", nullable = false)
+    Long playSessionId;
+
+    @Column(name = "question_id", nullable = false)
+    Long questionId;
+
+    @Column(name = "user_id", nullable = false)
+    Long userId;
+
+    @Column(name = "selected_option_id")
+    Long selectedOptionId;
+
+    @Column(name = "selected_value", length = 10)
+    String selectedValue;
+
+    @Column(name = "is_correct_client")
+    Boolean correctClient;
+
+    @Column(name = "is_correct_server")
+    Boolean correctServer;
+
+    @Column(name = "is_skipped", nullable = false)
+    Boolean skipped;
+
+    @Column(name = "answer_elapsed_ms")
+    Integer answerElapsedMs;
+
+    @Column(name = "is_marked", nullable = false)
+    Boolean marked;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+
+    public static QuizPlayAnswer create(
+            Long playSessionId,
+            Long questionId,
+            Long userId,
+            Long selectedOptionId,
+            String selectedValue,
+            Boolean correctClient,
+            Boolean correctServer,
+            Boolean skipped,
+            Integer answerElapsedMs,
+            Boolean marked
+    ) {
+        QuizPlayAnswer answer = new QuizPlayAnswer();
+        answer.playSessionId = playSessionId;
+        answer.questionId = questionId;
+        answer.userId = userId;
+        answer.selectedOptionId = selectedOptionId;
+        answer.selectedValue = selectedValue;
+        answer.correctClient = correctClient;
+        answer.correctServer = correctServer;
+        answer.skipped = skipped;
+        answer.answerElapsedMs = answerElapsedMs;
+        answer.marked = Boolean.TRUE.equals(marked);
+        return answer;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.quiz.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,6 +14,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * 퀴즈 풀이 세션 엔티티
@@ -27,13 +31,18 @@ import lombok.experimental.FieldDefaults;
                 @Index(name = "idx_quiz_play_sessions_quiz_session_id", columnList = "quiz_session_id"),
                 @Index(name = "idx_quiz_play_sessions_user_id_status", columnList = "user_id, status"),
                 @Index(name = "idx_quiz_play_sessions_user_id_created_at", columnList = "user_id, created_at"),
+                @Index(name = "idx_quiz_play_sessions_parent_play_session_id", columnList = "parent_play_session_id"),
                 @Index(name = "idx_quiz_play_sessions_subject_id_created_at", columnList = "subject_id, created_at")
         }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class QuizPlaySession {
+
+    private static final String PLAY_TYPE_FIRST = "first";
+    private static final String STATUS_IN_PROGRESS = "in_progress";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -52,15 +61,75 @@ public class QuizPlaySession {
     @Column(name = "subject_id", nullable = false)
     Long subjectId;
 
+    @Column(name = "play_type", length = 20, nullable = false)
+    String playType;
+
+    @Column(name = "parent_play_session_id")
+    Long parentPlaySessionId;
+
+    @Column(name = "parent_quiz_session_id")
+    Long parentQuizSessionId;
+
+    @Column(name = "generation", nullable = false)
+    Integer generation;
+
+    @Column(name = "is_question_shuffled", nullable = false)
+    Boolean questionShuffled;
+
+    @Column(name = "is_option_shuffled", nullable = false)
+    Boolean optionShuffled;
+
+    @Column(name = "shuffle_seed", length = 100)
+    String shuffleSeed;
+
     @Column(name = "status", length = 20, nullable = false)
     String status;
 
     @Column(name = "last_question_index", nullable = false)
     Integer lastQuestionIndex;
 
+    @Column(name = "elapsed_ms", nullable = false)
+    Integer elapsedMs;
+
+    @Column(name = "submitted_at")
+    LocalDateTime submittedAt;
+
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     LocalDateTime updatedAt;
+
+    public static QuizPlaySession createFirst(
+            String clientSessionId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizPlaySession playSession = new QuizPlaySession();
+        playSession.clientSessionId = clientSessionId;
+        playSession.quizSessionId = quizSessionId;
+        playSession.userId = userId;
+        playSession.subjectId = subjectId;
+        playSession.playType = PLAY_TYPE_FIRST;
+        playSession.generation = 0;
+        playSession.questionShuffled = Boolean.TRUE.equals(questionShuffled);
+        playSession.optionShuffled = optionShuffled == null || Boolean.TRUE.equals(optionShuffled);
+        playSession.shuffleSeed = shuffleSeed;
+        playSession.status = STATUS_IN_PROGRESS;
+        playSession.lastQuestionIndex = 0;
+        playSession.elapsedMs = 0;
+        return playSession;
+    }
+
+    public boolean isSameStartRequest(Long quizSessionId, Long userId, String playType) {
+        return this.quizSessionId.equals(quizSessionId)
+                && this.userId.equals(userId)
+                && this.playType.equals(playType);
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -42,6 +42,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class QuizPlaySession {
 
     private static final String PLAY_TYPE_FIRST = "first";
+    private static final String PLAY_TYPE_RETRY_ALL = "retry_all";
     private static final String STATUS_IN_PROGRESS = "in_progress";
     private static final String STATUS_SUBMITTED = "submitted";
 
@@ -112,13 +113,59 @@ public class QuizPlaySession {
             Boolean optionShuffled,
             String shuffleSeed
     ) {
+        QuizPlaySession playSession = createBase(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                PLAY_TYPE_FIRST,
+                questionShuffled,
+                optionShuffled,
+                shuffleSeed
+        );
+        playSession.generation = 0;
+        return playSession;
+    }
+
+    public static QuizPlaySession createRetryAll(
+            String clientSessionId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizPlaySession playSession = createBase(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                PLAY_TYPE_RETRY_ALL,
+                questionShuffled,
+                optionShuffled,
+                shuffleSeed
+        );
+        playSession.generation = 0;
+        return playSession;
+    }
+
+    private static QuizPlaySession createBase(
+            String clientSessionId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            String playType,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
         QuizPlaySession playSession = new QuizPlaySession();
         playSession.clientSessionId = clientSessionId;
         playSession.quizSessionId = quizSessionId;
         playSession.userId = userId;
         playSession.subjectId = subjectId;
-        playSession.playType = PLAY_TYPE_FIRST;
-        playSession.generation = 0;
+        playSession.playType = playType;
         playSession.questionShuffled = Boolean.TRUE.equals(questionShuffled);
         playSession.optionShuffled = optionShuffled == null || Boolean.TRUE.equals(optionShuffled);
         playSession.shuffleSeed = shuffleSeed;

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -43,6 +43,7 @@ public class QuizPlaySession {
 
     private static final String PLAY_TYPE_FIRST = "first";
     private static final String PLAY_TYPE_RETRY_ALL = "retry_all";
+    private static final String PLAY_TYPE_RETRY_WRONG = "retry_wrong";
     private static final String STATUS_IN_PROGRESS = "in_progress";
     private static final String STATUS_SUBMITTED = "submitted";
 
@@ -150,6 +151,34 @@ public class QuizPlaySession {
         return playSession;
     }
 
+    public static QuizPlaySession createRetryWrong(
+            String clientSessionId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            Long parentPlaySessionId,
+            Long parentQuizSessionId,
+            Integer generation,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizPlaySession playSession = createBase(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                PLAY_TYPE_RETRY_WRONG,
+                questionShuffled == null || Boolean.TRUE.equals(questionShuffled),
+                optionShuffled,
+                shuffleSeed
+        );
+        playSession.parentPlaySessionId = parentPlaySessionId;
+        playSession.parentQuizSessionId = parentQuizSessionId;
+        playSession.generation = generation;
+        return playSession;
+    }
+
     private static QuizPlaySession createBase(
             String clientSessionId,
             Long quizSessionId,
@@ -179,6 +208,15 @@ public class QuizPlaySession {
         return this.quizSessionId.equals(quizSessionId)
                 && this.userId.equals(userId)
                 && this.playType.equals(playType);
+    }
+
+    public boolean isSameRetryWrongRequest(Long parentPlaySessionId, Long parentQuizSessionId, Long userId) {
+        return this.userId.equals(userId)
+                && PLAY_TYPE_RETRY_WRONG.equals(this.playType)
+                && this.parentPlaySessionId != null
+                && this.parentPlaySessionId.equals(parentPlaySessionId)
+                && this.parentQuizSessionId != null
+                && this.parentQuizSessionId.equals(parentQuizSessionId);
     }
 
     public void submit(Integer elapsedMs) {

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -43,6 +43,7 @@ public class QuizPlaySession {
 
     private static final String PLAY_TYPE_FIRST = "first";
     private static final String STATUS_IN_PROGRESS = "in_progress";
+    private static final String STATUS_SUBMITTED = "submitted";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -131,5 +132,11 @@ public class QuizPlaySession {
         return this.quizSessionId.equals(quizSessionId)
                 && this.userId.equals(userId)
                 && this.playType.equals(playType);
+    }
+
+    public void submit(Integer elapsedMs) {
+        this.status = STATUS_SUBMITTED;
+        this.elapsedMs = elapsedMs;
+        this.submittedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -169,7 +169,7 @@ public class QuizPlaySession {
                 userId,
                 subjectId,
                 PLAY_TYPE_RETRY_WRONG,
-                questionShuffled == null || Boolean.TRUE.equals(questionShuffled),
+                questionShuffled,
                 optionShuffled,
                 shuffleSeed
         );

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
@@ -136,8 +136,6 @@ public class QuizResult {
         result.leveledUp = false;
         result.scoreMatched = scoreMatched;
         result.abuseFlagged = abuseFlagged;
-        result.createdAt = LocalDateTime.now();
-        result.updatedAt = result.createdAt;
         return result;
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
@@ -116,6 +116,10 @@ public class QuizResult {
             Integer skipCount,
             Integer accuracyPct,
             Integer elapsedMs,
+            Integer dotoriEarned,
+            Integer xpEarned,
+            Boolean leveledUp,
+            Integer newLevel,
             Boolean scoreMatched,
             Boolean abuseFlagged
     ) {
@@ -131,9 +135,10 @@ public class QuizResult {
         result.skipCount = skipCount;
         result.accuracyPct = accuracyPct;
         result.elapsedMs = elapsedMs;
-        result.dotoriEarned = 0;
-        result.xpEarned = 0;
-        result.leveledUp = false;
+        result.dotoriEarned = dotoriEarned;
+        result.xpEarned = xpEarned;
+        result.leveledUp = leveledUp;
+        result.newLevel = newLevel;
         result.scoreMatched = scoreMatched;
         result.abuseFlagged = abuseFlagged;
         return result;

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.quiz.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -13,6 +14,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * 퀴즈 결과 엔티티
@@ -32,6 +36,7 @@ import lombok.experimental.FieldDefaults;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class QuizResult {
 
@@ -61,9 +66,78 @@ public class QuizResult {
     @Column(name = "correct_count", nullable = false)
     Integer correctCount;
 
+    @Column(name = "wrong_count", nullable = false)
+    Integer wrongCount;
+
+    @Column(name = "skip_count", nullable = false)
+    Integer skipCount;
+
+    @Column(name = "accuracy_pct", nullable = false)
+    Integer accuracyPct;
+
+    @Column(name = "elapsed_ms", nullable = false)
+    Integer elapsedMs;
+
+    @Column(name = "dotori_earned", nullable = false)
+    Integer dotoriEarned;
+
+    @Column(name = "xp_earned", nullable = false)
+    Integer xpEarned;
+
+    @Column(name = "is_leveled_up", nullable = false)
+    Boolean leveledUp;
+
+    @Column(name = "new_level")
+    Integer newLevel;
+
+    @Column(name = "is_score_matched", nullable = false)
+    Boolean scoreMatched;
+
+    @Column(name = "is_abuse_flagged", nullable = false)
+    Boolean abuseFlagged;
+
+    @CreatedDate
     @Column(name = "created_at", nullable = false)
     LocalDateTime createdAt;
 
+    @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     LocalDateTime updatedAt;
+
+    public static QuizResult create(
+            String publicId,
+            Long playSessionId,
+            Long quizSessionId,
+            Long userId,
+            Long subjectId,
+            Integer totalCount,
+            Integer correctCount,
+            Integer wrongCount,
+            Integer skipCount,
+            Integer accuracyPct,
+            Integer elapsedMs,
+            Boolean scoreMatched,
+            Boolean abuseFlagged
+    ) {
+        QuizResult result = new QuizResult();
+        result.publicId = publicId;
+        result.playSessionId = playSessionId;
+        result.quizSessionId = quizSessionId;
+        result.userId = userId;
+        result.subjectId = subjectId;
+        result.totalCount = totalCount;
+        result.correctCount = correctCount;
+        result.wrongCount = wrongCount;
+        result.skipCount = skipCount;
+        result.accuracyPct = accuracyPct;
+        result.elapsedMs = elapsedMs;
+        result.dotoriEarned = 0;
+        result.xpEarned = 0;
+        result.leveledUp = false;
+        result.scoreMatched = scoreMatched;
+        result.abuseFlagged = abuseFlagged;
+        result.createdAt = LocalDateTime.now();
+        result.updatedAt = result.createdAt;
+        return result;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizSession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizSession.java
@@ -33,6 +33,11 @@ import lombok.experimental.FieldDefaults;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class QuizSession extends BaseEntity {
 
+    private static final String STATUS_IN_PROGRESS = "in_progress";
+    private static final String STATUS_COMPLETED = "completed";
+    private static final String STATUS_FAILED = "failed";
+    private static final int FAIL_REASON_MAX_LENGTH = 255;
+
     @Column(name = "public_id", length = 36, nullable = false)
     String publicId;
 
@@ -111,5 +116,30 @@ public class QuizSession extends BaseEntity {
         quizSession.status = status;
         quizSession.jobId = jobId;
         return quizSession;
+    }
+
+    public void markGenerationInProgress() {
+        this.status = STATUS_IN_PROGRESS;
+        this.failReason = null;
+    }
+
+    public void markGenerationCompleted(Integer generatedCount) {
+        this.status = STATUS_COMPLETED;
+        this.generatedCount = generatedCount;
+        this.failReason = null;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void markGenerationFailed(String failReason) {
+        this.status = STATUS_FAILED;
+        this.failReason = truncateFailReason(failReason);
+        this.completedAt = LocalDateTime.now();
+    }
+
+    private String truncateFailReason(String failReason) {
+        if (failReason == null || failReason.length() <= FAIL_REASON_MAX_LENGTH) {
+            return failReason;
+        }
+        return failReason.substring(0, FAIL_REASON_MAX_LENGTH);
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/event/QuizGenerationEnqueueRequestedEvent.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/event/QuizGenerationEnqueueRequestedEvent.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.quiz.event;
+
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.service.QuizGenerationQueueMessage;
+
+/**
+ * 퀴즈 생성 작업이 DB에 안전하게 적재된 후 Redis 큐 발행을 요청하는 이벤트.
+ *
+ * - 발행 시점: 퀴즈 세션 생성 트랜잭션 *안*
+ * - 처리 시점: 트랜잭션 commit *이후* ({@code AFTER_COMMIT})
+ * - 목적: DB rollback 시 Redis Stream에 orphan 메시지가 남지 않도록 정합성 보장
+ */
+public record QuizGenerationEnqueueRequestedEvent(QuizGenerationQueueMessage message) {
+
+    public static QuizGenerationEnqueueRequestedEvent of(QuizGenerationJob generationJob, QuizSession quizSession) {
+        return new QuizGenerationEnqueueRequestedEvent(QuizGenerationQueueMessage.of(generationJob, quizSession));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizGenerationJobRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizGenerationJobRepository.java
@@ -1,6 +1,8 @@
 package com.f1.quiket.domain.quiz.repository;
 
 import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface QuizGenerationJobRepository extends JpaRepository<QuizGenerationJob, Long> {
 
     Optional<QuizGenerationJob> findByQuizSessionId(Long quizSessionId);
+
+    List<QuizGenerationJob> findAllByStatusAndTimeoutAtBefore(String status, LocalDateTime timeoutAt);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizGenerationJobRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizGenerationJobRepository.java
@@ -1,0 +1,12 @@
+package com.f1.quiket.domain.quiz.repository;
+
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuizGenerationJobRepository extends JpaRepository<QuizGenerationJob, Long> {
+
+    Optional<QuizGenerationJob> findByQuizSessionId(Long quizSessionId);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlayAnswerRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlayAnswerRepository.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.quiz.repository;
+
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 퀴즈 풀이 답안 조회 리포지토리
+ */
+@Repository
+public interface QuizPlayAnswerRepository extends JpaRepository<QuizPlayAnswer, Long> {
+
+    /**
+     * 풀이 세션 답안 목록 조회
+     */
+    List<QuizPlayAnswer> findAllByPlaySessionId(Long playSessionId);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
@@ -15,4 +15,5 @@ public interface QuizPlaySessionRepository extends JpaRepository<QuizPlaySession
      * 사용자 풀이 세션 목록 조회
      */
     List<QuizPlaySession> findAllByUserId(Long userId);
+
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
@@ -21,4 +21,9 @@ public interface QuizPlaySessionRepository extends JpaRepository<QuizPlaySession
      * 클라이언트 풀이 세션 단건 조회
      */
     Optional<QuizPlaySession> findByClientSessionId(String clientSessionId);
+
+    /**
+     * 사용자 풀이 세션 단건 조회
+     */
+    Optional<QuizPlaySession> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.quiz.repository;
 
 import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +16,9 @@ public interface QuizPlaySessionRepository extends JpaRepository<QuizPlaySession
      * 사용자 풀이 세션 목록 조회
      */
     List<QuizPlaySession> findAllByUserId(Long userId);
+
+    /**
+     * 클라이언트 풀이 세션 단건 조회
+     */
+    Optional<QuizPlaySession> findByClientSessionId(String clientSessionId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
@@ -15,4 +15,5 @@ public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
      * 사용자 결과 목록 조회
      */
     List<QuizResult> findAllByUserId(Long userId);
+
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
@@ -21,4 +21,9 @@ public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
      * 풀이 세션 결과 단건 조회
      */
     Optional<QuizResult> findByPlaySessionId(Long playSessionId);
+
+    /**
+     * 사용자 결과 단건 조회
+     */
+    Optional<QuizResult> findByPublicIdAndUserId(String publicId, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.quiz.repository;
 
 import com.f1.quiket.domain.quiz.entity.QuizResult;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +16,9 @@ public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
      * 사용자 결과 목록 조회
      */
     List<QuizResult> findAllByUserId(Long userId);
+
+    /**
+     * 풀이 세션 결과 단건 조회
+     */
+    Optional<QuizResult> findByPlaySessionId(Long playSessionId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
@@ -27,4 +27,9 @@ public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> 
      * 사용자 퀴즈 세션 단건 조회
      */
     Optional<QuizSession> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
+
+    /**
+     * 사용자 퀴즈 세션 단건 조회 (PK 기반)
+     */
+    Optional<QuizSession> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
@@ -15,4 +15,9 @@ public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> 
      * 사용자 퀴즈 세션 목록 조회
      */
     List<QuizSession> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 과목 퀴즈 세션 목록 조회
+     */
+    List<QuizSession> findAllBySubjectIdAndDeletedAtIsNull(Long subjectId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionScopeRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionScopeRepository.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.quiz.repository;
 
 import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,9 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface QuizSessionScopeRepository extends JpaRepository<QuizSessionScope, Long> {
+
+    /**
+     * 퀴즈 세션 출제 범위 목록 조회
+     */
+    List<QuizSessionScope> findAllByQuizSessionId(Long quizSessionId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizAiClient.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizAiClient.java
@@ -1,0 +1,9 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationPrompt;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationResponse;
+
+public interface QuizAiClient {
+
+    QuizAiGenerationResponse generate(QuizAiGenerationPrompt prompt);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizAiResponseValidator.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizAiResponseValidator.java
@@ -1,0 +1,131 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizAiGeneratedOption;
+import com.f1.quiket.domain.quiz.dto.QuizAiGeneratedQuestion;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationRequest;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationResponse;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class QuizAiResponseValidator {
+
+    private static final String QUIZ_TYPE_MULTIPLE_CHOICE = "multiple_choice";
+    private static final String QUIZ_TYPE_OX = "ox";
+    private static final Set<String> DIFFICULTIES = Set.of("easy", "medium", "hard");
+
+    public void validate(QuizAiGenerationRequest request, QuizAiGenerationResponse response) {
+        if (response == null || response.getQuestions() == null) {
+            throw invalidResponse("AI 퀴즈 응답이 비어 있습니다.");
+        }
+        if (response.getQuestions().size() != request.questionCount()) {
+            throw invalidResponse("AI 퀴즈 문항 수가 요청과 다릅니다.");
+        }
+
+        Set<String> allowedPartIds = request.parts().stream()
+                .map(part -> part.getPublicId())
+                .collect(Collectors.toSet());
+
+        for (QuizAiGeneratedQuestion question : response.getQuestions()) {
+            validateQuestion(request, question, allowedPartIds);
+        }
+    }
+
+    private void validateQuestion(
+            QuizAiGenerationRequest request,
+            QuizAiGeneratedQuestion question,
+            Set<String> allowedPartIds
+    ) {
+        if (question == null) {
+            throw invalidResponse("AI 퀴즈 문항이 비어 있습니다.");
+        }
+        validateRequired(question.getPartId(), "partId");
+        validateRequired(question.getQuestionType(), "questionType");
+        validateRequired(question.getDifficulty(), "difficulty");
+        validateRequired(question.getSummary(), "summary");
+        validateRequired(question.getBody(), "body");
+        validateRequired(question.getAnswerValue(), "answerValue");
+        validateRequired(question.getCorrectExplanation(), "correctExplanation");
+        validateRequired(question.getIncorrectExplanation(), "incorrectExplanation");
+
+        if (!allowedPartIds.contains(question.getPartId())) {
+            throw invalidResponse("출제 범위 밖 partId가 포함되었습니다.");
+        }
+        if (!request.quizType().equals(question.getQuestionType())) {
+            throw invalidResponse("요청과 다른 문항 유형이 포함되었습니다.");
+        }
+        if (!DIFFICULTIES.contains(question.getDifficulty())) {
+            throw invalidResponse("허용되지 않은 난이도가 포함되었습니다.");
+        }
+        if (question.getSummary().length() < 8 || question.getSummary().length() > 20) {
+            throw invalidResponse("문항 요약 길이가 올바르지 않습니다.");
+        }
+        if (question.getCorrectExplanation().length() < 5 || question.getIncorrectExplanation().length() < 5) {
+            throw invalidResponse("문항 해설이 너무 짧습니다.");
+        }
+
+        if (QUIZ_TYPE_MULTIPLE_CHOICE.equals(request.quizType())) {
+            validateMultipleChoice(request, question);
+            return;
+        }
+        if (QUIZ_TYPE_OX.equals(request.quizType())) {
+            validateOx(question);
+            return;
+        }
+        throw invalidResponse("지원하지 않는 문항 유형입니다.");
+    }
+
+    private void validateMultipleChoice(QuizAiGenerationRequest request, QuizAiGeneratedQuestion question) {
+        List<QuizAiGeneratedOption> options = question.getOptions();
+        if (options == null || options.size() != request.choiceCount()) {
+            throw invalidResponse("객관식 보기 수가 요청과 다릅니다.");
+        }
+
+        Set<Integer> optionNumbers = new HashSet<>();
+        for (QuizAiGeneratedOption option : options) {
+            if (option == null || option.getOptionNumber() == null || !StringUtils.hasText(option.getContent())) {
+                throw invalidResponse("객관식 선택지가 올바르지 않습니다.");
+            }
+            if (option.getOptionNumber() < 1 || option.getOptionNumber() > request.choiceCount()) {
+                throw invalidResponse("객관식 선택지 번호가 범위를 벗어났습니다.");
+            }
+            if (!optionNumbers.add(option.getOptionNumber())) {
+                throw invalidResponse("객관식 선택지 번호가 중복되었습니다.");
+            }
+        }
+
+        try {
+            int answerNumber = Integer.parseInt(question.getAnswerValue());
+            if (!optionNumbers.contains(answerNumber)) {
+                throw invalidResponse("객관식 정답 번호가 선택지에 없습니다.");
+            }
+        } catch (NumberFormatException e) {
+            throw invalidResponse("객관식 정답 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private void validateOx(QuizAiGeneratedQuestion question) {
+        if (question.getOptions() != null && !question.getOptions().isEmpty()) {
+            throw invalidResponse("OX 문항에는 선택지가 없어야 합니다.");
+        }
+        if (!Set.of("O", "X").contains(question.getAnswerValue())) {
+            throw invalidResponse("OX 정답 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private void validateRequired(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) {
+            throw invalidResponse("AI 퀴즈 필수 필드 누락: " + fieldName);
+        }
+    }
+
+    private CustomException invalidResponse(String message) {
+        return new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, message);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationEnqueueListener.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationEnqueueListener.java
@@ -1,0 +1,49 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.event.QuizGenerationEnqueueRequestedEvent;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
+import com.f1.quiket.global.error.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 퀴즈 생성 큐 발행 이벤트 리스너.
+ *
+ * - 호출 측 트랜잭션 commit 이후 별도 트랜잭션(REQUIRES_NEW)에서 Redis 큐 발행
+ * - enqueue 실패 시 generation_job을 failed 상태로 마킹해 사용자 status 조회로 노출
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QuizGenerationEnqueueListener {
+
+    private static final String FAIL_CODE_ENQUEUE = "enqueue_failed";
+
+    private final QuizGenerationQueue quizGenerationQueue;
+    private final QuizGenerationJobRepository quizGenerationJobRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handle(QuizGenerationEnqueueRequestedEvent event) {
+        Long generationJobId = event.message().generationJobId();
+        try {
+            String messageId = quizGenerationQueue.enqueue(event.message());
+            quizGenerationJobRepository.findById(generationJobId)
+                    .ifPresent(job -> job.assignMqMessageId(messageId));
+        } catch (CustomException e) {
+            log.error("퀴즈 생성 큐 발행 실패 — generation_job을 failed로 마킹. generationJobId={}", generationJobId, e);
+            quizGenerationJobRepository.findById(generationJobId)
+                    .ifPresent(this::markEnqueueFailed);
+        }
+    }
+
+    private void markEnqueueFailed(QuizGenerationJob job) {
+        job.markFailed(FAIL_CODE_ENQUEUE, "퀴즈 생성 큐 발행에 실패했습니다.", true);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessor.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessor.java
@@ -56,6 +56,14 @@ public class QuizGenerationJobProcessor {
     private final QuestionAnswerRepository questionAnswerRepository;
     private final TransactionTemplate transactionTemplate;
 
+    /**
+     * 퀴즈 생성 작업 처리.
+     *
+     * <p>성공/실패 무관 항상 {@code true} 반환 — 호출 측({@code QuizGenerationWorker})이
+     * 큐에서 메시지를 ack(삭제)하도록 함. 실패 케이스는 generation_job/quiz_session을
+     * failed 상태로 마킹해 사용자 status 조회로 노출되며, 큐에는 남기지 않음 (자동 재시도 X).
+     * 자동 재시도가 필요해지면 후속 이슈에서 {@code retryCount}/{@code is_retryable} 기반 재enqueue 도입.</p>
+     */
     public boolean process(QuizGenerationQueueMessage message) {
         try {
             GenerationContext context = transactionTemplate.execute(status -> prepareContext(message));

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessor.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessor.java
@@ -1,0 +1,256 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.dto.QuizAiGeneratedOption;
+import com.f1.quiket.domain.quiz.dto.QuizAiGeneratedQuestion;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationPrompt;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationRequest;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.global.util.UuidV7Generator;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class QuizGenerationJobProcessor {
+
+    private static final String STATUS_IN_PROGRESS = "in_progress";
+    private static final String FAIL_CODE_GENERATION_FAILED = "quiz_generation_failed";
+    private static final String TIMEOUT_FAIL_REASON = "퀴즈 생성 작업이 제한 시간을 초과했습니다.";
+    private static final int MAX_RETRY_COUNT = 3;
+    private static final int FAIL_REASON_MAX_LENGTH = 500;
+
+    private final QuizAiClient quizAiClient;
+    private final QuizGenerationPromptBuilder promptBuilder;
+    private final QuizAiResponseValidator responseValidator;
+    private final QuizGenerationJobRepository quizGenerationJobRepository;
+    private final QuizSessionRepository quizSessionRepository;
+    private final QuizSessionScopeRepository quizSessionScopeRepository;
+    private final SubjectRepository subjectRepository;
+    private final PartRepository partRepository;
+    private final QuestionRepository questionRepository;
+    private final QuestionOptionRepository questionOptionRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
+    private final TransactionTemplate transactionTemplate;
+
+    public boolean process(QuizGenerationQueueMessage message) {
+        try {
+            GenerationContext context = transactionTemplate.execute(status -> prepareContext(message));
+            if (context == null) {
+                return true;
+            }
+
+            QuizAiGenerationPrompt prompt = promptBuilder.build(context.request());
+            QuizAiGenerationResponse response = quizAiClient.generate(prompt);
+            responseValidator.validate(context.request(), response);
+
+            transactionTemplate.executeWithoutResult(status -> completeGeneration(context, response));
+            return true;
+        } catch (Exception e) {
+            transactionTemplate.executeWithoutResult(status -> failGeneration(message, e));
+            return true;
+        }
+    }
+
+    public int markTimedOutJobs() {
+        Integer count = transactionTemplate.execute(status -> {
+            List<QuizGenerationJob> jobs = quizGenerationJobRepository.findAllByStatusAndTimeoutAtBefore(
+                    STATUS_IN_PROGRESS,
+                    LocalDateTime.now()
+            );
+            jobs.forEach(this::markTimedOutJob);
+            return jobs.size();
+        });
+        return count == null ? 0 : count;
+    }
+
+    private GenerationContext prepareContext(QuizGenerationQueueMessage message) {
+        QuizGenerationJob job = quizGenerationJobRepository.findById(message.generationJobId())
+                .orElse(null);
+        if (job == null || job.isTerminalStatus()) {
+            return null;
+        }
+
+        QuizSession quizSession = findQuizSession(message);
+        Subject subject = subjectRepository
+                .findByIdAndUserIdAndDeletedAtIsNull(quizSession.getSubjectId(), quizSession.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+        List<Part> parts = findScopeParts(quizSession);
+
+        job.markInProgress();
+        quizSession.markGenerationInProgress();
+
+        QuizAiGenerationRequest request = new QuizAiGenerationRequest(
+                subject,
+                parts,
+                quizSession.getQuizType(),
+                quizSession.getChoiceCount(),
+                quizSession.getQuestionCount(),
+                quizSession.getPlayMode(),
+                quizSession.getTimerEnabled(),
+                quizSession.getTimerScope(),
+                quizSession.getTimerSeconds(),
+                quizSession.getDifficulty()
+        );
+        Map<String, Part> partsByPublicId = parts.stream()
+                .collect(Collectors.toMap(Part::getPublicId, Function.identity()));
+        return new GenerationContext(message.generationJobId(), quizSession.getId(), quizSession.getUserId(), request, partsByPublicId);
+    }
+
+    private QuizSession findQuizSession(QuizGenerationQueueMessage message) {
+        return quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(message.quizSessionId(), message.userId())
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+    }
+
+    private List<Part> findScopeParts(QuizSession quizSession) {
+        List<Long> partIds = quizSessionScopeRepository.findAllByQuizSessionId(quizSession.getId()).stream()
+                .map(QuizSessionScope::getPartId)
+                .toList();
+        if (partIds.isEmpty()) {
+            throw new CustomException(ErrorCode.QUIZ_SCOPE_INVALID);
+        }
+
+        List<Part> parts = partRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(partIds, quizSession.getUserId());
+        if (parts.size() != partIds.stream().distinct().count()) {
+            throw new CustomException(ErrorCode.QUIZ_SCOPE_INVALID);
+        }
+        return parts;
+    }
+
+    private void completeGeneration(GenerationContext context, QuizAiGenerationResponse response) {
+        QuizGenerationJob job = quizGenerationJobRepository.findById(context.generationJobId())
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        if (job.isTerminalStatus()) {
+            return;
+        }
+
+        QuizSession quizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(
+                context.quizSessionId(),
+                context.userId()
+        ).orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+
+        List<QuizAiGeneratedQuestion> generatedQuestions = response.getQuestions();
+        for (int i = 0; i < generatedQuestions.size(); i++) {
+            saveQuestion(quizSession, context.partsByPublicId(), generatedQuestions.get(i), i + 1);
+        }
+        quizSession.markGenerationCompleted(generatedQuestions.size());
+        job.markCompleted();
+    }
+
+    private void saveQuestion(
+            QuizSession quizSession,
+            Map<String, Part> partsByPublicId,
+            QuizAiGeneratedQuestion generatedQuestion,
+            int displayOrder
+    ) {
+        Part part = partsByPublicId.get(generatedQuestion.getPartId());
+        if (part == null) {
+            throw new CustomException(ErrorCode.QUIZ_SCOPE_INVALID);
+        }
+
+        Question savedQuestion = questionRepository.save(Question.create(
+                UuidV7Generator.generate(),
+                quizSession.getId(),
+                quizSession.getUserId(),
+                quizSession.getSubjectId(),
+                part.getChapterId(),
+                part.getId(),
+                generatedQuestion.getQuestionType(),
+                generatedQuestion.getDifficulty(),
+                generatedQuestion.getBody(),
+                generatedQuestion.getSummary(),
+                generatedQuestion.getCorrectExplanation(),
+                generatedQuestion.getIncorrectExplanation(),
+                displayOrder
+        ));
+        saveOptions(savedQuestion, generatedQuestion);
+        questionAnswerRepository.save(QuestionAnswer.create(savedQuestion.getId(), generatedQuestion.getAnswerValue()));
+    }
+
+    private void saveOptions(Question question, QuizAiGeneratedQuestion generatedQuestion) {
+        List<QuizAiGeneratedOption> generatedOptions = generatedQuestion.getOptions();
+        if (generatedOptions == null || generatedOptions.isEmpty()) {
+            return;
+        }
+
+        List<QuestionOption> options = generatedOptions.stream()
+                .map(option -> QuestionOption.create(
+                        question.getId(),
+                        option.getOptionNumber(),
+                        option.getContent(),
+                        String.valueOf(option.getOptionNumber()).equals(generatedQuestion.getAnswerValue())
+                ))
+                .toList();
+        questionOptionRepository.saveAll(options);
+    }
+
+    private void failGeneration(QuizGenerationQueueMessage message, Exception e) {
+        QuizGenerationJob job = quizGenerationJobRepository.findById(message.generationJobId())
+                .orElse(null);
+        if (job == null || job.isTerminalStatus()) {
+            return;
+        }
+
+        job.increaseRetryCount();
+        String failReason = truncateFailReason(resolveFailReason(e));
+        job.markFailed(resolveFailCode(e), failReason, job.getRetryCount() < MAX_RETRY_COUNT);
+        quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(message.quizSessionId(), message.userId())
+                .ifPresent(quizSession -> quizSession.markGenerationFailed(failReason));
+    }
+
+    private void markTimedOutJob(QuizGenerationJob job) {
+        job.markTimeout(TIMEOUT_FAIL_REASON);
+        quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(job.getQuizSessionId(), job.getUserId())
+                .ifPresent(quizSession -> quizSession.markGenerationFailed(TIMEOUT_FAIL_REASON));
+    }
+
+    private String resolveFailCode(Exception e) {
+        if (e instanceof CustomException customException) {
+            return customException.getErrorCode().getCode();
+        }
+        return FAIL_CODE_GENERATION_FAILED;
+    }
+
+    private String resolveFailReason(Exception e) {
+        return e.getMessage() == null ? "퀴즈 생성 처리에 실패했습니다." : e.getMessage();
+    }
+
+    private String truncateFailReason(String failReason) {
+        if (failReason.length() <= FAIL_REASON_MAX_LENGTH) {
+            return failReason;
+        }
+        return failReason.substring(0, FAIL_REASON_MAX_LENGTH);
+    }
+
+    private record GenerationContext(
+            Long generationJobId,
+            Long quizSessionId,
+            Long userId,
+            QuizAiGenerationRequest request,
+            Map<String, Part> partsByPublicId
+    ) {
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationPromptBuilder.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationPromptBuilder.java
@@ -1,0 +1,89 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationPrompt;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationRequest;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuizGenerationPromptBuilder {
+
+    public QuizAiGenerationPrompt build(QuizAiGenerationRequest request) {
+        return new QuizAiGenerationPrompt(systemMessage(), userMessage(request));
+    }
+
+    private String systemMessage() {
+        return """
+                너는 Quiket의 학습 퀴즈 생성 엔진이다.
+                반드시 제공된 JSON Schema에 맞는 JSON만 반환한다.
+                자연어 설명, 마크다운, 코드블록은 절대 반환하지 않는다.
+                모든 문항은 제공된 partId 중 하나에만 종속되어야 한다.
+                """;
+    }
+
+    private String userMessage(QuizAiGenerationRequest request) {
+        return """
+                [과목 정보]
+                - 과목명: %s
+                - 학습 목적: %s
+
+                [퀴즈 설정]
+                - 문제 유형: %s
+                - 객관식 보기 수: %s
+                - 문제 수: %d
+                - 풀이 방식: %s
+                - 타이머 사용 여부: %s
+                - 타이머 범위: %s
+                - 타이머 초: %s
+                - 난이도: %s
+
+                [출제 범위]
+                %s
+
+                [생성 규칙]
+                - questions 배열 길이는 요청 문제 수와 정확히 같아야 한다.
+                - questionType은 요청한 문제 유형과 같아야 한다.
+                - partId는 출제 범위에 제공된 partId 중 하나만 사용한다.
+                - summary는 8자 이상 20자 이하의 한국어 핵심 요약이다.
+                - body는 문제 본문이다.
+                - correctExplanation과 incorrectExplanation은 각각 5자 이상 작성한다.
+                - multiple_choice는 options를 요청 보기 수만큼 만들고 answerValue는 정답 optionNumber 문자열이다.
+                - ox는 options를 빈 배열로 두고 answerValue는 O 또는 X만 사용한다.
+                """.formatted(
+                request.subject().getName(),
+                request.subject().getPurpose(),
+                request.quizType(),
+                valueOrNone(request.choiceCount()),
+                request.questionCount(),
+                request.playMode(),
+                Boolean.TRUE.equals(request.timerEnabled()),
+                valueOrNone(request.timerScope()),
+                valueOrNone(request.timerSeconds()),
+                request.difficulty(),
+                partContext(request)
+        );
+    }
+
+    private String partContext(QuizAiGenerationRequest request) {
+        return request.parts().stream()
+                .sorted(Comparator.comparing(Part::getChapterId).thenComparing(Part::getPartNumber))
+                .map(part -> """
+                        - partId: %s
+                          chapterId: %d
+                          partName: %s
+                          content: %s
+                        """.formatted(
+                        part.getPublicId(),
+                        part.getChapterId(),
+                        part.getName(),
+                        valueOrNone(part.getContent())
+                ))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String valueOrNone(Object value) {
+        return value == null ? "없음" : value.toString();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueue.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueue.java
@@ -1,6 +1,12 @@
 package com.f1.quiket.domain.quiz.service;
 
+import java.util.Optional;
+
 public interface QuizGenerationQueue {
 
     String enqueue(QuizGenerationQueueMessage message);
+
+    Optional<QuizGenerationQueueRecord> poll();
+
+    void acknowledge(String messageId);
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueue.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueue.java
@@ -1,0 +1,6 @@
+package com.f1.quiket.domain.quiz.service;
+
+public interface QuizGenerationQueue {
+
+    String enqueue(QuizGenerationQueueMessage message);
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueueMessage.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueueMessage.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+
+public record QuizGenerationQueueMessage(
+        Long generationJobId,
+        Long quizSessionId,
+        String quizSessionPublicId,
+        String jobId,
+        Long userId
+) {
+
+    public static QuizGenerationQueueMessage of(QuizGenerationJob generationJob, QuizSession quizSession) {
+        return new QuizGenerationQueueMessage(
+                generationJob.getId(),
+                quizSession.getId(),
+                quizSession.getPublicId(),
+                quizSession.getJobId(),
+                quizSession.getUserId()
+        );
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueueRecord.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationQueueRecord.java
@@ -1,0 +1,7 @@
+package com.f1.quiket.domain.quiz.service;
+
+public record QuizGenerationQueueRecord(
+        String messageId,
+        QuizGenerationQueueMessage message
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusService.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.quiz.service;
 
 import com.f1.quiket.domain.quiz.dto.QuizGenerationStatusResponse;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuizGenerationStatusService {
 
     private final QuizSessionRepository quizSessionRepository;
+    private final QuizGenerationJobRepository quizGenerationJobRepository;
 
     /**
      * 퀴즈 생성 상태 조회
@@ -27,6 +29,8 @@ public class QuizGenerationStatusService {
                 .findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionPublicId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
 
-        return QuizGenerationStatusResponse.from(quizSession);
+        return quizGenerationJobRepository.findByQuizSessionId(quizSession.getId())
+                .map(generationJob -> QuizGenerationStatusResponse.from(quizSession, generationJob))
+                .orElseGet(() -> QuizGenerationStatusResponse.from(quizSession));
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartService.java
@@ -61,21 +61,27 @@ public class QuizPlaySessionStartService {
             QuizSession quizSession,
             QuizPlayStartRequest request
     ) {
+        QuizPlaySession playSession = QuizPlaySession.createFirst(
+                request.getClientSessionId(),
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                request.getQuestionShuffled(),
+                request.getOptionShuffled(),
+                request.getShuffleSeed()
+        );
         try {
-            QuizPlaySession playSession = QuizPlaySession.createFirst(
-                    request.getClientSessionId(),
-                    quizSession.getId(),
-                    userId,
-                    quizSession.getSubjectId(),
-                    request.getQuestionShuffled(),
-                    request.getOptionShuffled(),
-                    request.getShuffleSeed()
-            );
-            return QuizPlaySessionResponse.of(quizPlaySessionRepository.save(playSession), quizSession);
+            QuizPlaySession saved = quizPlaySessionRepository.save(playSession);
+            return QuizPlaySessionResponse.of(saved, quizSession);
         } catch (DataIntegrityViolationException e) {
-            return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
-                    .map(existing -> responseFromExisting(existing, quizSession, request))
-                    .orElseThrow(() -> e);
+            // 사전 find 이후 다른 트랜잭션이 같은 clientSessionId로 먼저 insert한 race 케이스.
+            // 같은 트랜잭션은 이미 rollback-only로 마킹된 상태라 여기서 재조회하지 않고
+            // CONFLICT 응답으로 위임 — 클라이언트가 동일 ID로 재시도하면 사전 find 분기로 idempotent 처리됨.
+            throw new CustomException(
+                    ErrorCode.CONFLICT,
+                    "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.",
+                    e
+            );
         }
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartService.java
@@ -1,0 +1,81 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizPlayStartRequest;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizPlaySessionStartService {
+
+    private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
+    private static final String PLAY_TYPE_FIRST = "first";
+
+    private final QuizSessionRepository quizSessionRepository;
+    private final QuizPlaySessionRepository quizPlaySessionRepository;
+
+    public QuizPlaySessionResponse start(Long userId, String quizSessionPublicId, QuizPlayStartRequest request) {
+        QuizSession quizSession = quizSessionRepository
+                .findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        validateStartable(quizSession, request);
+
+        return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
+                .map(existing -> responseFromExisting(existing, quizSession, request))
+                .orElseGet(() -> createPlaySession(userId, quizSession, request));
+    }
+
+    private void validateStartable(QuizSession quizSession, QuizPlayStartRequest request) {
+        if (!QUIZ_SESSION_STATUS_COMPLETED.equals(quizSession.getStatus())) {
+            throw new CustomException(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+        }
+        if (!PLAY_TYPE_FIRST.equals(request.getPlayType()) || StringUtils.hasText(request.getParentPlaySessionId())) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+    }
+
+    private QuizPlaySessionResponse responseFromExisting(
+            QuizPlaySession existing,
+            QuizSession quizSession,
+            QuizPlayStartRequest request
+    ) {
+        if (!existing.isSameStartRequest(quizSession.getId(), quizSession.getUserId(), request.getPlayType())) {
+            throw new CustomException(ErrorCode.CONFLICT, "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.");
+        }
+        return QuizPlaySessionResponse.of(existing, quizSession);
+    }
+
+    private QuizPlaySessionResponse createPlaySession(
+            Long userId,
+            QuizSession quizSession,
+            QuizPlayStartRequest request
+    ) {
+        try {
+            QuizPlaySession playSession = QuizPlaySession.createFirst(
+                    request.getClientSessionId(),
+                    quizSession.getId(),
+                    userId,
+                    quizSession.getSubjectId(),
+                    request.getQuestionShuffled(),
+                    request.getOptionShuffled(),
+                    request.getShuffleSeed()
+            );
+            return QuizPlaySessionResponse.of(quizPlaySessionRepository.save(playSession), quizSession);
+        } catch (DataIntegrityViolationException e) {
+            return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
+                    .map(existing -> responseFromExisting(existing, quizSession, request))
+                    .orElseThrow(() -> e);
+        }
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultQueryService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultQueryService.java
@@ -46,9 +46,9 @@ public class QuizResultQueryService {
     private final QuizResultResponseAssembler quizResultResponseAssembler;
 
     public QuizResultResponse getQuizResult(Long userId, String resultPublicId) {
-        User user = findUser(userId);
         QuizResult result = quizResultRepository.findByPublicIdAndUserId(resultPublicId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_RESULT_NOT_FOUND));
+        User user = findUser(userId);
         QuizPlaySession playSession = quizPlaySessionRepository.findByIdAndUserId(result.getPlaySessionId(), userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_PLAY_SESSION_NOT_FOUND));
         QuizSession quizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getQuizSessionId(), userId)

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultQueryService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultQueryService.java
@@ -1,0 +1,111 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuizResultQueryService {
+
+    private final QuizResultRepository quizResultRepository;
+    private final QuizPlaySessionRepository quizPlaySessionRepository;
+    private final QuizSessionRepository quizSessionRepository;
+    private final SubjectRepository subjectRepository;
+    private final UserRepository userRepository;
+    private final QuestionRepository questionRepository;
+    private final QuestionOptionRepository questionOptionRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
+    private final QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private final QuizResultResponseAssembler quizResultResponseAssembler;
+
+    public QuizResultResponse getQuizResult(Long userId, String resultPublicId) {
+        User user = findUser(userId);
+        QuizResult result = quizResultRepository.findByPublicIdAndUserId(resultPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_RESULT_NOT_FOUND));
+        QuizPlaySession playSession = quizPlaySessionRepository.findByIdAndUserId(result.getPlaySessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_PLAY_SESSION_NOT_FOUND));
+        QuizSession quizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getQuizSessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        Subject subject = subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getSubjectId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+
+        List<Question> questions = findQuestions(userId, quizSession.getId());
+        List<Long> questionIds = questions.stream()
+                .map(Question::getId)
+                .toList();
+        Map<Long, List<QuestionOption>> optionsByQuestionId = getOptionsByQuestionId(questionIds);
+        Map<Long, QuestionAnswer> answersByQuestionId = getAnswersByQuestionId(questionIds);
+        List<QuizPlayAnswer> playAnswers = quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId());
+
+        return quizResultResponseAssembler.build(
+                result,
+                playSession,
+                quizSession,
+                subject,
+                user,
+                questions,
+                optionsByQuestionId,
+                answersByQuestionId,
+                playAnswers
+        );
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    private List<Question> findQuestions(Long userId, Long quizSessionId) {
+        List<Question> questions = questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(
+                quizSessionId,
+                userId
+        );
+        if (questions.isEmpty()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "완료된 퀴즈 세션에 문항이 존재하지 않습니다.");
+        }
+        return questions;
+    }
+
+    private Map<Long, List<QuestionOption>> getOptionsByQuestionId(List<Long> questionIds) {
+        return questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(questionIds)
+                .stream()
+                .collect(Collectors.groupingBy(QuestionOption::getQuestionId));
+    }
+
+    private Map<Long, QuestionAnswer> getAnswersByQuestionId(List<Long> questionIds) {
+        Map<Long, QuestionAnswer> answersByQuestionId = questionAnswerRepository.findAllByQuestionIdIn(questionIds)
+                .stream()
+                .collect(Collectors.toMap(QuestionAnswer::getQuestionId, Function.identity()));
+        if (answersByQuestionId.size() != questionIds.size()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 문항 정답 정보가 올바르지 않습니다.");
+        }
+        return answersByQuestionId;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultResponseAssembler.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultResponseAssembler.java
@@ -1,0 +1,56 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.dto.QuizReviewItemResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuizResultResponseAssembler {
+
+    public QuizResultResponse build(
+            QuizResult result,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            User user,
+            List<Question> questions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId,
+            List<QuizPlayAnswer> playAnswers
+    ) {
+        Map<Long, QuizPlayAnswer> playAnswersByQuestionId = playAnswers.stream()
+                .collect(Collectors.toMap(QuizPlayAnswer::getQuestionId, Function.identity()));
+        List<QuizReviewItemResponse> reviewItems = questions.stream()
+                .map(question -> QuizReviewItemResponse.of(
+                        question,
+                        optionsByQuestionId.getOrDefault(question.getId(), List.of()),
+                        answersByQuestionId.get(question.getId()),
+                        getPlayAnswer(playAnswersByQuestionId, question)
+                ))
+                .toList();
+        return QuizResultResponse.of(result, playSession, quizSession, subject, user, reviewItems);
+    }
+
+    private QuizPlayAnswer getPlayAnswer(Map<Long, QuizPlayAnswer> playAnswersByQuestionId, Question question) {
+        QuizPlayAnswer playAnswer = playAnswersByQuestionId.get(question.getId());
+        if (playAnswer == null) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 풀이 답안 정보가 올바르지 않습니다.");
+        }
+        return playAnswer;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllService.java
@@ -1,0 +1,80 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizResultRetryAllService {
+
+    private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
+    private static final String PLAY_TYPE_RETRY_ALL = "retry_all";
+
+    private final QuizResultRepository quizResultRepository;
+    private final QuizSessionRepository quizSessionRepository;
+    private final QuizPlaySessionRepository quizPlaySessionRepository;
+
+    public QuizPlaySessionResponse retryAll(Long userId, String resultPublicId, QuizRetryRequest request) {
+        QuizResult result = quizResultRepository.findByPublicIdAndUserId(resultPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_RESULT_NOT_FOUND));
+        QuizSession quizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getQuizSessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        validateRetryable(quizSession);
+
+        return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
+                .map(existing -> responseFromExisting(existing, quizSession))
+                .orElseGet(() -> createRetryAllPlaySession(userId, quizSession, request));
+    }
+
+    private void validateRetryable(QuizSession quizSession) {
+        if (!QUIZ_SESSION_STATUS_COMPLETED.equals(quizSession.getStatus())) {
+            throw new CustomException(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+        }
+    }
+
+    private QuizPlaySessionResponse responseFromExisting(QuizPlaySession existing, QuizSession quizSession) {
+        if (!existing.isSameStartRequest(quizSession.getId(), quizSession.getUserId(), PLAY_TYPE_RETRY_ALL)) {
+            throw new CustomException(ErrorCode.CONFLICT, "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.");
+        }
+        return QuizPlaySessionResponse.of(existing, quizSession);
+    }
+
+    private QuizPlaySessionResponse createRetryAllPlaySession(
+            Long userId,
+            QuizSession quizSession,
+            QuizRetryRequest request
+    ) {
+        QuizPlaySession playSession = QuizPlaySession.createRetryAll(
+                request.getClientSessionId(),
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                request.getQuestionShuffled(),
+                request.getOptionShuffled(),
+                request.getShuffleSeed()
+        );
+        try {
+            QuizPlaySession saved = quizPlaySessionRepository.save(playSession);
+            return QuizPlaySessionResponse.of(saved, quizSession);
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(
+                    ErrorCode.CONFLICT,
+                    "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.",
+                    e
+            );
+        }
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllService.java
@@ -8,6 +8,7 @@ import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -26,17 +27,24 @@ public class QuizResultRetryAllService {
     private final QuizResultRepository quizResultRepository;
     private final QuizSessionRepository quizSessionRepository;
     private final QuizPlaySessionRepository quizPlaySessionRepository;
+    private final SubjectRepository subjectRepository;
 
     public QuizPlaySessionResponse retryAll(Long userId, String resultPublicId, QuizRetryRequest request) {
         QuizResult result = quizResultRepository.findByPublicIdAndUserId(resultPublicId, userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_RESULT_NOT_FOUND));
         QuizSession quizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getQuizSessionId(), userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        validateSubjectAlive(userId, quizSession.getSubjectId());
         validateRetryable(quizSession);
 
         return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
                 .map(existing -> responseFromExisting(existing, quizSession))
                 .orElseGet(() -> createRetryAllPlaySession(userId, quizSession, request));
+    }
+
+    private void validateSubjectAlive(Long userId, Long subjectId) {
+        subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subjectId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
     }
 
     private void validateRetryable(QuizSession quizSession) {

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongService.java
@@ -1,0 +1,286 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.global.util.UuidV7Generator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizResultRetryWrongService {
+
+    private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
+
+    private final QuizResultRepository quizResultRepository;
+    private final QuizPlaySessionRepository quizPlaySessionRepository;
+    private final QuizSessionRepository quizSessionRepository;
+    private final SubjectRepository subjectRepository;
+    private final QuestionRepository questionRepository;
+    private final QuestionOptionRepository questionOptionRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
+    private final QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private final QuizSessionScopeRepository quizSessionScopeRepository;
+
+    public QuizPlaySessionResponse retryWrong(Long userId, String resultPublicId, QuizRetryRequest request) {
+        QuizResult result = quizResultRepository.findByPublicIdAndUserId(resultPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_RESULT_NOT_FOUND));
+        QuizPlaySession parentPlaySession = quizPlaySessionRepository.findByIdAndUserId(result.getPlaySessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_PLAY_SESSION_NOT_FOUND));
+        QuizSession parentQuizSession = quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(result.getQuizSessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        validateSubjectAlive(userId, parentQuizSession.getSubjectId());
+        validateRetryable(parentQuizSession);
+
+        return quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId())
+                .map(existing -> responseFromExisting(existing, parentPlaySession, parentQuizSession, userId))
+                .orElseGet(() -> createRetryWrongPlaySession(userId, parentPlaySession, parentQuizSession, request));
+    }
+
+    private void validateSubjectAlive(Long userId, Long subjectId) {
+        subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subjectId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+    }
+
+    private void validateRetryable(QuizSession quizSession) {
+        if (!QUIZ_SESSION_STATUS_COMPLETED.equals(quizSession.getStatus())) {
+            throw new CustomException(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+        }
+    }
+
+    private QuizPlaySessionResponse responseFromExisting(
+            QuizPlaySession existing,
+            QuizPlaySession parentPlaySession,
+            QuizSession parentQuizSession,
+            Long userId
+    ) {
+        if (!existing.isSameRetryWrongRequest(parentPlaySession.getId(), parentQuizSession.getId(), userId)) {
+            throw new CustomException(ErrorCode.CONFLICT, "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.");
+        }
+        QuizSession childQuizSession = quizSessionRepository
+                .findByIdAndUserIdAndDeletedAtIsNull(existing.getQuizSessionId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+        return QuizPlaySessionResponse.of(existing, childQuizSession);
+    }
+
+    private QuizPlaySessionResponse createRetryWrongPlaySession(
+            Long userId,
+            QuizPlaySession parentPlaySession,
+            QuizSession parentQuizSession,
+            QuizRetryRequest request
+    ) {
+        List<Question> parentQuestions = findParentQuestions(userId, parentQuizSession.getId());
+        List<QuizPlayAnswer> parentPlayAnswers = quizPlayAnswerRepository.findAllByPlaySessionId(parentPlaySession.getId());
+        List<Question> wrongQuestions = findWrongQuestions(parentQuestions, parentPlayAnswers);
+        Map<Long, List<QuestionOption>> optionsByQuestionId = getOptionsByQuestionId(parentQuestions);
+        Map<Long, QuestionAnswer> answersByQuestionId = getAnswersByQuestionId(parentQuestions);
+
+        try {
+            QuizSession childQuizSession = createChildQuizSession(parentQuizSession, wrongQuestions);
+            copyScopes(childQuizSession, wrongQuestions);
+            copyQuestions(childQuizSession, wrongQuestions, optionsByQuestionId, answersByQuestionId);
+            QuizPlaySession playSession = createPlaySession(userId, parentPlaySession, parentQuizSession, childQuizSession, request);
+            QuizPlaySession savedPlaySession = quizPlaySessionRepository.save(playSession);
+            return QuizPlaySessionResponse.of(savedPlaySession, childQuizSession);
+        } catch (DataIntegrityViolationException e) {
+            throw new CustomException(
+                    ErrorCode.CONFLICT,
+                    "이미 다른 풀이 세션에서 사용 중인 clientSessionId입니다.",
+                    e
+            );
+        }
+    }
+
+    private List<Question> findParentQuestions(Long userId, Long quizSessionId) {
+        List<Question> questions = questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(
+                quizSessionId,
+                userId
+        );
+        if (questions.isEmpty()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "완료된 퀴즈 세션에 문항이 존재하지 않습니다.");
+        }
+        return questions;
+    }
+
+    private List<Question> findWrongQuestions(List<Question> parentQuestions, List<QuizPlayAnswer> parentPlayAnswers) {
+        Set<Long> wrongQuestionIds = parentPlayAnswers.stream()
+                .filter(answer -> Boolean.FALSE.equals(answer.getCorrectServer()))
+                .map(QuizPlayAnswer::getQuestionId)
+                .collect(Collectors.toSet());
+        List<Question> wrongQuestions = parentQuestions.stream()
+                .filter(question -> wrongQuestionIds.contains(question.getId()))
+                .toList();
+        if (wrongQuestions.isEmpty()) {
+            throw new CustomException(ErrorCode.CONFLICT, "오답 문항이 없어 다시 풀 수 없습니다.");
+        }
+        if (wrongQuestions.size() != wrongQuestionIds.size()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "풀이 답안의 문항 정보가 올바르지 않습니다.");
+        }
+        return wrongQuestions;
+    }
+
+    private Map<Long, List<QuestionOption>> getOptionsByQuestionId(List<Question> questions) {
+        return questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(questionIds(questions))
+                .stream()
+                .collect(Collectors.groupingBy(QuestionOption::getQuestionId));
+    }
+
+    private Map<Long, QuestionAnswer> getAnswersByQuestionId(List<Question> questions) {
+        Map<Long, QuestionAnswer> answersByQuestionId = questionAnswerRepository.findAllByQuestionIdIn(questionIds(questions))
+                .stream()
+                .collect(Collectors.toMap(QuestionAnswer::getQuestionId, Function.identity()));
+        if (answersByQuestionId.size() != questions.size()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 문항 정답 정보가 올바르지 않습니다.");
+        }
+        return answersByQuestionId;
+    }
+
+    private List<Long> questionIds(List<Question> questions) {
+        return questions.stream()
+                .map(Question::getId)
+                .toList();
+    }
+
+    private QuizSession createChildQuizSession(QuizSession parentQuizSession, List<Question> wrongQuestions) {
+        QuizSession childQuizSession = QuizSession.create(
+                UuidV7Generator.generate(),
+                parentQuizSession.getUserId(),
+                parentQuizSession.getSubjectId(),
+                parentQuizSession.getQuizType(),
+                parentQuizSession.getChoiceCount(),
+                wrongQuestions.size(),
+                parentQuizSession.getPlayMode(),
+                parentQuizSession.getTimerEnabled(),
+                parentQuizSession.getTimerScope(),
+                parentQuizSession.getTimerSeconds(),
+                parentQuizSession.getDifficulty(),
+                QUIZ_SESSION_STATUS_COMPLETED,
+                null
+        );
+        childQuizSession.markGenerationCompleted(wrongQuestions.size());
+        return quizSessionRepository.save(childQuizSession);
+    }
+
+    private void copyScopes(QuizSession childQuizSession, List<Question> wrongQuestions) {
+        Map<Long, Question> questionsByPartId = wrongQuestions.stream()
+                .collect(Collectors.toMap(
+                        Question::getPartId,
+                        Function.identity(),
+                        (first, ignored) -> first,
+                        LinkedHashMap::new
+                ));
+        List<QuizSessionScope> scopes = questionsByPartId.values().stream()
+                .map(question -> QuizSessionScope.create(
+                        childQuizSession.getId(),
+                        question.getPartId(),
+                        question.getChapterId()
+                ))
+                .toList();
+        quizSessionScopeRepository.saveAll(scopes);
+    }
+
+    private void copyQuestions(
+            QuizSession childQuizSession,
+            List<Question> wrongQuestions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId
+    ) {
+        int displayOrder = 1;
+        for (Question parentQuestion : wrongQuestions) {
+            Question childQuestion = questionRepository.save(Question.create(
+                    UuidV7Generator.generate(),
+                    childQuizSession.getId(),
+                    parentQuestion.getUserId(),
+                    parentQuestion.getSubjectId(),
+                    parentQuestion.getChapterId(),
+                    parentQuestion.getPartId(),
+                    parentQuestion.getQuestionType(),
+                    parentQuestion.getDifficulty(),
+                    parentQuestion.getBody(),
+                    parentQuestion.getSummary(),
+                    parentQuestion.getCorrectExplanation(),
+                    parentQuestion.getIncorrectExplanation(),
+                    displayOrder++
+            ));
+            copyOptions(parentQuestion, childQuestion, optionsByQuestionId);
+            copyAnswer(parentQuestion, childQuestion, answersByQuestionId);
+        }
+    }
+
+    private void copyOptions(
+            Question parentQuestion,
+            Question childQuestion,
+            Map<Long, List<QuestionOption>> optionsByQuestionId
+    ) {
+        List<QuestionOption> childOptions = optionsByQuestionId.getOrDefault(parentQuestion.getId(), List.of())
+                .stream()
+                .map(option -> QuestionOption.create(
+                        childQuestion.getId(),
+                        option.getOptionNumber(),
+                        option.getContent(),
+                        option.getCorrect()
+                ))
+                .toList();
+        if (!childOptions.isEmpty()) {
+            questionOptionRepository.saveAll(childOptions);
+        }
+    }
+
+    private void copyAnswer(
+            Question parentQuestion,
+            Question childQuestion,
+            Map<Long, QuestionAnswer> answersByQuestionId
+    ) {
+        QuestionAnswer parentAnswer = answersByQuestionId.get(parentQuestion.getId());
+        questionAnswerRepository.save(QuestionAnswer.create(childQuestion.getId(), parentAnswer.getAnswerValue()));
+    }
+
+    private QuizPlaySession createPlaySession(
+            Long userId,
+            QuizPlaySession parentPlaySession,
+            QuizSession parentQuizSession,
+            QuizSession childQuizSession,
+            QuizRetryRequest request
+    ) {
+        return QuizPlaySession.createRetryWrong(
+                request.getClientSessionId(),
+                childQuizSession.getId(),
+                userId,
+                childQuizSession.getSubjectId(),
+                parentPlaySession.getId(),
+                parentQuizSession.getId(),
+                parentPlaySession.getGeneration() + 1,
+                request.getQuestionShuffled(),
+                request.getOptionShuffled(),
+                request.getShuffleSeed()
+        );
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
@@ -47,6 +47,7 @@ public class QuizResultSubmitService {
     private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
     private static final String PLAY_TYPE_FIRST = "first";
     private static final String PLAY_TYPE_RETRY_ALL = "retry_all";
+    private static final String PLAY_TYPE_RETRY_WRONG = "retry_wrong";
     private static final String QUESTION_TYPE_MULTIPLE_CHOICE = "multiple_choice";
     private static final String QUESTION_TYPE_OX = "ox";
     private static final int ABUSE_MISMATCH_THRESHOLD_PCT = 30;
@@ -142,7 +143,9 @@ public class QuizResultSubmitService {
     }
 
     private boolean isSupportedPlayType(String playType) {
-        return PLAY_TYPE_FIRST.equals(playType) || PLAY_TYPE_RETRY_ALL.equals(playType);
+        return PLAY_TYPE_FIRST.equals(playType)
+                || PLAY_TYPE_RETRY_ALL.equals(playType)
+                || PLAY_TYPE_RETRY_WRONG.equals(playType);
     }
 
     private List<Question> findQuestions(Long userId, Long quizSessionId) {

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
@@ -6,7 +6,6 @@ import com.f1.quiket.domain.quiz.dto.QuizAnswerSubmitItem;
 import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
-import com.f1.quiket.domain.quiz.dto.QuizReviewItemResponse;
 import com.f1.quiket.domain.quiz.entity.Question;
 import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
 import com.f1.quiket.domain.quiz.entity.QuestionOption;
@@ -61,6 +60,7 @@ public class QuizResultSubmitService {
     private final QuizResultRepository quizResultRepository;
     private final UserRepository userRepository;
     private final GamificationRewardService gamificationRewardService;
+    private final QuizResultResponseAssembler quizResultResponseAssembler;
 
     public QuizResultSubmitOutcome submit(Long userId, QuizResultSubmitRequest request) {
         User user = findUser(userId);
@@ -178,7 +178,7 @@ public class QuizResultSubmitService {
             Map<Long, QuestionAnswer> answersByQuestionId
     ) {
         List<QuizPlayAnswer> playAnswers = quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId());
-        QuizResultResponse response = buildResponse(
+        QuizResultResponse response = quizResultResponseAssembler.build(
                 result,
                 playSession,
                 quizSession,
@@ -256,7 +256,7 @@ public class QuizResultSubmitService {
                 abuseFlagged
         ));
 
-        QuizResultResponse response = buildResponse(
+        QuizResultResponse response = quizResultResponseAssembler.build(
                 savedResult,
                 playSession,
                 quizSession,
@@ -371,38 +371,6 @@ public class QuizResultSubmitService {
                 .filter(answer -> answer.getCorrectClient() != null)
                 .filter(answer -> !answer.getCorrectClient().equals(answer.getCorrectServer()))
                 .count();
-    }
-
-    private QuizResultResponse buildResponse(
-            QuizResult result,
-            QuizPlaySession playSession,
-            QuizSession quizSession,
-            Subject subject,
-            User user,
-            List<Question> questions,
-            Map<Long, List<QuestionOption>> optionsByQuestionId,
-            Map<Long, QuestionAnswer> answersByQuestionId,
-            List<QuizPlayAnswer> playAnswers
-    ) {
-        Map<Long, QuizPlayAnswer> playAnswersByQuestionId = playAnswers.stream()
-                .collect(Collectors.toMap(QuizPlayAnswer::getQuestionId, Function.identity()));
-        List<QuizReviewItemResponse> reviewItems = questions.stream()
-                .map(question -> QuizReviewItemResponse.of(
-                        question,
-                        optionsByQuestionId.getOrDefault(question.getId(), List.of()),
-                        answersByQuestionId.get(question.getId()),
-                        getPlayAnswer(playAnswersByQuestionId, question)
-                ))
-                .toList();
-        return QuizResultResponse.of(result, playSession, quizSession, subject, user, reviewItems);
-    }
-
-    private QuizPlayAnswer getPlayAnswer(Map<Long, QuizPlayAnswer> playAnswersByQuestionId, Question question) {
-        QuizPlayAnswer playAnswer = playAnswersByQuestionId.get(question.getId());
-        if (playAnswer == null) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 풀이 답안 정보가 올바르지 않습니다.");
-        }
-        return playAnswer;
     }
 
     private record GradedAnswer(Long selectedOptionId, String selectedValue, Boolean correct) {

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
@@ -1,5 +1,7 @@
 package com.f1.quiket.domain.quiz.service;
 
+import com.f1.quiket.domain.gamification.service.GamificationRewardService;
+import com.f1.quiket.domain.gamification.service.QuizRewardResult;
 import com.f1.quiket.domain.quiz.dto.QuizAnswerSubmitItem;
 import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
@@ -21,6 +23,8 @@ import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.subject.entity.Subject;
 import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import com.f1.quiket.global.util.UuidV7Generator;
@@ -55,8 +59,11 @@ public class QuizResultSubmitService {
     private final QuizPlaySessionRepository quizPlaySessionRepository;
     private final QuizPlayAnswerRepository quizPlayAnswerRepository;
     private final QuizResultRepository quizResultRepository;
+    private final UserRepository userRepository;
+    private final GamificationRewardService gamificationRewardService;
 
     public QuizResultSubmitOutcome submit(Long userId, QuizResultSubmitRequest request) {
+        User user = findUser(userId);
         QuizPlaySession playSession = findPlaySession(userId, request.getClientSessionId());
         QuizSession quizSession = findQuizSession(userId, request.getQuizSessionId());
         Subject subject = findSubject(userId, quizSession.getSubjectId());
@@ -76,6 +83,7 @@ public class QuizResultSubmitService {
                         playSession,
                         quizSession,
                         subject,
+                        user,
                         questions,
                         optionsByQuestionId,
                         answersByQuestionId
@@ -86,10 +94,16 @@ public class QuizResultSubmitService {
                         playSession,
                         quizSession,
                         subject,
+                        user,
                         questions,
                         optionsByQuestionId,
                         answersByQuestionId
                 ));
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
     }
 
     private QuizPlaySession findPlaySession(Long userId, String clientSessionId) {
@@ -158,6 +172,7 @@ public class QuizResultSubmitService {
             QuizPlaySession playSession,
             QuizSession quizSession,
             Subject subject,
+            User user,
             List<Question> questions,
             Map<Long, List<QuestionOption>> optionsByQuestionId,
             Map<Long, QuestionAnswer> answersByQuestionId
@@ -168,6 +183,7 @@ public class QuizResultSubmitService {
                 playSession,
                 quizSession,
                 subject,
+                user,
                 questions,
                 optionsByQuestionId,
                 answersByQuestionId,
@@ -182,6 +198,7 @@ public class QuizResultSubmitService {
             QuizPlaySession playSession,
             QuizSession quizSession,
             Subject subject,
+            User user,
             List<Question> questions,
             Map<Long, List<QuestionOption>> optionsByQuestionId,
             Map<Long, QuestionAnswer> answersByQuestionId
@@ -213,6 +230,12 @@ public class QuizResultSubmitService {
 
         quizPlayAnswerRepository.saveAll(playAnswers);
         playSession.submit(request.getElapsedMs());
+        QuizRewardResult reward = gamificationRewardService.applyQuizReward(
+                user,
+                playSession,
+                quizSession,
+                correctCount
+        );
         QuizResult savedResult = quizResultRepository.save(QuizResult.create(
                 UuidV7Generator.generate(),
                 playSession.getId(),
@@ -225,6 +248,10 @@ public class QuizResultSubmitService {
                 skipCount,
                 accuracyPct,
                 request.getElapsedMs(),
+                reward.dotoriEarned(),
+                reward.xpEarned(),
+                reward.leveledUp(),
+                reward.newLevel(),
                 scoreMatched,
                 abuseFlagged
         ));
@@ -234,6 +261,7 @@ public class QuizResultSubmitService {
                 playSession,
                 quizSession,
                 subject,
+                user,
                 questions,
                 optionsByQuestionId,
                 answersByQuestionId,
@@ -350,6 +378,7 @@ public class QuizResultSubmitService {
             QuizPlaySession playSession,
             QuizSession quizSession,
             Subject subject,
+            User user,
             List<Question> questions,
             Map<Long, List<QuestionOption>> optionsByQuestionId,
             Map<Long, QuestionAnswer> answersByQuestionId,
@@ -365,7 +394,7 @@ public class QuizResultSubmitService {
                         getPlayAnswer(playAnswersByQuestionId, question)
                 ))
                 .toList();
-        return QuizResultResponse.of(result, playSession, quizSession, subject, reviewItems);
+        return QuizResultResponse.of(result, playSession, quizSession, subject, user, reviewItems);
     }
 
     private QuizPlayAnswer getPlayAnswer(Map<Long, QuizPlayAnswer> playAnswersByQuestionId, Question question) {

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
@@ -46,6 +46,7 @@ public class QuizResultSubmitService {
 
     private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
     private static final String PLAY_TYPE_FIRST = "first";
+    private static final String PLAY_TYPE_RETRY_ALL = "retry_all";
     private static final String QUESTION_TYPE_MULTIPLE_CHOICE = "multiple_choice";
     private static final String QUESTION_TYPE_OX = "ox";
     private static final int ABUSE_MISMATCH_THRESHOLD_PCT = 30;
@@ -133,11 +134,15 @@ public class QuizResultSubmitService {
         if (!playSession.getQuizSessionId().equals(quizSession.getId())) {
             throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
         }
-        if (!PLAY_TYPE_FIRST.equals(request.getPlayType())
-                || !PLAY_TYPE_FIRST.equals(playSession.getPlayType())
+        if (!playSession.getPlayType().equals(request.getPlayType())
+                || !isSupportedPlayType(playSession.getPlayType())
                 || StringUtils.hasText(request.getParentPlaySessionId())) {
             throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
         }
+    }
+
+    private boolean isSupportedPlayType(String playType) {
+        return PLAY_TYPE_FIRST.equals(playType) || PLAY_TYPE_RETRY_ALL.equals(playType);
     }
 
     private List<Question> findQuestions(Long userId, Long quizSessionId) {

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitService.java
@@ -1,0 +1,381 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.domain.quiz.dto.QuizAnswerSubmitItem;
+import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
+import com.f1.quiket.domain.quiz.dto.QuizReviewItemResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.global.util.UuidV7Generator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizResultSubmitService {
+
+    private static final String QUIZ_SESSION_STATUS_COMPLETED = "completed";
+    private static final String PLAY_TYPE_FIRST = "first";
+    private static final String QUESTION_TYPE_MULTIPLE_CHOICE = "multiple_choice";
+    private static final String QUESTION_TYPE_OX = "ox";
+    private static final int ABUSE_MISMATCH_THRESHOLD_PCT = 30;
+
+    private final QuizSessionRepository quizSessionRepository;
+    private final SubjectRepository subjectRepository;
+    private final QuestionRepository questionRepository;
+    private final QuestionOptionRepository questionOptionRepository;
+    private final QuestionAnswerRepository questionAnswerRepository;
+    private final QuizPlaySessionRepository quizPlaySessionRepository;
+    private final QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private final QuizResultRepository quizResultRepository;
+
+    public QuizResultSubmitOutcome submit(Long userId, QuizResultSubmitRequest request) {
+        QuizPlaySession playSession = findPlaySession(userId, request.getClientSessionId());
+        QuizSession quizSession = findQuizSession(userId, request.getQuizSessionId());
+        Subject subject = findSubject(userId, quizSession.getSubjectId());
+
+        validateSubmitTarget(playSession, quizSession, request);
+
+        List<Question> questions = findQuestions(userId, quizSession.getId());
+        List<Long> questionIds = questions.stream()
+                .map(Question::getId)
+                .toList();
+        Map<Long, List<QuestionOption>> optionsByQuestionId = getOptionsByQuestionId(questionIds);
+        Map<Long, QuestionAnswer> answersByQuestionId = getAnswersByQuestionId(questionIds);
+
+        return quizResultRepository.findByPlaySessionId(playSession.getId())
+                .map(existing -> responseFromExisting(
+                        existing,
+                        playSession,
+                        quizSession,
+                        subject,
+                        questions,
+                        optionsByQuestionId,
+                        answersByQuestionId
+                ))
+                .orElseGet(() -> createResult(
+                        userId,
+                        request,
+                        playSession,
+                        quizSession,
+                        subject,
+                        questions,
+                        optionsByQuestionId,
+                        answersByQuestionId
+                ));
+    }
+
+    private QuizPlaySession findPlaySession(Long userId, String clientSessionId) {
+        return quizPlaySessionRepository.findByClientSessionId(clientSessionId)
+                .filter(playSession -> playSession.getUserId().equals(userId))
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_PLAY_SESSION_NOT_FOUND));
+    }
+
+    private QuizSession findQuizSession(Long userId, String quizSessionPublicId) {
+        return quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSessionPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.QUIZ_SESSION_NOT_FOUND));
+    }
+
+    private Subject findSubject(Long userId, Long subjectId) {
+        return subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subjectId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+    }
+
+    private void validateSubmitTarget(
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            QuizResultSubmitRequest request
+    ) {
+        if (!QUIZ_SESSION_STATUS_COMPLETED.equals(quizSession.getStatus())) {
+            throw new CustomException(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+        }
+        if (!playSession.getQuizSessionId().equals(quizSession.getId())) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+        if (!PLAY_TYPE_FIRST.equals(request.getPlayType())
+                || !PLAY_TYPE_FIRST.equals(playSession.getPlayType())
+                || StringUtils.hasText(request.getParentPlaySessionId())) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+    }
+
+    private List<Question> findQuestions(Long userId, Long quizSessionId) {
+        List<Question> questions = questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(
+                quizSessionId,
+                userId
+        );
+        if (questions.isEmpty()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "완료된 퀴즈 세션에 문항이 존재하지 않습니다.");
+        }
+        return questions;
+    }
+
+    private Map<Long, List<QuestionOption>> getOptionsByQuestionId(List<Long> questionIds) {
+        return questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(questionIds)
+                .stream()
+                .collect(Collectors.groupingBy(QuestionOption::getQuestionId));
+    }
+
+    private Map<Long, QuestionAnswer> getAnswersByQuestionId(List<Long> questionIds) {
+        Map<Long, QuestionAnswer> answersByQuestionId = questionAnswerRepository.findAllByQuestionIdIn(questionIds)
+                .stream()
+                .collect(Collectors.toMap(QuestionAnswer::getQuestionId, Function.identity()));
+        if (answersByQuestionId.size() != questionIds.size()) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 문항 정답 정보가 올바르지 않습니다.");
+        }
+        return answersByQuestionId;
+    }
+
+    private QuizResultSubmitOutcome responseFromExisting(
+            QuizResult result,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            List<Question> questions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId
+    ) {
+        List<QuizPlayAnswer> playAnswers = quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId());
+        QuizResultResponse response = buildResponse(
+                result,
+                playSession,
+                quizSession,
+                subject,
+                questions,
+                optionsByQuestionId,
+                answersByQuestionId,
+                playAnswers
+        );
+        return new QuizResultSubmitOutcome(response, false);
+    }
+
+    private QuizResultSubmitOutcome createResult(
+            Long userId,
+            QuizResultSubmitRequest request,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            List<Question> questions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId
+    ) {
+        Map<Long, QuizPlayAnswer> playAnswersByQuestionId = gradeAnswers(
+                userId,
+                request,
+                playSession,
+                questions,
+                optionsByQuestionId,
+                answersByQuestionId
+        );
+        List<QuizPlayAnswer> playAnswers = questions.stream()
+                .map(question -> playAnswersByQuestionId.get(question.getId()))
+                .toList();
+
+        int totalCount = questions.size();
+        int correctCount = (int) playAnswers.stream()
+                .filter(QuizPlayAnswer::getCorrectServer)
+                .count();
+        int skipCount = (int) playAnswers.stream()
+                .filter(QuizPlayAnswer::getSkipped)
+                .count();
+        int wrongCount = totalCount - correctCount - skipCount;
+        int accuracyPct = correctCount * 100 / totalCount;
+        int mismatchCount = calculateMismatchCount(playAnswers);
+        boolean scoreMatched = mismatchCount == 0;
+        boolean abuseFlagged = mismatchCount * 100 >= totalCount * ABUSE_MISMATCH_THRESHOLD_PCT;
+
+        quizPlayAnswerRepository.saveAll(playAnswers);
+        playSession.submit(request.getElapsedMs());
+        QuizResult savedResult = quizResultRepository.save(QuizResult.create(
+                UuidV7Generator.generate(),
+                playSession.getId(),
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                totalCount,
+                correctCount,
+                wrongCount,
+                skipCount,
+                accuracyPct,
+                request.getElapsedMs(),
+                scoreMatched,
+                abuseFlagged
+        ));
+
+        QuizResultResponse response = buildResponse(
+                savedResult,
+                playSession,
+                quizSession,
+                subject,
+                questions,
+                optionsByQuestionId,
+                answersByQuestionId,
+                playAnswers
+        );
+        return new QuizResultSubmitOutcome(response, true);
+    }
+
+    private Map<Long, QuizPlayAnswer> gradeAnswers(
+            Long userId,
+            QuizResultSubmitRequest request,
+            QuizPlaySession playSession,
+            List<Question> questions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId
+    ) {
+        Map<String, Question> questionsByPublicId = questions.stream()
+                .collect(Collectors.toMap(Question::getPublicId, Function.identity(), (left, right) -> left, LinkedHashMap::new));
+        validateSubmittedQuestions(request.getAnswers(), questionsByPublicId);
+
+        Map<Long, QuestionOption> optionsById = optionsByQuestionId.values().stream()
+                .flatMap(List::stream)
+                .collect(Collectors.toMap(QuestionOption::getId, Function.identity()));
+
+        Map<Long, QuizPlayAnswer> playAnswersByQuestionId = new LinkedHashMap<>();
+        for (QuizAnswerSubmitItem item : request.getAnswers()) {
+            Question question = questionsByPublicId.get(item.getQuestionId());
+            QuestionAnswer answer = answersByQuestionId.get(question.getId());
+            GradedAnswer gradedAnswer = gradeAnswer(item, question, answer, optionsById);
+            QuizPlayAnswer playAnswer = QuizPlayAnswer.create(
+                    playSession.getId(),
+                    question.getId(),
+                    userId,
+                    gradedAnswer.selectedOptionId(),
+                    gradedAnswer.selectedValue(),
+                    item.getCorrectClient(),
+                    gradedAnswer.correct(),
+                    item.getSkipped(),
+                    item.getAnswerElapsedMs(),
+                    item.getMarked()
+            );
+            playAnswersByQuestionId.put(question.getId(), playAnswer);
+        }
+        return playAnswersByQuestionId;
+    }
+
+    private void validateSubmittedQuestions(List<QuizAnswerSubmitItem> items, Map<String, Question> questionsByPublicId) {
+        if (items.size() != questionsByPublicId.size()) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+
+        Set<String> submittedQuestionIds = new HashSet<>();
+        for (QuizAnswerSubmitItem item : items) {
+            if (!questionsByPublicId.containsKey(item.getQuestionId()) || !submittedQuestionIds.add(item.getQuestionId())) {
+                throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+            }
+        }
+    }
+
+    private GradedAnswer gradeAnswer(
+            QuizAnswerSubmitItem item,
+            Question question,
+            QuestionAnswer answer,
+            Map<Long, QuestionOption> optionsById
+    ) {
+        if (Boolean.TRUE.equals(item.getSkipped())) {
+            return new GradedAnswer(null, null, false);
+        }
+        if (QUESTION_TYPE_MULTIPLE_CHOICE.equals(question.getQuestionType())) {
+            Long selectedOptionId = parseSelectedOptionId(item.getSelectedOptionId());
+            QuestionOption selectedOption = optionsById.get(selectedOptionId);
+            if (selectedOption == null || !selectedOption.getQuestionId().equals(question.getId())) {
+                throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+            }
+            return new GradedAnswer(selectedOptionId, null, Boolean.TRUE.equals(selectedOption.getCorrect()));
+        }
+        if (QUESTION_TYPE_OX.equals(question.getQuestionType())) {
+            String selectedValue = normalizeSelectedValue(item.getSelectedValue());
+            if (!"O".equals(selectedValue) && !"X".equals(selectedValue)) {
+                throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+            }
+            return new GradedAnswer(null, selectedValue, selectedValue.equals(answer.getAnswerValue()));
+        }
+        throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 문항 유형이 올바르지 않습니다.");
+    }
+
+    private Long parseSelectedOptionId(String selectedOptionId) {
+        if (!StringUtils.hasText(selectedOptionId)) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+        try {
+            return Long.parseLong(selectedOptionId);
+        } catch (NumberFormatException e) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+    }
+
+    private String normalizeSelectedValue(String selectedValue) {
+        if (!StringUtils.hasText(selectedValue)) {
+            throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID);
+        }
+        return selectedValue.trim().toUpperCase();
+    }
+
+    private int calculateMismatchCount(List<QuizPlayAnswer> playAnswers) {
+        return (int) playAnswers.stream()
+                .filter(answer -> answer.getCorrectClient() != null)
+                .filter(answer -> !answer.getCorrectClient().equals(answer.getCorrectServer()))
+                .count();
+    }
+
+    private QuizResultResponse buildResponse(
+            QuizResult result,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            List<Question> questions,
+            Map<Long, List<QuestionOption>> optionsByQuestionId,
+            Map<Long, QuestionAnswer> answersByQuestionId,
+            List<QuizPlayAnswer> playAnswers
+    ) {
+        Map<Long, QuizPlayAnswer> playAnswersByQuestionId = playAnswers.stream()
+                .collect(Collectors.toMap(QuizPlayAnswer::getQuestionId, Function.identity()));
+        List<QuizReviewItemResponse> reviewItems = questions.stream()
+                .map(question -> QuizReviewItemResponse.of(
+                        question,
+                        optionsByQuestionId.getOrDefault(question.getId(), List.of()),
+                        answersByQuestionId.get(question.getId()),
+                        getPlayAnswer(playAnswersByQuestionId, question)
+                ))
+                .toList();
+        return QuizResultResponse.of(result, playSession, quizSession, subject, reviewItems);
+    }
+
+    private QuizPlayAnswer getPlayAnswer(Map<Long, QuizPlayAnswer> playAnswersByQuestionId, Question question) {
+        QuizPlayAnswer playAnswer = playAnswersByQuestionId.get(question.getId());
+        if (playAnswer == null) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR, "퀴즈 풀이 답안 정보가 올바르지 않습니다.");
+        }
+        return playAnswer;
+    }
+
+    private record GradedAnswer(Long selectedOptionId, String selectedValue, Boolean correct) {
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
@@ -7,6 +7,7 @@ import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
 import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.event.QuizGenerationEnqueueRequestedEvent;
 import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -47,8 +49,8 @@ public class QuizSessionCreateService {
     private final QuizSessionRepository quizSessionRepository;
     private final QuizSessionScopeRepository quizSessionScopeRepository;
     private final QuizGenerationJobRepository quizGenerationJobRepository;
-    private final QuizGenerationQueue quizGenerationQueue;
     private final QuizGenerationLockStore quizGenerationLockStore;
+    private final ApplicationEventPublisher eventPublisher;
 
     /**
      * 퀴즈 세션 생성
@@ -92,8 +94,8 @@ public class QuizSessionCreateService {
         QuizGenerationJob generationJob = quizGenerationJobRepository.save(
                 QuizGenerationJob.create(savedQuizSession.getId(), userId, null)
         );
-        String messageId = quizGenerationQueue.enqueue(QuizGenerationQueueMessage.of(generationJob, savedQuizSession));
-        generationJob.assignMqMessageId(messageId);
+        // 실제 Redis 큐 발행은 AFTER_COMMIT 리스너에서 처리 (DB rollback 시 orphan 메시지 방지)
+        eventPublisher.publishEvent(QuizGenerationEnqueueRequestedEvent.of(generationJob, savedQuizSession));
 
         return QuizGenerationAcceptedResponse.from(savedQuizSession, generationJob);
     }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateService.java
@@ -4,8 +4,10 @@ import com.f1.quiket.domain.part.entity.Part;
 import com.f1.quiket.domain.part.repository.PartRepository;
 import com.f1.quiket.domain.quiz.dto.QuizCreateRequest;
 import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
 import com.f1.quiket.domain.subject.entity.Subject;
@@ -44,6 +46,8 @@ public class QuizSessionCreateService {
     private final PartRepository partRepository;
     private final QuizSessionRepository quizSessionRepository;
     private final QuizSessionScopeRepository quizSessionScopeRepository;
+    private final QuizGenerationJobRepository quizGenerationJobRepository;
+    private final QuizGenerationQueue quizGenerationQueue;
     private final QuizGenerationLockStore quizGenerationLockStore;
 
     /**
@@ -85,8 +89,13 @@ public class QuizSessionCreateService {
 
         QuizSession savedQuizSession = quizSessionRepository.save(quizSession);
         quizSessionScopeRepository.saveAll(createScopes(savedQuizSession.getId(), parts));
+        QuizGenerationJob generationJob = quizGenerationJobRepository.save(
+                QuizGenerationJob.create(savedQuizSession.getId(), userId, null)
+        );
+        String messageId = quizGenerationQueue.enqueue(QuizGenerationQueueMessage.of(generationJob, savedQuizSession));
+        generationJob.assignMqMessageId(messageId);
 
-        return QuizGenerationAcceptedResponse.from(savedQuizSession);
+        return QuizGenerationAcceptedResponse.from(savedQuizSession, generationJob);
     }
 
     /**

--- a/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
@@ -2,9 +2,14 @@ package com.f1.quiket.domain.quiz.service;
 
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.Limit;
+import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
@@ -14,6 +19,7 @@ import org.springframework.stereotype.Component;
 public class RedisQuizGenerationQueue implements QuizGenerationQueue {
 
     private static final String STREAM_KEY = "quiz:generation:jobs";
+    private static final int POLL_COUNT = 1;
 
     private final StringRedisTemplate stringRedisTemplate;
 
@@ -31,6 +37,34 @@ public class RedisQuizGenerationQueue implements QuizGenerationQueue {
         }
     }
 
+    @Override
+    public Optional<QuizGenerationQueueRecord> poll() {
+        try {
+            List<MapRecord<String, Object, Object>> records = stringRedisTemplate.opsForStream()
+                    .range(STREAM_KEY, Range.unbounded(), Limit.limit().count(POLL_COUNT));
+            if (records == null || records.isEmpty()) {
+                return Optional.empty();
+            }
+
+            MapRecord<String, Object, Object> record = records.get(0);
+            return Optional.of(new QuizGenerationQueueRecord(
+                    record.getId().getValue(),
+                    toMessage(record.getValue())
+            ));
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    @Override
+    public void acknowledge(String messageId) {
+        try {
+            stringRedisTemplate.opsForStream().delete(STREAM_KEY, messageId);
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
     private Map<String, String> toRecord(QuizGenerationQueueMessage message) {
         return Map.of(
                 "generationJobId", String.valueOf(message.generationJobId()),
@@ -39,5 +73,27 @@ public class RedisQuizGenerationQueue implements QuizGenerationQueue {
                 "jobId", message.jobId(),
                 "userId", String.valueOf(message.userId())
         );
+    }
+
+    private QuizGenerationQueueMessage toMessage(Map<Object, Object> record) {
+        return new QuizGenerationQueueMessage(
+                parseLong(record, "generationJobId"),
+                parseLong(record, "quizSessionId"),
+                value(record, "quizSessionPublicId"),
+                value(record, "jobId"),
+                parseLong(record, "userId")
+        );
+    }
+
+    private Long parseLong(Map<Object, Object> record, String key) {
+        return Long.valueOf(value(record, key));
+    }
+
+    private String value(Map<Object, Object> record, String key) {
+        Object value = record.get(key);
+        if (value == null) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE);
+        }
+        return String.valueOf(value);
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
@@ -1,0 +1,43 @@
+package com.f1.quiket.domain.quiz.service;
+
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisQuizGenerationQueue implements QuizGenerationQueue {
+
+    private static final String STREAM_KEY = "quiz:generation:jobs";
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public String enqueue(QuizGenerationQueueMessage message) {
+        try {
+            RecordId recordId = stringRedisTemplate.opsForStream()
+                    .add(STREAM_KEY, toRecord(message));
+            if (recordId == null) {
+                throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE);
+            }
+            return recordId.getValue();
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, e);
+        }
+    }
+
+    private Map<String, String> toRecord(QuizGenerationQueueMessage message) {
+        return Map.of(
+                "generationJobId", String.valueOf(message.generationJobId()),
+                "quizSessionId", String.valueOf(message.quizSessionId()),
+                "quizSessionPublicId", message.quizSessionPublicId(),
+                "jobId", message.jobId(),
+                "userId", String.valueOf(message.userId())
+        );
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
@@ -14,6 +14,18 @@ import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
+/**
+ * Redis Stream 기반 퀴즈 생성 큐 — MVP 단일 워커 가정.
+ *
+ * <h3>제약</h3>
+ * <ul>
+ *     <li>{@code XRANGE} + {@code XDEL} 패턴 — Consumer Group({@code XREADGROUP}/{@code XACK}) 미사용</li>
+ *     <li>워커 인스턴스가 2개 이상이면 동일 메시지가 중복 처리될 수 있음 — 단일 워커 한정으로만 안전</li>
+ *     <li>워커가 처리 도중 죽으면 {@link #acknowledge(String)}가 호출되지 않아 같은 메시지가 다음 poll에 재선택 → 처리 idempotency 가정 필요</li>
+ * </ul>
+ *
+ * <p>운영 트래픽 증가 또는 워커 다중화 시 Consumer Group 기반 redelivery로 전환 필요 (후속 이슈).</p>
+ */
 @Component
 @RequiredArgsConstructor
 public class RedisQuizGenerationQueue implements QuizGenerationQueue {

--- a/src/main/java/com/f1/quiket/domain/subject/controller/CertificateController.java
+++ b/src/main/java/com/f1/quiket/domain/subject/controller/CertificateController.java
@@ -1,0 +1,36 @@
+package com.f1.quiket.domain.subject.controller;
+
+import com.f1.quiket.domain.subject.dto.CertificateResponse;
+import com.f1.quiket.domain.subject.service.CertificateService;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 자격증 마스터 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/certificates")
+public class CertificateController {
+
+    private final CertificateService certificateService;
+
+    /**
+     * 자격증 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CertificateResponse>>> getCertificates(
+            @RequestParam(name = "featured", required = false) Boolean featured,
+            @RequestParam(name = "keyword", required = false) String keyword
+    ) {
+        List<CertificateResponse> response = certificateService.getCertificates(featured, keyword);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/controller/SubjectController.java
+++ b/src/main/java/com/f1/quiket/domain/subject/controller/SubjectController.java
@@ -1,0 +1,153 @@
+package com.f1.quiket.domain.subject.controller;
+
+import com.f1.quiket.domain.subject.dto.SubjectCreateRequest;
+import com.f1.quiket.domain.subject.dto.QuizScopeResponse;
+import com.f1.quiket.domain.subject.dto.SubjectDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectDetailUpdateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleResponse;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleUpsertRequest;
+import com.f1.quiket.domain.subject.dto.SubjectNameUpdateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectPageResponse;
+import com.f1.quiket.domain.subject.dto.SubjectResponse;
+import com.f1.quiket.domain.subject.service.SubjectService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 과목 API 진입점
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/subjects")
+public class SubjectController {
+
+    private final SubjectService subjectService;
+
+    /**
+     * 내 과목 목록 조회
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<SubjectPageResponse>> getSubjects(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        SubjectPageResponse response = subjectService.getSubjects(principal.getPublicId(), page, size);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 과목 생성
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponse<SubjectResponse>> createSubject(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody SubjectCreateRequest request
+    ) {
+        SubjectResponse response = subjectService.createSubject(principal.getPublicId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(SuccessCode.CREATED, response));
+    }
+
+    /**
+     * 과목 상세 조회
+     */
+    @GetMapping("/{subjectId}")
+    public ResponseEntity<ApiResponse<SubjectDetailResponse>> getSubject(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId
+    ) {
+        SubjectDetailResponse response = subjectService.getSubject(principal.getPublicId(), subjectId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 퀴즈 출제 범위 조회
+     */
+    @GetMapping("/{subjectId}/quiz-scope")
+    public ResponseEntity<ApiResponse<QuizScopeResponse>> getQuizScope(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId
+    ) {
+        QuizScopeResponse response = subjectService.getQuizScope(principal.getPublicId(), subjectId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 과목 삭제
+     */
+    @DeleteMapping("/{subjectId}")
+    public ResponseEntity<ApiResponse<Void>> deleteSubject(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId
+    ) {
+        subjectService.deleteSubject(principal.getPublicId(), subjectId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
+    }
+
+    /**
+     * 과목명 수정
+     */
+    @PatchMapping("/{subjectId}/name")
+    public ResponseEntity<ApiResponse<SubjectResponse>> updateSubjectName(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId,
+            @Valid @RequestBody SubjectNameUpdateRequest request
+    ) {
+        SubjectResponse response = subjectService.updateSubjectName(principal.getPublicId(), subjectId, request.getName());
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 과목 상세 수정
+     */
+    @PutMapping("/{subjectId}/details")
+    public ResponseEntity<ApiResponse<SubjectDetailResponse>> updateSubjectDetails(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId,
+            @Valid @RequestBody SubjectDetailUpdateRequest request
+    ) {
+        SubjectDetailResponse response = subjectService.updateSubjectDetails(principal.getPublicId(), subjectId, request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 시험 일정 등록 또는 수정
+     */
+    @PutMapping("/{subjectId}/exam-schedule")
+    public ResponseEntity<ApiResponse<SubjectExamScheduleResponse>> upsertSubjectExamSchedule(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId,
+            @Valid @RequestBody SubjectExamScheduleUpsertRequest request
+    ) {
+        SubjectExamScheduleResponse response = subjectService.upsertExamSchedule(principal.getPublicId(), subjectId, request);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 시험 일정 삭제
+     */
+    @DeleteMapping("/{subjectId}/exam-schedule")
+    public ResponseEntity<ApiResponse<Void>> deleteSubjectExamSchedule(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable String subjectId
+    ) {
+        subjectService.deleteExamSchedule(principal.getPublicId(), subjectId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/CertificateResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/CertificateResponse.java
@@ -1,0 +1,34 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.Certificate;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 자격증 응답 DTO
+ */
+@Getter
+@Builder
+public class CertificateResponse {
+
+    /** 자격증 식별자 */
+    private final Long id;
+    /** 자격증명 */
+    private final String name;
+    /** 자주 찾는 자격증 여부 */
+    private final Boolean featured;
+    /** 표시 순서 */
+    private final Integer displayOrder;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static CertificateResponse from(Certificate certificate) {
+        return CertificateResponse.builder()
+                .id(certificate.getId())
+                .name(certificate.getName())
+                .featured(certificate.getFeatured())
+                .displayOrder(certificate.getDisplayOrder())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/ChapterWithPartsResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/ChapterWithPartsResponse.java
@@ -1,0 +1,38 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 챕터와 파트 응답 DTO
+ */
+@Getter
+@Builder
+public class ChapterWithPartsResponse {
+
+    /** 챕터 식별자 */
+    private final String id;
+    /** 과목 식별자 */
+    private final String subjectId;
+    /** 챕터명 */
+    private final String name;
+    /** 표시 순서 */
+    private final Integer displayOrder;
+    /** 파트 목록 */
+    private final List<PartSummaryResponse> parts;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static ChapterWithPartsResponse of(Chapter chapter, String subjectPublicId, List<PartSummaryResponse> parts) {
+        return ChapterWithPartsResponse.builder()
+                .id(chapter.getPublicId())
+                .subjectId(subjectPublicId)
+                .name(chapter.getName())
+                .displayOrder(chapter.getDisplayOrder())
+                .parts(parts)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/PartSummaryResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/PartSummaryResponse.java
@@ -1,0 +1,35 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.part.entity.Part;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 파트 요약 응답 DTO
+ */
+@Getter
+@Builder
+public class PartSummaryResponse {
+
+    /** 파트 식별자 */
+    private final String id;
+    /** 챕터 식별자 */
+    private final String chapterId;
+    /** 파트명 */
+    private final String name;
+    /** 파트 번호 */
+    private final Integer partNumber;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static PartSummaryResponse of(Part part, Chapter chapter) {
+        return PartSummaryResponse.builder()
+                .id(part.getPublicId())
+                .chapterId(chapter.getPublicId())
+                .name(part.getName())
+                .partNumber(part.getPartNumber())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/QuizScopeResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/QuizScopeResponse.java
@@ -1,0 +1,20 @@
+package com.f1.quiket.domain.subject.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 퀴즈 출제 범위 응답 DTO
+ */
+@Getter
+@Builder
+public class QuizScopeResponse {
+
+    /** 과목 식별자 */
+    private final String subjectId;
+    /** 과목명 */
+    private final String subjectName;
+    /** 챕터 목록 */
+    private final List<ChapterWithPartsResponse> chapters;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectCreateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectCreateRequest.java
@@ -1,0 +1,36 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 과목 생성 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectCreateRequest {
+
+    /** 과목명 */
+    @NotBlank(message = "과목명을 입력해주세요")
+    @Size(max = 30, message = "과목명은 30자 이하여야 합니다")
+    private String name;
+
+    /** 학습 목적 */
+    @NotBlank(message = "학습 목적은 필수입니다")
+    private String purpose;
+
+    /** 시험 상세 */
+    @Valid
+    private SubjectExamDetailRequest examDetail;
+
+    /** 복습 상세 */
+    @Valid
+    private SubjectReviewDetailRequest reviewDetail;
+
+    /** 기타 상세 */
+    @Valid
+    private SubjectOtherDetailRequest otherDetail;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectDetailResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectDetailResponse.java
@@ -1,0 +1,29 @@
+package com.f1.quiket.domain.subject.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 상세 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectDetailResponse {
+
+    /** 과목 식별자 */
+    private final String id;
+    /** 과목명 */
+    private final String name;
+    /** 학습 목적 */
+    private final String purpose;
+    /** 목적별 상세 */
+    private final SubjectPurposeDetailResponse detail;
+    /** 생성 시각 */
+    private final LocalDateTime createdAt;
+    /** 시험 일정 */
+    private final SubjectExamScheduleResponse examSchedule;
+    /** 챕터 목록 */
+    private final List<ChapterWithPartsResponse> chapters;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectDetailUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectDetailUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.f1.quiket.domain.subject.dto;
+
+/**
+ * 과목 상세 수정 요청 DTO
+ */
+public class SubjectDetailUpdateRequest extends SubjectCreateRequest {
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamDetailRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamDetailRequest.java
@@ -1,0 +1,60 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 과목 시험 상세 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectExamDetailRequest {
+
+    /** 시험 유형 */
+    @NotBlank(message = "시험 유형은 필수입니다")
+    private String examType;
+
+    /** 대학 전공 계열 */
+    @Size(max = 30, message = "전공 계열은 30자 이하여야 합니다")
+    private String univMajorField;
+
+    /** 대학 전공명 */
+    @Size(max = 30, message = "전공명은 30자 이하여야 합니다")
+    private String univMajorName;
+
+    /** 대학 과목 유형 */
+    private String univCourseType;
+
+    /** 중고등 학년 */
+    private String mhGrade;
+
+    /** 중고등 과목 유형 */
+    @Size(max = 30, message = "과목 유형은 30자 이하여야 합니다")
+    private String mhSubjectType;
+
+    /** 자격증 식별자 */
+    private Long certificateId;
+
+    /** 직접 입력 자격증명 */
+    @Size(max = 100, message = "자격증명은 100자 이하여야 합니다")
+    private String certificateName;
+
+    /** 공무원 급수 */
+    private String civilRank;
+
+    /** 공무원 직렬 */
+    private String civilSeries;
+
+    /** 어학 언어 */
+    private String langType;
+
+    /** 어학 시험명 */
+    @Size(max = 30, message = "어학 시험명은 30자 이하여야 합니다")
+    private String langExamName;
+
+    /** 기타 시험명 */
+    @Size(max = 30, message = "기타 시험명은 30자 이하여야 합니다")
+    private String otherExamName;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamDetailResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamDetailResponse.java
@@ -1,0 +1,61 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.SubjectExamDetail;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 시험 상세 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectExamDetailResponse {
+
+    /** 시험 유형 */
+    private final String examType;
+    /** 대학 전공 계열 */
+    private final String univMajorField;
+    /** 대학 전공명 */
+    private final String univMajorName;
+    /** 대학 과목 유형 */
+    private final String univCourseType;
+    /** 중고등 학년 */
+    private final String mhGrade;
+    /** 중고등 과목 유형 */
+    private final String mhSubjectType;
+    /** 자격증 식별자 */
+    private final Long certificateId;
+    /** 직접 입력 자격증명 */
+    private final String certificateName;
+    /** 공무원 급수 */
+    private final String civilRank;
+    /** 공무원 직렬 */
+    private final String civilSeries;
+    /** 어학 언어 */
+    private final String langType;
+    /** 어학 시험명 */
+    private final String langExamName;
+    /** 기타 시험명 */
+    private final String otherExamName;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static SubjectExamDetailResponse from(SubjectExamDetail detail) {
+        return SubjectExamDetailResponse.builder()
+                .examType(detail.getExamType())
+                .univMajorField(detail.getUnivMajorField())
+                .univMajorName(detail.getUnivMajorName())
+                .univCourseType(detail.getUnivCourseType())
+                .mhGrade(detail.getMhGrade())
+                .mhSubjectType(detail.getMhSubjectType())
+                .certificateId(detail.getCertificateId())
+                .certificateName(detail.getCertificateName())
+                .civilRank(detail.getCivilRank())
+                .civilSeries(detail.getCivilSeries())
+                .langType(detail.getLangType())
+                .langExamName(detail.getLangExamName())
+                .otherExamName(detail.getOtherExamName())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamScheduleResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamScheduleResponse.java
@@ -1,0 +1,53 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.entity.SubjectExamSchedule;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 시험 일정 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectExamScheduleResponse {
+
+    /** 일정 식별자 */
+    private final String id;
+    /** 과목 식별자 */
+    private final String subjectId;
+    /** 시험명 */
+    private final String examName;
+    /** 시험일 */
+    private final LocalDate examDate;
+    /** D-Day */
+    private final Integer dDay;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static SubjectExamScheduleResponse of(SubjectExamSchedule schedule, Subject subject) {
+        String examName = schedule.getExamName();
+        return SubjectExamScheduleResponse.builder()
+                .id(schedule.getPublicId())
+                .subjectId(subject.getPublicId())
+                .examName(examName == null || examName.isBlank() ? subject.getName() : examName)
+                .examDate(schedule.getExamDate())
+                .dDay(calculateDDay(schedule.getExamDate()))
+                .build();
+    }
+
+    /**
+     * D-Day 산출
+     */
+    private static Integer calculateDDay(LocalDate examDate) {
+        long remainDays = ChronoUnit.DAYS.between(LocalDate.now(), examDate);
+        // 지난 시험일 제외
+        if (remainDays < 0) {
+            return null;
+        }
+        return Math.toIntExact(remainDays);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamScheduleUpsertRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectExamScheduleUpsertRequest.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 시험 일정 저장 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectExamScheduleUpsertRequest {
+
+    /** 시험명 */
+    @Size(max = 100, message = "시험명은 100자 이하여야 합니다")
+    private String examName;
+
+    /** 시험일 */
+    @NotNull(message = "시험 날짜는 필수입니다")
+    private LocalDate examDate;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectNameUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectNameUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 과목명 수정 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectNameUpdateRequest {
+
+    /** 과목명 */
+    @NotBlank(message = "과목명을 입력해주세요")
+    @Size(max = 30, message = "과목명은 30자 이하여야 합니다")
+    private String name;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectOtherDetailRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectOtherDetailRequest.java
@@ -1,0 +1,22 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 과목 기타 상세 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectOtherDetailRequest {
+
+    /** 이용 목적 */
+    @NotBlank(message = "이용 목적은 필수입니다")
+    private String usagePurpose;
+
+    /** 추가 설명 */
+    @Size(min = 1, max = 100, message = "추가 설명은 1자 이상 100자 이하여야 합니다")
+    private String description;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectOtherDetailResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectOtherDetailResponse.java
@@ -1,0 +1,28 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.SubjectOtherDetail;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 기타 상세 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectOtherDetailResponse {
+
+    /** 이용 목적 */
+    private final String usagePurpose;
+    /** 추가 설명 */
+    private final String description;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static SubjectOtherDetailResponse from(SubjectOtherDetail detail) {
+        return SubjectOtherDetailResponse.builder()
+                .usagePurpose(detail.getUsagePurpose())
+                .description(detail.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectPageResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectPageResponse.java
@@ -1,0 +1,26 @@
+package com.f1.quiket.domain.subject.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 페이지 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectPageResponse {
+
+    /** 현재 페이지 번호 */
+    private final Integer page;
+    /** 페이지 크기 */
+    private final Integer size;
+    /** 전체 건수 */
+    private final Long totalElements;
+    /** 전체 페이지 수 */
+    private final Integer totalPages;
+    /** 마지막 페이지 여부 */
+    private final Boolean last;
+    /** 과목 목록 */
+    private final List<SubjectSummaryResponse> content;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectPurposeDetailResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectPurposeDetailResponse.java
@@ -1,0 +1,19 @@
+package com.f1.quiket.domain.subject.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 목적별 상세 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectPurposeDetailResponse {
+
+    /** 시험 상세 */
+    private final SubjectExamDetailResponse examDetail;
+    /** 복습 상세 */
+    private final SubjectReviewDetailResponse reviewDetail;
+    /** 기타 상세 */
+    private final SubjectOtherDetailResponse otherDetail;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectResponse.java
@@ -1,0 +1,38 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.Subject;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 기본 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectResponse {
+
+    /** 과목 식별자 */
+    private final String id;
+    /** 과목명 */
+    private final String name;
+    /** 학습 목적 */
+    private final String purpose;
+    /** 목적별 상세 */
+    private final SubjectPurposeDetailResponse detail;
+    /** 생성 시각 */
+    private final LocalDateTime createdAt;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static SubjectResponse of(Subject subject, SubjectPurposeDetailResponse detail) {
+        return SubjectResponse.builder()
+                .id(subject.getPublicId())
+                .name(subject.getName())
+                .purpose(subject.getPurpose())
+                .detail(detail)
+                .createdAt(subject.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectReviewDetailRequest.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectReviewDetailRequest.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.subject.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 과목 복습 상세 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class SubjectReviewDetailRequest {
+
+    /** 학습 분야 */
+    @NotBlank(message = "분야는 필수입니다")
+    @Size(max = 30, message = "분야는 30자 이하여야 합니다")
+    private String field;
+
+    /** 학습 정도 */
+    @NotBlank(message = "학습 정도는 필수입니다")
+    private String studyLevel;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectReviewDetailResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectReviewDetailResponse.java
@@ -1,0 +1,28 @@
+package com.f1.quiket.domain.subject.dto;
+
+import com.f1.quiket.domain.subject.entity.SubjectReviewDetail;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 복습 상세 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectReviewDetailResponse {
+
+    /** 학습 분야 */
+    private final String field;
+    /** 학습 정도 */
+    private final String studyLevel;
+
+    /**
+     * 엔티티 응답 변환
+     */
+    public static SubjectReviewDetailResponse from(SubjectReviewDetail detail) {
+        return SubjectReviewDetailResponse.builder()
+                .field(detail.getField())
+                .studyLevel(detail.getStudyLevel())
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/dto/SubjectSummaryResponse.java
+++ b/src/main/java/com/f1/quiket/domain/subject/dto/SubjectSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.f1.quiket.domain.subject.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 과목 요약 응답 DTO
+ */
+@Getter
+@Builder
+public class SubjectSummaryResponse {
+
+    /** 과목 식별자 */
+    private final String id;
+    /** 과목명 */
+    private final String name;
+    /** 학습 목적 */
+    private final String purpose;
+    /** 챕터 수 */
+    private final Integer chapterCount;
+    /** 파트 수 */
+    private final Integer partCount;
+    /** 마지막 활동 시각 */
+    private final LocalDateTime lastActivityAt;
+    /** 시험 일정 */
+    private final SubjectExamScheduleResponse examSchedule;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/Certificate.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/Certificate.java
@@ -1,0 +1,54 @@
+package com.f1.quiket.domain.subject.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 자격증 마스터 엔티티
+ */
+@Entity
+@Table(
+        name = "certificates",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_certificates_name", columnNames = "name")
+        },
+        indexes = {
+                @Index(name = "idx_certificates_is_featured_display_order", columnList = "is_featured, display_order")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Certificate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    Long id;
+
+    @Column(name = "name", length = 100, nullable = false)
+    String name;
+
+    @Column(name = "is_featured", nullable = false)
+    Boolean featured;
+
+    @Column(name = "display_order", nullable = false)
+    Integer displayOrder;
+
+    @Column(name = "created_at", nullable = false)
+    LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    LocalDateTime updatedAt;
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/Subject.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/Subject.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.subject.entity;
 
 import com.f1.quiket.global.entity.BaseEntity;
+import com.f1.quiket.global.util.UuidV7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
@@ -41,4 +42,30 @@ public class Subject extends BaseEntity {
 
     @Column(name = "purpose", length = 20, nullable = false)
     String purpose;
+
+    /**
+     * 과목 생성
+     */
+    public static Subject create(Long userId, String name, String purpose) {
+        Subject subject = new Subject();
+        subject.publicId = UuidV7Generator.generate();
+        subject.userId = userId;
+        subject.name = name;
+        subject.purpose = purpose;
+        return subject;
+    }
+
+    /**
+     * 과목명 변경
+     */
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * 과목 상세 유형 변경
+     */
+    public void updatePurpose(String purpose) {
+        this.purpose = purpose;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/subject/entity/SubjectExamDetail.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/SubjectExamDetail.java
@@ -1,0 +1,103 @@
+package com.f1.quiket.domain.subject.entity;
+
+import com.f1.quiket.domain.subject.dto.SubjectExamDetailRequest;
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 과목 시험 상세 엔티티
+ */
+@Entity
+@Table(
+        name = "subject_exam_details",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_subject_exam_details_subject_id", columnNames = "subject_id")
+        },
+        indexes = {
+                @Index(name = "idx_subject_exam_details_exam_type", columnList = "exam_type")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SubjectExamDetail extends BaseEntity {
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "exam_type", length = 20, nullable = false)
+    String examType;
+
+    @Column(name = "univ_major_field", length = 30)
+    String univMajorField;
+
+    @Column(name = "univ_major_name", length = 30)
+    String univMajorName;
+
+    @Column(name = "univ_course_type", length = 20)
+    String univCourseType;
+
+    @Column(name = "mh_grade", length = 10)
+    String mhGrade;
+
+    @Column(name = "mh_subject_type", length = 30)
+    String mhSubjectType;
+
+    @Column(name = "certificate_id")
+    Long certificateId;
+
+    @Column(name = "certificate_name", length = 100)
+    String certificateName;
+
+    @Column(name = "civil_rank", length = 20)
+    String civilRank;
+
+    @Column(name = "civil_series", length = 30)
+    String civilSeries;
+
+    @Column(name = "lang_type", length = 20)
+    String langType;
+
+    @Column(name = "lang_exam_name", length = 30)
+    String langExamName;
+
+    @Column(name = "other_exam_name", length = 30)
+    String otherExamName;
+
+    /**
+     * 시험 상세 생성
+     */
+    public static SubjectExamDetail create(Long subjectId, SubjectExamDetailRequest request) {
+        SubjectExamDetail detail = new SubjectExamDetail();
+        detail.subjectId = subjectId;
+        detail.update(request);
+        return detail;
+    }
+
+    /**
+     * 시험 상세 변경
+     */
+    public void update(SubjectExamDetailRequest request) {
+        this.examType = request.getExamType();
+        this.univMajorField = request.getUnivMajorField();
+        this.univMajorName = request.getUnivMajorName();
+        this.univCourseType = request.getUnivCourseType();
+        this.mhGrade = request.getMhGrade();
+        this.mhSubjectType = request.getMhSubjectType();
+        this.certificateId = request.getCertificateId();
+        this.certificateName = request.getCertificateName();
+        this.civilRank = request.getCivilRank();
+        this.civilSeries = request.getCivilSeries();
+        this.langType = request.getLangType();
+        this.langExamName = request.getLangExamName();
+        this.otherExamName = request.getOtherExamName();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/SubjectExamSchedule.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/SubjectExamSchedule.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.subject.entity;
 
 import com.f1.quiket.global.entity.BaseEntity;
+import com.f1.quiket.global.util.UuidV7Generator;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
@@ -46,4 +47,26 @@ public class SubjectExamSchedule extends BaseEntity {
 
     @Column(name = "exam_date", nullable = false)
     LocalDate examDate;
+
+    /**
+     * 시험 일정 생성
+     */
+    public static SubjectExamSchedule create(Long subjectId, Long userId, String examName, LocalDate examDate) {
+        SubjectExamSchedule schedule = new SubjectExamSchedule();
+        schedule.publicId = UuidV7Generator.generate();
+        schedule.subjectId = subjectId;
+        schedule.userId = userId;
+        schedule.examName = examName;
+        schedule.examDate = examDate;
+        return schedule;
+    }
+
+    /**
+     * 시험 일정 변경
+     */
+    public void update(String examName, LocalDate examDate) {
+        this.examName = examName;
+        this.examDate = examDate;
+        restore();
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/subject/entity/SubjectOtherDetail.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/SubjectOtherDetail.java
@@ -1,0 +1,55 @@
+package com.f1.quiket.domain.subject.entity;
+
+import com.f1.quiket.domain.subject.dto.SubjectOtherDetailRequest;
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 과목 기타 상세 엔티티
+ */
+@Entity
+@Table(
+        name = "subject_other_details",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_subject_other_details_subject_id", columnNames = "subject_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SubjectOtherDetail extends BaseEntity {
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "usage_purpose", length = 30, nullable = false)
+    String usagePurpose;
+
+    @Column(name = "description", length = 100)
+    String description;
+
+    /**
+     * 기타 상세 생성
+     */
+    public static SubjectOtherDetail create(Long subjectId, SubjectOtherDetailRequest request) {
+        SubjectOtherDetail detail = new SubjectOtherDetail();
+        detail.subjectId = subjectId;
+        detail.update(request);
+        return detail;
+    }
+
+    /**
+     * 기타 상세 변경
+     */
+    public void update(SubjectOtherDetailRequest request) {
+        this.usagePurpose = request.getUsagePurpose();
+        this.description = request.getDescription();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/SubjectReviewDetail.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/SubjectReviewDetail.java
@@ -1,0 +1,55 @@
+package com.f1.quiket.domain.subject.entity;
+
+import com.f1.quiket.domain.subject.dto.SubjectReviewDetailRequest;
+import com.f1.quiket.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * 과목 복습 상세 엔티티
+ */
+@Entity
+@Table(
+        name = "subject_review_details",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uq_subject_review_details_subject_id", columnNames = "subject_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class SubjectReviewDetail extends BaseEntity {
+
+    @Column(name = "subject_id", nullable = false)
+    Long subjectId;
+
+    @Column(name = "field", length = 30, nullable = false)
+    String field;
+
+    @Column(name = "study_level", length = 30, nullable = false)
+    String studyLevel;
+
+    /**
+     * 복습 상세 생성
+     */
+    public static SubjectReviewDetail create(Long subjectId, SubjectReviewDetailRequest request) {
+        SubjectReviewDetail detail = new SubjectReviewDetail();
+        detail.subjectId = subjectId;
+        detail.update(request);
+        return detail;
+    }
+
+    /**
+     * 복습 상세 변경
+     */
+    public void update(SubjectReviewDetailRequest request) {
+        this.field = request.getField();
+        this.studyLevel = request.getStudyLevel();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/type/ExamType.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/type/ExamType.java
@@ -1,0 +1,29 @@
+package com.f1.quiket.domain.subject.entity.type;
+
+import java.util.Arrays;
+
+/**
+ * 시험 유형
+ */
+public enum ExamType {
+
+    UNIVERSITY("university"),
+    MIDDLE_HIGH("middle_high"),
+    CERTIFICATE("certificate"),
+    CIVIL_SERVICE("civil_service"),
+    LANGUAGE("language"),
+    OTHER_EXAM("other_exam");
+
+    private final String value;
+
+    ExamType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * 문자열 enum 검증
+     */
+    public static boolean contains(String value) {
+        return Arrays.stream(values()).anyMatch(type -> type.value.equals(value));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/type/StudyLevel.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/type/StudyLevel.java
@@ -1,0 +1,27 @@
+package com.f1.quiket.domain.subject.entity.type;
+
+import java.util.Arrays;
+
+/**
+ * 학습 정도
+ */
+public enum StudyLevel {
+
+    BEGINNER("beginner"),
+    CASUAL("casual"),
+    REGULAR("regular"),
+    EXPERT("expert");
+
+    private final String value;
+
+    StudyLevel(String value) {
+        this.value = value;
+    }
+
+    /**
+     * 문자열 enum 검증
+     */
+    public static boolean contains(String value) {
+        return Arrays.stream(values()).anyMatch(level -> level.value.equals(value));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/type/SubjectPurpose.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/type/SubjectPurpose.java
@@ -1,0 +1,33 @@
+package com.f1.quiket.domain.subject.entity.type;
+
+import java.util.Arrays;
+
+/**
+ * 과목 학습 목적
+ */
+public enum SubjectPurpose {
+
+    EXAM("exam"),
+    REVIEW("review"),
+    OTHER("other");
+
+    private final String value;
+
+    SubjectPurpose(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    /**
+     * 문자열 enum 변환
+     */
+    public static SubjectPurpose from(String value) {
+        return Arrays.stream(values())
+                .filter(purpose -> purpose.value.equals(value))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/entity/type/UsagePurpose.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/type/UsagePurpose.java
@@ -1,0 +1,28 @@
+package com.f1.quiket.domain.subject.entity.type;
+
+import java.util.Arrays;
+
+/**
+ * 기타 이용 목적
+ */
+public enum UsagePurpose {
+
+    WORK("work"),
+    PERSONAL("personal"),
+    HOBBY("hobby"),
+    MEMORY("memory"),
+    OTHER("other");
+
+    private final String value;
+
+    UsagePurpose(String value) {
+        this.value = value;
+    }
+
+    /**
+     * 문자열 enum 검증
+     */
+    public static boolean contains(String value) {
+        return Arrays.stream(values()).anyMatch(purpose -> purpose.value.equals(value));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/repository/CertificateRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/CertificateRepository.java
@@ -1,0 +1,33 @@
+package com.f1.quiket.domain.subject.repository;
+
+import com.f1.quiket.domain.subject.entity.Certificate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 자격증 마스터 리포지토리
+ */
+@Repository
+public interface CertificateRepository extends JpaRepository<Certificate, Long> {
+
+    /**
+     * 전체 자격증 목록 조회
+     */
+    List<Certificate> findAllByOrderByDisplayOrderAscNameAsc();
+
+    /**
+     * 자주 찾는 자격증 목록 조회
+     */
+    List<Certificate> findAllByFeaturedTrueOrderByDisplayOrderAscNameAsc();
+
+    /**
+     * 자격증명 검색
+     */
+    List<Certificate> findAllByNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc(String keyword);
+
+    /**
+     * 자주 찾는 자격증명 검색
+     */
+    List<Certificate> findAllByFeaturedTrueAndNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc(String keyword);
+}

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamDetailRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamDetailRepository.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.subject.repository;
+
+import com.f1.quiket.domain.subject.entity.SubjectExamDetail;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 과목 시험 상세 리포지토리
+ */
+@Repository
+public interface SubjectExamDetailRepository extends JpaRepository<SubjectExamDetail, Long> {
+
+    /**
+     * 과목 시험 상세 조회
+     */
+    Optional<SubjectExamDetail> findBySubjectId(Long subjectId);
+
+    /**
+     * 과목 시험 상세 삭제
+     */
+    void deleteBySubjectId(Long subjectId);
+}

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamScheduleRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamScheduleRepository.java
@@ -4,6 +4,7 @@ import com.f1.quiket.domain.subject.entity.SubjectExamSchedule;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -27,4 +28,14 @@ public interface SubjectExamScheduleRepository extends JpaRepository<SubjectExam
      * 과목별 일정 목록 조회
      */
     List<SubjectExamSchedule> findAllBySubjectIdInAndDeletedAtIsNull(Collection<Long> subjectIds);
+
+    /**
+     * 과목 일정 조회
+     */
+    Optional<SubjectExamSchedule> findBySubjectIdAndDeletedAtIsNull(Long subjectId);
+
+    /**
+     * 과목 일정 전체 조회
+     */
+    Optional<SubjectExamSchedule> findBySubjectId(Long subjectId);
 }

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectOtherDetailRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectOtherDetailRepository.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.subject.repository;
+
+import com.f1.quiket.domain.subject.entity.SubjectOtherDetail;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 과목 기타 상세 리포지토리
+ */
+@Repository
+public interface SubjectOtherDetailRepository extends JpaRepository<SubjectOtherDetail, Long> {
+
+    /**
+     * 과목 기타 상세 조회
+     */
+    Optional<SubjectOtherDetail> findBySubjectId(Long subjectId);
+
+    /**
+     * 과목 기타 상세 삭제
+     */
+    void deleteBySubjectId(Long subjectId);
+}

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
@@ -28,11 +28,6 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
      * 공개 식별자 기반 사용자 과목 조회
      */
     Optional<Subject> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
-    
-    /**
-     * 사용자 과목 단건 조회
-     */
-    Optional<Subject> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
 
     /**
      * 사용자 과목 단건 조회 (PK 기반)

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
@@ -2,6 +2,9 @@ package com.f1.quiket.domain.subject.repository;
 
 import com.f1.quiket.domain.subject.entity.Subject;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -15,4 +18,14 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
      * 사용자 과목 목록 조회
      */
     List<Subject> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 사용자 과목 페이지 조회
+     */
+    Page<Subject> findByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
+
+    /**
+     * 공개 식별자 기반 사용자 과목 조회
+     */
+    Optional<Subject> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
 }

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectReviewDetailRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectReviewDetailRepository.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.subject.repository;
+
+import com.f1.quiket.domain.subject.entity.SubjectReviewDetail;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 과목 복습 상세 리포지토리
+ */
+@Repository
+public interface SubjectReviewDetailRepository extends JpaRepository<SubjectReviewDetail, Long> {
+
+    /**
+     * 과목 복습 상세 조회
+     */
+    Optional<SubjectReviewDetail> findBySubjectId(Long subjectId);
+
+    /**
+     * 과목 복습 상세 삭제
+     */
+    void deleteBySubjectId(Long subjectId);
+}

--- a/src/main/java/com/f1/quiket/domain/subject/service/CertificateService.java
+++ b/src/main/java/com/f1/quiket/domain/subject/service/CertificateService.java
@@ -1,0 +1,44 @@
+package com.f1.quiket.domain.subject.service;
+
+import com.f1.quiket.domain.subject.dto.CertificateResponse;
+import com.f1.quiket.domain.subject.entity.Certificate;
+import com.f1.quiket.domain.subject.repository.CertificateRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * 자격증 마스터 조회 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class CertificateService {
+
+    private final CertificateRepository certificateRepository;
+
+    /**
+     * 자격증 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<CertificateResponse> getCertificates(Boolean featured, String keyword) {
+        boolean featuredOnly = Boolean.TRUE.equals(featured);
+        List<Certificate> certificates;
+
+        // featured와 keyword 조합별 JPA 기본 메서드 사용
+        if (featuredOnly && StringUtils.hasText(keyword)) {
+            certificates = certificateRepository.findAllByFeaturedTrueAndNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc(keyword);
+        } else if (featuredOnly) {
+            certificates = certificateRepository.findAllByFeaturedTrueOrderByDisplayOrderAscNameAsc();
+        } else if (StringUtils.hasText(keyword)) {
+            certificates = certificateRepository.findAllByNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc(keyword);
+        } else {
+            certificates = certificateRepository.findAllByOrderByDisplayOrderAscNameAsc();
+        }
+
+        return certificates.stream()
+                .map(CertificateResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/f1/quiket/domain/subject/service/SubjectService.java
@@ -1,0 +1,445 @@
+package com.f1.quiket.domain.subject.service;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.dto.ChapterWithPartsResponse;
+import com.f1.quiket.domain.subject.dto.PartSummaryResponse;
+import com.f1.quiket.domain.subject.dto.QuizScopeResponse;
+import com.f1.quiket.domain.subject.dto.SubjectCreateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectDetailUpdateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectExamDetailRequest;
+import com.f1.quiket.domain.subject.dto.SubjectExamDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleResponse;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleUpsertRequest;
+import com.f1.quiket.domain.subject.dto.SubjectOtherDetailRequest;
+import com.f1.quiket.domain.subject.dto.SubjectOtherDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectPageResponse;
+import com.f1.quiket.domain.subject.dto.SubjectPurposeDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectResponse;
+import com.f1.quiket.domain.subject.dto.SubjectReviewDetailRequest;
+import com.f1.quiket.domain.subject.dto.SubjectReviewDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectSummaryResponse;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.entity.SubjectExamDetail;
+import com.f1.quiket.domain.subject.entity.SubjectExamSchedule;
+import com.f1.quiket.domain.subject.entity.SubjectOtherDetail;
+import com.f1.quiket.domain.subject.entity.SubjectReviewDetail;
+import com.f1.quiket.domain.subject.entity.type.ExamType;
+import com.f1.quiket.domain.subject.entity.type.StudyLevel;
+import com.f1.quiket.domain.subject.entity.type.SubjectPurpose;
+import com.f1.quiket.domain.subject.entity.type.UsagePurpose;
+import com.f1.quiket.domain.subject.repository.SubjectExamDetailRepository;
+import com.f1.quiket.domain.subject.repository.SubjectExamScheduleRepository;
+import com.f1.quiket.domain.subject.repository.SubjectOtherDetailRepository;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.subject.repository.SubjectReviewDetailRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * 과목 비즈니스 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class SubjectService {
+
+    private static final int MIN_PAGE = 0;
+    private static final int MIN_SIZE = 1;
+    private static final int MAX_SIZE = 100;
+
+    private final UserRepository userRepository;
+    private final SubjectRepository subjectRepository;
+    private final SubjectExamDetailRepository subjectExamDetailRepository;
+    private final SubjectReviewDetailRepository subjectReviewDetailRepository;
+    private final SubjectOtherDetailRepository subjectOtherDetailRepository;
+    private final SubjectExamScheduleRepository subjectExamScheduleRepository;
+    private final ChapterRepository chapterRepository;
+    private final PartRepository partRepository;
+    private final QuizSessionRepository quizSessionRepository;
+
+    /**
+     * 과목 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public SubjectPageResponse getSubjects(String userPublicId, int page, int size) {
+        User user = findUser(userPublicId);
+        PageRequest pageRequest = PageRequest.of(normalizePage(page), normalizeSize(size), Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Subject> subjectPage = subjectRepository.findByUserIdAndDeletedAtIsNull(user.getId(), pageRequest);
+        List<Subject> subjects = subjectPage.getContent();
+        List<Long> subjectIds = subjects.stream().map(Subject::getId).toList();
+
+        if (subjectIds.isEmpty()) {
+            return SubjectPageResponse.builder()
+                    .page(subjectPage.getNumber())
+                    .size(subjectPage.getSize())
+                    .totalElements(subjectPage.getTotalElements())
+                    .totalPages(subjectPage.getTotalPages())
+                    .last(subjectPage.isLast())
+                    .content(List.of())
+                    .build();
+        }
+
+        Map<Long, Long> chapterCounts = chapterRepository.findAllBySubjectIdInAndDeletedAtIsNull(subjectIds).stream()
+                .collect(Collectors.groupingBy(Chapter::getSubjectId, Collectors.counting()));
+        Map<Long, Long> partCounts = partRepository.findAllBySubjectIdInAndDeletedAtIsNull(subjectIds).stream()
+                .collect(Collectors.groupingBy(Part::getSubjectId, Collectors.counting()));
+        Map<Long, SubjectExamSchedule> schedules = subjectExamScheduleRepository.findAllBySubjectIdInAndDeletedAtIsNull(subjectIds).stream()
+                .collect(Collectors.toMap(SubjectExamSchedule::getSubjectId, Function.identity()));
+
+        List<SubjectSummaryResponse> content = subjects.stream()
+                .map(subject -> toSummary(subject, chapterCounts, partCounts, schedules))
+                .toList();
+
+        return SubjectPageResponse.builder()
+                .page(subjectPage.getNumber())
+                .size(subjectPage.getSize())
+                .totalElements(subjectPage.getTotalElements())
+                .totalPages(subjectPage.getTotalPages())
+                .last(subjectPage.isLast())
+                .content(content)
+                .build();
+    }
+
+    /**
+     * 과목 생성
+     */
+    @Transactional
+    public SubjectResponse createSubject(String userPublicId, SubjectCreateRequest request) {
+        User user = findUser(userPublicId);
+        SubjectPurpose purpose = validatePurpose(request);
+        Subject subject = subjectRepository.save(Subject.create(user.getId(), request.getName(), purpose.value()));
+        saveDetail(subject.getId(), purpose, request);
+        return SubjectResponse.of(subject, getPurposeDetail(subject));
+    }
+
+    /**
+     * 과목 상세 조회
+     */
+    @Transactional(readOnly = true)
+    public SubjectDetailResponse getSubject(String userPublicId, String subjectPublicId) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        return toDetail(subject);
+    }
+
+    /**
+     * 퀴즈 출제 범위 조회
+     */
+    @Transactional(readOnly = true)
+    public QuizScopeResponse getQuizScope(String userPublicId, String subjectPublicId) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        return QuizScopeResponse.builder()
+                .subjectId(subject.getPublicId())
+                .subjectName(subject.getName())
+                .chapters(getChapterWithParts(subject))
+                .build();
+    }
+
+    /**
+     * 과목명 수정
+     */
+    @Transactional
+    public SubjectResponse updateSubjectName(String userPublicId, String subjectPublicId, String name) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        subject.updateName(name);
+        return SubjectResponse.of(subject, getPurposeDetail(subject));
+    }
+
+    /**
+     * 과목 상세 수정
+     */
+    @Transactional
+    public SubjectDetailResponse updateSubjectDetails(String userPublicId, String subjectPublicId, SubjectDetailUpdateRequest request) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        SubjectPurpose purpose = validatePurpose(request);
+        subject.updatePurpose(purpose.value());
+        replaceDetails(subject.getId(), purpose, request);
+        return toDetail(subject);
+    }
+
+    /**
+     * 시험 일정 등록 또는 수정
+     */
+    @Transactional
+    public SubjectExamScheduleResponse upsertExamSchedule(String userPublicId, String subjectPublicId, SubjectExamScheduleUpsertRequest request) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        SubjectExamSchedule schedule = subjectExamScheduleRepository.findBySubjectId(subject.getId())
+                .map(existingSchedule -> {
+                    existingSchedule.update(normalizeBlank(request.getExamName()), request.getExamDate());
+                    return existingSchedule;
+                })
+                .orElseGet(() -> subjectExamScheduleRepository.save(
+                        SubjectExamSchedule.create(subject.getId(), user.getId(), normalizeBlank(request.getExamName()), request.getExamDate())
+                ));
+        return SubjectExamScheduleResponse.of(schedule, subject);
+    }
+
+    /**
+     * 시험 일정 삭제
+     */
+    @Transactional
+    public void deleteExamSchedule(String userPublicId, String subjectPublicId) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+        SubjectExamSchedule schedule = subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+        schedule.delete();
+    }
+
+    /**
+     * 과목 삭제
+     */
+    @Transactional
+    public void deleteSubject(String userPublicId, String subjectPublicId) {
+        User user = findUser(userPublicId);
+        Subject subject = findSubject(subjectPublicId, user.getId());
+
+        // 하위 데이터 soft delete
+        subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId()).ifPresent(SubjectExamSchedule::delete);
+        chapterRepository.findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId()).forEach(Chapter::delete);
+        partRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId()).forEach(Part::delete);
+        quizSessionRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId()).forEach(session -> session.delete());
+
+        subject.delete();
+    }
+
+    /**
+     * 사용자 조회
+     */
+    private User findUser(String userPublicId) {
+        return userRepository.findByPublicIdAndDeletedAtIsNull(userPublicId)
+                .orElseThrow(() -> new CustomException(ErrorCode.AUTH_USER_NOT_FOUND));
+    }
+
+    /**
+     * 소유 과목 조회
+     */
+    private Subject findSubject(String subjectPublicId, Long userId) {
+        return subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subjectPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+    }
+
+    /**
+     * 과목 상세 응답 변환
+     */
+    private SubjectDetailResponse toDetail(Subject subject) {
+        List<ChapterWithPartsResponse> chapterResponses = getChapterWithParts(subject);
+
+        SubjectExamScheduleResponse scheduleResponse = subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId())
+                .map(schedule -> SubjectExamScheduleResponse.of(schedule, subject))
+                .orElse(null);
+
+        return SubjectDetailResponse.builder()
+                .id(subject.getPublicId())
+                .name(subject.getName())
+                .purpose(subject.getPurpose())
+                .detail(getPurposeDetail(subject))
+                .createdAt(subject.getCreatedAt())
+                .examSchedule(scheduleResponse)
+                .chapters(chapterResponses)
+                .build();
+    }
+
+    /**
+     * 챕터와 파트 응답 목록 생성
+     */
+    private List<ChapterWithPartsResponse> getChapterWithParts(Subject subject) {
+        List<Chapter> chapters = chapterRepository.findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId());
+        if (chapters.isEmpty()) {
+            return List.of();
+        }
+        Map<Long, Chapter> chapterMap = chapters.stream().collect(Collectors.toMap(Chapter::getId, Function.identity()));
+        Map<Long, List<Part>> partMap = partRepository.findAllByChapterIdInAndDeletedAtIsNull(chapters.stream().map(Chapter::getId).toList()).stream()
+                .sorted(Comparator.comparing(Part::getPartNumber).thenComparing(Part::getCreatedAt))
+                .collect(Collectors.groupingBy(Part::getChapterId));
+
+        return chapters.stream()
+                .map(chapter -> ChapterWithPartsResponse.of(
+                        chapter,
+                        subject.getPublicId(),
+                        partMap.getOrDefault(chapter.getId(), List.of()).stream()
+                                .map(part -> PartSummaryResponse.of(part, chapterMap.get(part.getChapterId())))
+                                .toList()
+                ))
+                .toList();
+    }
+
+    /**
+     * 과목 요약 응답 변환
+     */
+    private SubjectSummaryResponse toSummary(
+            Subject subject,
+            Map<Long, Long> chapterCounts,
+            Map<Long, Long> partCounts,
+            Map<Long, SubjectExamSchedule> schedules
+    ) {
+        SubjectExamSchedule schedule = schedules.get(subject.getId());
+        return SubjectSummaryResponse.builder()
+                .id(subject.getPublicId())
+                .name(subject.getName())
+                .purpose(subject.getPurpose())
+                .chapterCount(Math.toIntExact(chapterCounts.getOrDefault(subject.getId(), 0L)))
+                .partCount(Math.toIntExact(partCounts.getOrDefault(subject.getId(), 0L)))
+                .lastActivityAt(subject.getUpdatedAt())
+                .examSchedule(schedule == null ? null : SubjectExamScheduleResponse.of(schedule, subject))
+                .build();
+    }
+
+    /**
+     * 목적별 상세 조회
+     */
+    private SubjectPurposeDetailResponse getPurposeDetail(Subject subject) {
+        SubjectPurpose purpose = SubjectPurpose.from(subject.getPurpose());
+        if (purpose == SubjectPurpose.EXAM) {
+            return SubjectPurposeDetailResponse.builder()
+                    .examDetail(subjectExamDetailRepository.findBySubjectId(subject.getId())
+                            .map(SubjectExamDetailResponse::from)
+                            .orElse(null))
+                    .build();
+        }
+        if (purpose == SubjectPurpose.REVIEW) {
+            return SubjectPurposeDetailResponse.builder()
+                    .reviewDetail(subjectReviewDetailRepository.findBySubjectId(subject.getId())
+                            .map(SubjectReviewDetailResponse::from)
+                            .orElse(null))
+                    .build();
+        }
+        return SubjectPurposeDetailResponse.builder()
+                .otherDetail(subjectOtherDetailRepository.findBySubjectId(subject.getId())
+                        .map(SubjectOtherDetailResponse::from)
+                        .orElse(null))
+                .build();
+    }
+
+    /**
+     * 목적별 상세 저장
+     */
+    private void saveDetail(Long subjectId, SubjectPurpose purpose, SubjectCreateRequest request) {
+        if (purpose == SubjectPurpose.EXAM) {
+            SubjectExamDetailRequest detail = validateExamDetail(request.getExamDetail());
+            subjectExamDetailRepository.save(SubjectExamDetail.create(subjectId, detail));
+            return;
+        }
+        if (purpose == SubjectPurpose.REVIEW) {
+            SubjectReviewDetailRequest detail = validateReviewDetail(request.getReviewDetail());
+            subjectReviewDetailRepository.save(SubjectReviewDetail.create(subjectId, detail));
+            return;
+        }
+        SubjectOtherDetailRequest detail = validateOtherDetail(request.getOtherDetail());
+        subjectOtherDetailRepository.save(SubjectOtherDetail.create(subjectId, detail));
+    }
+
+    /**
+     * 목적별 상세 교체
+     */
+    private void replaceDetails(Long subjectId, SubjectPurpose purpose, SubjectCreateRequest request) {
+        if (purpose == SubjectPurpose.EXAM) {
+            SubjectExamDetailRequest detail = validateExamDetail(request.getExamDetail());
+            subjectReviewDetailRepository.deleteBySubjectId(subjectId);
+            subjectOtherDetailRepository.deleteBySubjectId(subjectId);
+            subjectExamDetailRepository.findBySubjectId(subjectId)
+                    .ifPresentOrElse(existingDetail -> existingDetail.update(detail),
+                            () -> subjectExamDetailRepository.save(SubjectExamDetail.create(subjectId, detail)));
+            return;
+        }
+        if (purpose == SubjectPurpose.REVIEW) {
+            SubjectReviewDetailRequest detail = validateReviewDetail(request.getReviewDetail());
+            subjectExamDetailRepository.deleteBySubjectId(subjectId);
+            subjectOtherDetailRepository.deleteBySubjectId(subjectId);
+            subjectReviewDetailRepository.findBySubjectId(subjectId)
+                    .ifPresentOrElse(existingDetail -> existingDetail.update(detail),
+                            () -> subjectReviewDetailRepository.save(SubjectReviewDetail.create(subjectId, detail)));
+            return;
+        }
+        SubjectOtherDetailRequest detail = validateOtherDetail(request.getOtherDetail());
+        subjectExamDetailRepository.deleteBySubjectId(subjectId);
+        subjectReviewDetailRepository.deleteBySubjectId(subjectId);
+        subjectOtherDetailRepository.findBySubjectId(subjectId)
+                .ifPresentOrElse(existingDetail -> existingDetail.update(detail),
+                        () -> subjectOtherDetailRepository.save(SubjectOtherDetail.create(subjectId, detail)));
+    }
+
+    /**
+     * 학습 목적 검증
+     */
+    private SubjectPurpose validatePurpose(SubjectCreateRequest request) {
+        try {
+            return SubjectPurpose.from(request.getPurpose());
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "지원하지 않는 학습 목적입니다.");
+        }
+    }
+
+    /**
+     * 시험 상세 검증
+     */
+    private SubjectExamDetailRequest validateExamDetail(SubjectExamDetailRequest detail) {
+        if (detail == null || !StringUtils.hasText(detail.getExamType()) || !ExamType.contains(detail.getExamType())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "시험 상세 정보가 올바르지 않습니다.");
+        }
+        return detail;
+    }
+
+    /**
+     * 복습 상세 검증
+     */
+    private SubjectReviewDetailRequest validateReviewDetail(SubjectReviewDetailRequest detail) {
+        if (detail == null || !StudyLevel.contains(detail.getStudyLevel())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "복습 상세 정보가 올바르지 않습니다.");
+        }
+        return detail;
+    }
+
+    /**
+     * 기타 상세 검증
+     */
+    private SubjectOtherDetailRequest validateOtherDetail(SubjectOtherDetailRequest detail) {
+        if (detail == null || !UsagePurpose.contains(detail.getUsagePurpose())) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "기타 상세 정보가 올바르지 않습니다.");
+        }
+        return detail;
+    }
+
+    /**
+     * 페이지 번호 보정
+     */
+    private int normalizePage(int page) {
+        return Math.max(page, MIN_PAGE);
+    }
+
+    /**
+     * 페이지 크기 보정
+     */
+    private int normalizeSize(int size) {
+        return Math.min(Math.max(size, MIN_SIZE), MAX_SIZE);
+    }
+
+    /**
+     * 빈 문자열 정규화
+     */
+    private String normalizeBlank(String value) {
+        return StringUtils.hasText(value) ? value : null;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/f1/quiket/domain/subject/service/SubjectService.java
@@ -137,7 +137,7 @@ public class SubjectService {
     public SubjectDetailResponse getSubject(String userPublicId, String subjectPublicId) {
         User user = findUser(userPublicId);
         Subject subject = findSubject(subjectPublicId, user.getId());
-        return toDetail(subject);
+        return toDetail(subject, user.getId());
     }
 
     /**
@@ -150,7 +150,7 @@ public class SubjectService {
         return QuizScopeResponse.builder()
                 .subjectId(subject.getPublicId())
                 .subjectName(subject.getName())
-                .chapters(getChapterWithParts(subject))
+                .chapters(getChapterWithParts(subject, user.getId()))
                 .build();
     }
 
@@ -175,7 +175,7 @@ public class SubjectService {
         SubjectPurpose purpose = validatePurpose(request);
         subject.updatePurpose(purpose.value());
         replaceDetails(subject.getId(), purpose, request);
-        return toDetail(subject);
+        return toDetail(subject, user.getId());
     }
 
     /**
@@ -218,7 +218,8 @@ public class SubjectService {
 
         // 하위 데이터 soft delete
         subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId()).ifPresent(SubjectExamSchedule::delete);
-        chapterRepository.findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId()).forEach(Chapter::delete);
+        chapterRepository.findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId(), user.getId())
+                .forEach(Chapter::delete);
         partRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId()).forEach(Part::delete);
         quizSessionRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId()).forEach(session -> session.delete());
 
@@ -244,8 +245,8 @@ public class SubjectService {
     /**
      * 과목 상세 응답 변환
      */
-    private SubjectDetailResponse toDetail(Subject subject) {
-        List<ChapterWithPartsResponse> chapterResponses = getChapterWithParts(subject);
+    private SubjectDetailResponse toDetail(Subject subject, Long userId) {
+        List<ChapterWithPartsResponse> chapterResponses = getChapterWithParts(subject, userId);
 
         SubjectExamScheduleResponse scheduleResponse = subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId())
                 .map(schedule -> SubjectExamScheduleResponse.of(schedule, subject))
@@ -265,8 +266,11 @@ public class SubjectService {
     /**
      * 챕터와 파트 응답 목록 생성
      */
-    private List<ChapterWithPartsResponse> getChapterWithParts(Subject subject) {
-        List<Chapter> chapters = chapterRepository.findAllBySubjectIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId());
+    private List<ChapterWithPartsResponse> getChapterWithParts(Subject subject, Long userId) {
+        List<Chapter> chapters = chapterRepository.findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(
+                subject.getId(),
+                userId
+        );
         if (chapters.isEmpty()) {
             return List.of();
         }

--- a/src/main/java/com/f1/quiket/domain/user/entity/User.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/User.java
@@ -93,6 +93,12 @@ public class User extends BaseEntity {
         this.nickname = nickname;
     }
 
+    public void applyQuizReward(Integer dotoriEarned, Integer xpEarned, Integer levelAfter) {
+        this.dotoriBalance += dotoriEarned;
+        this.xpTotal += xpEarned;
+        this.currentLevel = levelAfter;
+    }
+
     public void recordLoginFailure(int maxFailedCount) {
         LocalDateTime now = LocalDateTime.now();
         this.failedLoginCount++;

--- a/src/main/java/com/f1/quiket/domain/user/entity/User.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/User.java
@@ -93,7 +93,7 @@ public class User extends BaseEntity {
         this.nickname = nickname;
     }
 
-    public void applyQuizReward(Integer dotoriEarned, Integer xpEarned, Integer levelAfter) {
+    public void applyQuizReward(int dotoriEarned, int xpEarned, int levelAfter) {
         this.dotoriBalance += dotoriEarned;
         this.xpTotal += xpEarned;
         this.currentLevel = levelAfter;

--- a/src/main/java/com/f1/quiket/domain/user/entity/type/UserLevel.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/type/UserLevel.java
@@ -5,7 +5,10 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * 사용자 레벨 명칭
+ * 명세 GAMIF-002 — 사용자 레벨별 다람쥐 명칭.
+ *
+ * <p>Lv.1~Lv.10 매핑은 캐릭터 성장 정책의 단일 정답 소스로, 레벨 구간 XP는
+ * {@link com.f1.quiket.domain.gamification.service.GamificationLevelCalculator}에 정의되어 있다.</p>
  */
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/com/f1/quiket/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/f1/quiket/domain/user/repository/UserRepository.java
@@ -21,5 +21,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndDeletedAtIsNull(String email);
 
+    Optional<User> findByIdAndDeletedAtIsNull(Long id);
+
     Optional<User> findByPublicIdAndDeletedAtIsNull(String publicId);
 }

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     QUIZ_GENERATION_IN_PROGRESS(409, "QUIZ_GENERATION_IN_PROGRESS", "이미 생성 중인 퀴즈가 있습니다."),
     QUIZ_SESSION_NOT_FOUND(404, "QUIZ_SESSION_NOT_FOUND", "퀴즈 세션을 찾을 수 없습니다."),
     QUIZ_SESSION_NOT_COMPLETED(409, "QUIZ_SESSION_NOT_COMPLETED", "아직 생성 완료 전인 퀴즈입니다."),
+    QUIZ_PLAY_SESSION_NOT_FOUND(404, "QUIZ_PLAY_SESSION_NOT_FOUND", "퀴즈 풀이 세션을 찾을 수 없습니다."),
 
     // MyPage Errors
     MY_EMAIL_CHANGE_TOO_FREQUENT(429, "MY_EMAIL_CHANGE_TOO_FREQUENT", "이메일 변경은 하루에 1회만 가능합니다."),

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
     QUIZ_SESSION_NOT_FOUND(404, "QUIZ_SESSION_NOT_FOUND", "퀴즈 세션을 찾을 수 없습니다."),
     QUIZ_SESSION_NOT_COMPLETED(409, "QUIZ_SESSION_NOT_COMPLETED", "아직 생성 완료 전인 퀴즈입니다."),
     QUIZ_PLAY_SESSION_NOT_FOUND(404, "QUIZ_PLAY_SESSION_NOT_FOUND", "퀴즈 풀이 세션을 찾을 수 없습니다."),
+    QUIZ_RESULT_NOT_FOUND(404, "QUIZ_RESULT_NOT_FOUND", "퀴즈 결과를 찾을 수 없습니다."),
 
     // MyPage Errors
     MY_EMAIL_CHANGE_TOO_FREQUENT(429, "MY_EMAIL_CHANGE_TOO_FREQUENT", "이메일 변경은 하루에 1회만 가능합니다."),

--- a/src/main/java/com/f1/quiket/infra/aoai/client/AzureOpenAiQuizClient.java
+++ b/src/main/java/com/f1/quiket/infra/aoai/client/AzureOpenAiQuizClient.java
@@ -1,0 +1,158 @@
+package com.f1.quiket.infra.aoai.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationPrompt;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationResponse;
+import com.f1.quiket.domain.quiz.service.QuizAiClient;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.infra.aoai.config.AzureOpenAiProperties;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class AzureOpenAiQuizClient implements QuizAiClient {
+
+    private static final String API_KEY_HEADER = "api-key";
+    private static final String RESPONSE_FORMAT_NAME = "quiz_generation_response";
+
+    private final RestClient azureOpenAiRestClient;
+    private final AzureOpenAiProperties properties;
+    private final ObjectMapper objectMapper;
+
+    public AzureOpenAiQuizClient(
+            @Qualifier("azureOpenAiRestClient") RestClient azureOpenAiRestClient,
+            AzureOpenAiProperties properties
+    ) {
+        this.azureOpenAiRestClient = azureOpenAiRestClient;
+        this.properties = properties;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public QuizAiGenerationResponse generate(QuizAiGenerationPrompt prompt) {
+        validateConfigured();
+        try {
+            String responseBody = azureOpenAiRestClient.post()
+                    .uri(chatCompletionsUri())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .header(API_KEY_HEADER, properties.getApiKey())
+                    .body(requestBody(prompt))
+                    .retrieve()
+                    .body(String.class);
+            return parseResponse(responseBody);
+        } catch (CustomException e) {
+            throw e;
+        } catch (RestClientException | JsonProcessingException e) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AOAI 퀴즈 생성 호출에 실패했습니다.", e);
+        }
+    }
+
+    private void validateConfigured() {
+        if (!properties.isConfigured()) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AOAI 설정값이 준비되지 않았습니다.");
+        }
+    }
+
+    private String chatCompletionsUri() {
+        String endpoint = properties.getEndpoint().replaceAll("/+$", "");
+        return UriComponentsBuilder.fromUriString(endpoint)
+                .pathSegment("openai", "deployments", properties.getDeploymentName(), "chat", "completions")
+                .queryParam("api-version", properties.getApiVersion())
+                .build()
+                .toUriString();
+    }
+
+    private Map<String, Object> requestBody(QuizAiGenerationPrompt prompt) {
+        return Map.of(
+                "messages", List.of(
+                        Map.of("role", "system", "content", prompt.systemMessage()),
+                        Map.of("role", "user", "content", prompt.userMessage())
+                ),
+                "temperature", properties.getTemperature(),
+                "max_tokens", properties.getMaxOutputTokens(),
+                "response_format", responseFormat()
+        );
+    }
+
+    private Map<String, Object> responseFormat() {
+        return Map.of(
+                "type", "json_schema",
+                "json_schema", Map.of(
+                        "name", RESPONSE_FORMAT_NAME,
+                        "strict", true,
+                        "schema", responseSchema()
+                )
+        );
+    }
+
+    private Map<String, Object> responseSchema() {
+        Map<String, Object> optionSchema = new LinkedHashMap<>();
+        optionSchema.put("type", "object");
+        optionSchema.put("additionalProperties", false);
+        optionSchema.put("required", List.of("optionNumber", "content"));
+        optionSchema.put("properties", Map.of(
+                "optionNumber", Map.of("type", "integer", "minimum", 1, "maximum", 5),
+                "content", Map.of("type", "string", "minLength", 1)
+        ));
+
+        Map<String, Object> questionSchema = new LinkedHashMap<>();
+        questionSchema.put("type", "object");
+        questionSchema.put("additionalProperties", false);
+        questionSchema.put("required", List.of(
+                "partId",
+                "questionType",
+                "difficulty",
+                "summary",
+                "body",
+                "options",
+                "answerValue",
+                "correctExplanation",
+                "incorrectExplanation"
+        ));
+        questionSchema.put("properties", Map.of(
+                "partId", Map.of("type", "string", "minLength", 1),
+                "questionType", Map.of("type", "string", "enum", List.of("multiple_choice", "ox")),
+                "difficulty", Map.of("type", "string", "enum", List.of("easy", "medium", "hard")),
+                "summary", Map.of("type", "string", "minLength", 8, "maxLength", 20),
+                "body", Map.of("type", "string", "minLength", 1),
+                "options", Map.of("type", "array", "items", optionSchema),
+                "answerValue", Map.of("type", "string", "minLength", 1, "maxLength", 10),
+                "correctExplanation", Map.of("type", "string", "minLength", 5),
+                "incorrectExplanation", Map.of("type", "string", "minLength", 5)
+        ));
+
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+        schema.put("additionalProperties", false);
+        schema.put("required", List.of("questions"));
+        schema.put("properties", Map.of(
+                "questions", Map.of(
+                        "type", "array",
+                        "minItems", 1,
+                        "maxItems", 100,
+                        "items", questionSchema
+                )
+        ));
+        return schema;
+    }
+
+    private QuizAiGenerationResponse parseResponse(String responseBody) throws JsonProcessingException {
+        JsonNode rootNode = objectMapper.readTree(responseBody);
+        JsonNode contentNode = rootNode.path("choices").path(0).path("message").path("content");
+        if (contentNode.isMissingNode() || contentNode.isNull()) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AOAI 퀴즈 생성 응답이 비어 있습니다.");
+        }
+        return objectMapper.readValue(contentNode.asText(), QuizAiGenerationResponse.class);
+    }
+}

--- a/src/main/java/com/f1/quiket/infra/aoai/config/AzureOpenAiConfig.java
+++ b/src/main/java/com/f1/quiket/infra/aoai/config/AzureOpenAiConfig.java
@@ -1,0 +1,16 @@
+package com.f1.quiket.infra.aoai.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(AzureOpenAiProperties.class)
+public class AzureOpenAiConfig {
+
+    @Bean
+    public RestClient azureOpenAiRestClient() {
+        return RestClient.builder().build();
+    }
+}

--- a/src/main/java/com/f1/quiket/infra/aoai/config/AzureOpenAiConfig.java
+++ b/src/main/java/com/f1/quiket/infra/aoai/config/AzureOpenAiConfig.java
@@ -1,16 +1,32 @@
 package com.f1.quiket.infra.aoai.config;
 
+import java.net.http.HttpClient;
+import java.time.Duration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 @Configuration
 @EnableConfigurationProperties(AzureOpenAiProperties.class)
 public class AzureOpenAiConfig {
 
+    /**
+     * AOAI 호출 전용 RestClient
+     *
+     * - connect/read 타임아웃 명시적 설정 — 응답 지연 시 EC2 스레드 hang 방지
+     * - 타임아웃 값은 {@link AzureOpenAiProperties}에서 override 가능
+     */
     @Bean
-    public RestClient azureOpenAiRestClient() {
-        return RestClient.builder().build();
+    public RestClient azureOpenAiRestClient(AzureOpenAiProperties properties) {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(properties.getConnectTimeoutSeconds()))
+                .build();
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(Duration.ofSeconds(properties.getReadTimeoutSeconds()));
+        return RestClient.builder()
+                .requestFactory(requestFactory)
+                .build();
     }
 }

--- a/src/main/java/com/f1/quiket/infra/aoai/config/AzureOpenAiProperties.java
+++ b/src/main/java/com/f1/quiket/infra/aoai/config/AzureOpenAiProperties.java
@@ -1,0 +1,26 @@
+package com.f1.quiket.infra.aoai.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "azure.openai")
+public class AzureOpenAiProperties {
+
+    private String endpoint;
+    private String apiKey;
+    private String deploymentName;
+    private String apiVersion = "2024-10-21";
+    private Integer maxOutputTokens = 4096;
+    private Double temperature = 0.2;
+
+    public boolean isConfigured() {
+        return StringUtils.hasText(endpoint)
+                && StringUtils.hasText(apiKey)
+                && StringUtils.hasText(deploymentName)
+                && StringUtils.hasText(apiVersion);
+    }
+}

--- a/src/main/java/com/f1/quiket/infra/aoai/config/AzureOpenAiProperties.java
+++ b/src/main/java/com/f1/quiket/infra/aoai/config/AzureOpenAiProperties.java
@@ -16,6 +16,8 @@ public class AzureOpenAiProperties {
     private String apiVersion = "2024-10-21";
     private Integer maxOutputTokens = 4096;
     private Double temperature = 0.2;
+    private Integer connectTimeoutSeconds = 10;
+    private Integer readTimeoutSeconds = 120;
 
     public boolean isConfigured() {
         return StringUtils.hasText(endpoint)

--- a/src/main/java/com/f1/quiket/support/quiz/QuizGenerationWorker.java
+++ b/src/main/java/com/f1/quiket/support/quiz/QuizGenerationWorker.java
@@ -8,6 +8,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+/**
+ * Redis Stream에서 퀴즈 생성 작업을 poll하여 처리하는 단일 워커.
+ *
+ * <p>{@code @Scheduled} 기본 단일 스레드라 한 인스턴스 내에서 동시 실행 없음.
+ * 다중 인스턴스 운영은 {@link com.f1.quiket.domain.quiz.service.RedisQuizGenerationQueue}의
+ * 단일 워커 가정과 충돌하므로 Consumer Group 도입 전까지 금지.</p>
+ */
 @Component
 @RequiredArgsConstructor
 @ConditionalOnProperty(name = "quiket.quiz.generation.worker.enabled", havingValue = "true")
@@ -16,12 +23,18 @@ public class QuizGenerationWorker {
     private final QuizGenerationQueue quizGenerationQueue;
     private final QuizGenerationJobProcessor quizGenerationJobProcessor;
 
+    /**
+     * 큐에서 1건 poll하여 처리하고 성공/실패 무관 ack한다.
+     */
     @Scheduled(fixedDelayString = "${quiket.quiz.generation.worker.fixed-delay-ms:1000}")
-    public void consume() {
+    public void pollAndProcess() {
         quizGenerationQueue.poll()
                 .ifPresent(this::processRecord);
     }
 
+    /**
+     * timeout_at 초과한 in_progress 작업을 timeout 상태로 정리한다.
+     */
     @Scheduled(fixedDelayString = "${quiket.quiz.generation.worker.timeout-sweep-fixed-delay-ms:60000}")
     public void sweepTimeouts() {
         quizGenerationJobProcessor.markTimedOutJobs();

--- a/src/main/java/com/f1/quiket/support/quiz/QuizGenerationWorker.java
+++ b/src/main/java/com/f1/quiket/support/quiz/QuizGenerationWorker.java
@@ -1,0 +1,36 @@
+package com.f1.quiket.support.quiz;
+
+import com.f1.quiket.domain.quiz.service.QuizGenerationJobProcessor;
+import com.f1.quiket.domain.quiz.service.QuizGenerationQueue;
+import com.f1.quiket.domain.quiz.service.QuizGenerationQueueRecord;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "quiket.quiz.generation.worker.enabled", havingValue = "true")
+public class QuizGenerationWorker {
+
+    private final QuizGenerationQueue quizGenerationQueue;
+    private final QuizGenerationJobProcessor quizGenerationJobProcessor;
+
+    @Scheduled(fixedDelayString = "${quiket.quiz.generation.worker.fixed-delay-ms:1000}")
+    public void consume() {
+        quizGenerationQueue.poll()
+                .ifPresent(this::processRecord);
+    }
+
+    @Scheduled(fixedDelayString = "${quiket.quiz.generation.worker.timeout-sweep-fixed-delay-ms:60000}")
+    public void sweepTimeouts() {
+        quizGenerationJobProcessor.markTimedOutJobs();
+    }
+
+    private void processRecord(QuizGenerationQueueRecord record) {
+        boolean processed = quizGenerationJobProcessor.process(record.message());
+        if (processed) {
+            quizGenerationQueue.acknowledge(record.messageId());
+        }
+    }
+}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -54,6 +54,15 @@ aws:
     # SES 발신자 이메일 설정값
     from-email: ${AWS_SES_FROM_EMAIL:ja2hoon97@gmail.com}
 
+azure:
+  openai:
+    endpoint: ${AZURE_OPENAI_ENDPOINT:}
+    api-key: ${AZURE_OPENAI_API_KEY:}
+    deployment-name: ${AZURE_OPENAI_DEPLOYMENT_NAME:}
+    api-version: ${AZURE_OPENAI_API_VERSION:2024-10-21}
+    max-output-tokens: ${AZURE_OPENAI_MAX_OUTPUT_TOKENS:4096}
+    temperature: ${AZURE_OPENAI_TEMPERATURE:0.2}
+
 quiket:
   jwt:
     secret: ${QUIKET_JWT_SECRET}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -69,3 +69,9 @@ quiket:
   jwt:
     secret: ${QUIKET_JWT_SECRET}
     enabled: false  # Swagger UI 비활성화
+  quiz:
+    generation:
+      worker:
+        enabled: ${QUIKET_QUIZ_GENERATION_WORKER_ENABLED:true}
+        fixed-delay-ms: ${QUIKET_QUIZ_GENERATION_WORKER_FIXED_DELAY_MS:1000}
+        timeout-sweep-fixed-delay-ms: ${QUIKET_QUIZ_GENERATION_TIMEOUT_SWEEP_FIXED_DELAY_MS:60000}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -62,6 +62,8 @@ azure:
     api-version: ${AZURE_OPENAI_API_VERSION:2024-10-21}
     max-output-tokens: ${AZURE_OPENAI_MAX_OUTPUT_TOKENS:4096}
     temperature: ${AZURE_OPENAI_TEMPERATURE:0.2}
+    connect-timeout-seconds: ${AZURE_OPENAI_CONNECT_TIMEOUT_SECONDS:10}
+    read-timeout-seconds: ${AZURE_OPENAI_READ_TIMEOUT_SECONDS:120}
 
 quiket:
   jwt:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,6 +44,12 @@ quiket:
     secret: ${QUIKET_JWT_SECRET:local-dev-jwt-secret-for-quiket-f1-authentication}
     access-token-expires-in-seconds: 1800
     refresh-token-expires-in-seconds: 2592000
+  quiz:
+    generation:
+      worker:
+        enabled: ${QUIKET_QUIZ_GENERATION_WORKER_ENABLED:false}
+        fixed-delay-ms: ${QUIKET_QUIZ_GENERATION_WORKER_FIXED_DELAY_MS:1000}
+        timeout-sweep-fixed-delay-ms: ${QUIKET_QUIZ_GENERATION_TIMEOUT_SWEEP_FIXED_DELAY_MS:60000}
 
 kakao:
   oauth:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -48,3 +48,12 @@ quiket:
 kakao:
   oauth:
     user-info-uri: https://kapi.kakao.com/v2/user/me
+
+azure:
+  openai:
+    endpoint: ${AZURE_OPENAI_ENDPOINT:}
+    api-key: ${AZURE_OPENAI_API_KEY:}
+    deployment-name: ${AZURE_OPENAI_DEPLOYMENT_NAME:}
+    api-version: ${AZURE_OPENAI_API_VERSION:2024-10-21}
+    max-output-tokens: ${AZURE_OPENAI_MAX_OUTPUT_TOKENS:4096}
+    temperature: ${AZURE_OPENAI_TEMPERATURE:0.2}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,3 +57,5 @@ azure:
     api-version: ${AZURE_OPENAI_API_VERSION:2024-10-21}
     max-output-tokens: ${AZURE_OPENAI_MAX_OUTPUT_TOKENS:4096}
     temperature: ${AZURE_OPENAI_TEMPERATURE:0.2}
+    connect-timeout-seconds: ${AZURE_OPENAI_CONNECT_TIMEOUT_SECONDS:10}
+    read-timeout-seconds: ${AZURE_OPENAI_READ_TIMEOUT_SECONDS:120}

--- a/src/main/resources/db/migration/V10__create_quiz_play_sessions.sql
+++ b/src/main/resources/db/migration/V10__create_quiz_play_sessions.sql
@@ -1,0 +1,39 @@
+CREATE TABLE quiz_play_sessions (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    client_session_id VARCHAR(36) NOT NULL COMMENT '클라이언트 발급 풀이 세션 ID',
+    quiz_session_id BIGINT NOT NULL COMMENT '퀴즈 세션 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    subject_id BIGINT NOT NULL COMMENT '과목 ID',
+    play_type VARCHAR(20) NOT NULL DEFAULT 'first' COMMENT '풀이 유형',
+    parent_play_session_id BIGINT NULL COMMENT '부모 풀이 세션 ID',
+    parent_quiz_session_id BIGINT NULL COMMENT '부모 퀴즈 세션 ID',
+    generation TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '오답 복습 세대',
+    is_question_shuffled TINYINT(1) NOT NULL DEFAULT 0 COMMENT '문제 순서 셔플 여부',
+    is_option_shuffled TINYINT(1) NOT NULL DEFAULT 1 COMMENT '선택지 순서 셔플 여부',
+    shuffle_seed VARCHAR(100) NULL COMMENT '셔플 시드값',
+    status VARCHAR(20) NOT NULL DEFAULT 'in_progress' COMMENT '풀이 상태',
+    last_question_index TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '마지막 문항 인덱스',
+    elapsed_ms INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '누적 풀이 시간',
+    submitted_at DATETIME(3) NULL COMMENT '결과 제출 시각',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_quiz_play_sessions_client_session_id (client_session_id),
+    KEY idx_quiz_play_sessions_quiz_session_id (quiz_session_id),
+    KEY idx_quiz_play_sessions_user_id_status (user_id, status),
+    KEY idx_quiz_play_sessions_user_id_created_at (user_id, created_at),
+    KEY idx_quiz_play_sessions_parent_play_session_id (parent_play_session_id),
+    KEY idx_quiz_play_sessions_subject_id_created_at (subject_id, created_at),
+
+    CONSTRAINT fk_quiz_play_sessions_quiz_session_id
+        FOREIGN KEY (quiz_session_id) REFERENCES quiz_sessions(id),
+    CONSTRAINT chk_quiz_play_sessions_play_type
+        CHECK (play_type IN ('first', 'retry_all', 'retry_wrong')),
+    CONSTRAINT chk_quiz_play_sessions_status
+        CHECK (status IN ('in_progress', 'submitted', 'abandoned')),
+    CONSTRAINT chk_quiz_play_sessions_question_shuffled
+        CHECK (is_question_shuffled IN (0, 1)),
+    CONSTRAINT chk_quiz_play_sessions_option_shuffled
+        CHECK (is_option_shuffled IN (0, 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='퀴즈 풀이 세션';

--- a/src/main/resources/db/migration/V11__create_quiz_play_answers_and_results.sql
+++ b/src/main/resources/db/migration/V11__create_quiz_play_answers_and_results.sql
@@ -1,0 +1,56 @@
+CREATE TABLE IF NOT EXISTS quiz_play_answers (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    play_session_id BIGINT NOT NULL COMMENT '풀이 세션 ID',
+    question_id BIGINT NOT NULL COMMENT '문항 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    selected_option_id BIGINT NULL COMMENT '선택한 선택지 ID',
+    selected_value VARCHAR(10) NULL COMMENT '선택한 값',
+    is_correct_client TINYINT(1) NULL COMMENT '클라이언트 채점 결과',
+    is_correct_server TINYINT(1) NULL COMMENT '서버 재채점 결과',
+    is_skipped TINYINT(1) NOT NULL DEFAULT 0 COMMENT '미선택 제출 여부',
+    answer_elapsed_ms INT UNSIGNED NULL COMMENT '문항 응답 소요 시간',
+    is_marked TINYINT(1) NOT NULL DEFAULT 0 COMMENT '어려움 마킹 여부',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_quiz_play_answers_session_question (play_session_id, question_id),
+    KEY idx_quiz_play_answers_question_id (question_id),
+    KEY idx_quiz_play_answers_user_id (user_id),
+
+    CONSTRAINT chk_quiz_play_answers_is_correct_client
+        CHECK (is_correct_client IN (0, 1) OR is_correct_client IS NULL),
+    CONSTRAINT chk_quiz_play_answers_is_correct_server
+        CHECK (is_correct_server IN (0, 1) OR is_correct_server IS NULL)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='문항별 답안 및 채점 결과';
+
+CREATE TABLE IF NOT EXISTS quiz_results (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    public_id CHAR(36) NOT NULL COMMENT '외부 노출용 UUID v7',
+    play_session_id BIGINT NOT NULL COMMENT '풀이 세션 ID',
+    quiz_session_id BIGINT NOT NULL COMMENT '퀴즈 세션 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    subject_id BIGINT NOT NULL COMMENT '과목 ID',
+    total_count TINYINT UNSIGNED NOT NULL COMMENT '총 문항 수',
+    correct_count TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '정답 수',
+    wrong_count TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '오답 수',
+    skip_count TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '미선택 수',
+    accuracy_pct TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '정답률',
+    elapsed_ms INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '누적 풀이 시간',
+    dotori_earned SMALLINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '획득 도토리',
+    xp_earned SMALLINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '획득 XP',
+    is_leveled_up TINYINT(1) NOT NULL DEFAULT 0 COMMENT '레벨업 여부',
+    new_level TINYINT UNSIGNED NULL COMMENT '새 레벨',
+    is_score_matched TINYINT(1) NOT NULL DEFAULT 1 COMMENT '클라이언트-서버 채점 일치 여부',
+    is_abuse_flagged TINYINT(1) NOT NULL DEFAULT 0 COMMENT '어뷰징 의심 여부',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '결과 저장 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_quiz_results_public_id (public_id),
+    UNIQUE KEY uq_quiz_results_play_session_id (play_session_id),
+    KEY idx_quiz_results_user_id_created_at (user_id, created_at),
+    KEY idx_quiz_results_quiz_session_id (quiz_session_id),
+    KEY idx_quiz_results_subject_id_created_at (subject_id, created_at),
+    KEY idx_quiz_results_is_abuse_flagged (is_abuse_flagged)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='퀴즈 풀이 결과 요약';

--- a/src/main/resources/db/migration/V12__create_gamification_logs.sql
+++ b/src/main/resources/db/migration/V12__create_gamification_logs.sql
@@ -1,0 +1,55 @@
+CREATE TABLE IF NOT EXISTS user_xp_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    play_session_id BIGINT NULL COMMENT '풀이 세션 ID',
+    lecture_upload_id BIGINT NULL COMMENT '업로드 ID',
+    xp_type VARCHAR(30) NOT NULL COMMENT 'XP 유형',
+    base_xp SMALLINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '기본 XP',
+    streak_multiplier DECIMAL(3,1) NOT NULL DEFAULT 1.0 COMMENT '연속 학습 배수',
+    earned_xp SMALLINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '실제 적립 XP',
+    xp_before INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '적립 전 누적 XP',
+    xp_after INT UNSIGNED NOT NULL DEFAULT 0 COMMENT '적립 후 누적 XP',
+    level_before TINYINT UNSIGNED NOT NULL DEFAULT 1 COMMENT '적립 전 레벨',
+    level_after TINYINT UNSIGNED NOT NULL DEFAULT 1 COMMENT '적립 후 레벨',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '적립 시각',
+
+    PRIMARY KEY (id),
+    KEY idx_user_xp_logs_user_id_created_at (user_id, created_at),
+    KEY idx_user_xp_logs_play_session_id (play_session_id),
+
+    CONSTRAINT chk_user_xp_logs_xp_type
+        CHECK (xp_type IN ('quiz_correct', 'quiz_retry', 'upload', 'streak_bonus'))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='XP 적립 이력';
+
+CREATE TABLE IF NOT EXISTS user_dotori_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    play_session_id BIGINT NULL COMMENT '풀이 세션 ID',
+    change_type VARCHAR(20) NOT NULL COMMENT '변동 유형',
+    amount SMALLINT NOT NULL COMMENT '변동량',
+    balance_before INT NOT NULL COMMENT '변동 전 잔액',
+    balance_after INT NOT NULL COMMENT '변동 후 잔액',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '변동 시각',
+
+    PRIMARY KEY (id),
+    KEY idx_user_dotori_logs_user_id_created_at (user_id, created_at),
+    KEY idx_user_dotori_logs_play_session_id (play_session_id),
+
+    CONSTRAINT chk_user_dotori_logs_change_type
+        CHECK (change_type IN ('earn_quiz', 'spend_item')),
+    CONSTRAINT chk_user_dotori_logs_balance_after
+        CHECK (balance_after >= 0)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='도토리 적립/차감 이력';
+
+CREATE TABLE IF NOT EXISTS user_streak_logs (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    study_date DATE NOT NULL COMMENT '학습 날짜',
+    streak_count SMALLINT UNSIGNED NOT NULL DEFAULT 1 COMMENT '연속 학습 일수',
+    multiplier DECIMAL(3,1) NOT NULL DEFAULT 1.0 COMMENT '적용 배수',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '기록 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_user_streak_logs_user_study_date (user_id, study_date),
+    KEY idx_user_streak_logs_user_id_study_date (user_id, study_date)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='연속 학습 이력';

--- a/src/main/resources/db/migration/V13__add_deleted_at_to_subject_detail_tables.sql
+++ b/src/main/resources/db/migration/V13__add_deleted_at_to_subject_detail_tables.sql
@@ -1,0 +1,10 @@
+-- subject 상세 테이블 soft delete 컬럼 정합성 보강
+ALTER TABLE subject_exam_details
+    ADD COLUMN deleted_at DATETIME(3) NULL COMMENT '삭제 시각' AFTER updated_at;
+
+ALTER TABLE subject_review_details
+    ADD COLUMN deleted_at DATETIME(3) NULL COMMENT '삭제 시각' AFTER updated_at;
+
+ALTER TABLE subject_other_details
+    ADD COLUMN deleted_at DATETIME(3) NULL COMMENT '삭제 시각' AFTER updated_at;
+

--- a/src/main/resources/db/migration/V9__create_quiz_generation_jobs.sql
+++ b/src/main/resources/db/migration/V9__create_quiz_generation_jobs.sql
@@ -1,0 +1,33 @@
+CREATE TABLE quiz_generation_jobs (
+    id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK',
+    quiz_session_id BIGINT NOT NULL COMMENT '퀴즈 세션 ID',
+    user_id BIGINT NOT NULL COMMENT '사용자 ID',
+    status VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT '작업 상태',
+    progress_pct TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '진행률',
+    estimated_seconds SMALLINT NULL COMMENT '예상 소요 시간',
+    estimated_finish_at DATETIME(3) NULL COMMENT '예상 완료 시각',
+    started_at DATETIME(3) NULL COMMENT '처리 시작 시각',
+    completed_at DATETIME(3) NULL COMMENT '완료 시각',
+    timeout_at DATETIME(3) NULL COMMENT '타임아웃 기준 시각',
+    retry_count TINYINT UNSIGNED NOT NULL DEFAULT 0 COMMENT '재시도 횟수',
+    is_retryable TINYINT(1) NOT NULL DEFAULT 1 COMMENT '재시도 가능 여부',
+    fail_code VARCHAR(50) NULL COMMENT '실패 코드',
+    fail_reason VARCHAR(500) NULL COMMENT '실패 상세 사유',
+    mq_message_id VARCHAR(100) NULL COMMENT 'Redis Stream message-id',
+    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '생성 시각',
+    updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_quiz_generation_jobs_session_id (quiz_session_id),
+    KEY idx_quiz_generation_jobs_user_id_status (user_id, status),
+    KEY idx_quiz_generation_jobs_timeout_at (timeout_at),
+
+    CONSTRAINT fk_quiz_generation_jobs_session_id
+        FOREIGN KEY (quiz_session_id) REFERENCES quiz_sessions(id),
+    CONSTRAINT chk_quiz_generation_jobs_status
+        CHECK (status IN ('pending', 'in_progress', 'completed', 'failed', 'timeout')),
+    CONSTRAINT chk_quiz_generation_jobs_progress_pct
+        CHECK (progress_pct BETWEEN 0 AND 100),
+    CONSTRAINT chk_quiz_generation_jobs_retryable
+        CHECK (is_retryable IN (0, 1))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='퀴즈 AI 생성 작업 이력';

--- a/src/test/java/com/f1/quiket/domain/chapter/controller/ChapterControllerTest.java
+++ b/src/test/java/com/f1/quiket/domain/chapter/controller/ChapterControllerTest.java
@@ -1,0 +1,61 @@
+package com.f1.quiket.domain.chapter.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.chapter.dto.ChapterNameUpdateRequest;
+import com.f1.quiket.domain.chapter.dto.ChapterResponse;
+import com.f1.quiket.domain.chapter.service.ChapterService;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ChapterControllerTest {
+
+    private ChapterService chapterService;
+    private ChapterController chapterController;
+    private UserPrincipal principal;
+
+    @BeforeEach
+    void setUp() {
+        chapterService = mock(ChapterService.class);
+        chapterController = new ChapterController(chapterService);
+        principal = principal("user-public-id");
+    }
+
+    @Test
+    void updateChapterName_returns_ok_response() {
+        ChapterNameUpdateRequest request = new ChapterNameUpdateRequest();
+        ReflectionTestUtils.setField(request, "name", "트랜잭션");
+
+        ChapterResponse response = ChapterResponse.builder()
+                .id("chapter-public-id")
+                .subjectId("subject-public-id")
+                .name("트랜잭션")
+                .displayOrder(1)
+                .build();
+        when(chapterService.updateChapterName(principal.getPublicId(), "chapter-public-id", "트랜잭션")).thenReturn(response);
+
+        ResponseEntity<ApiResponse<ChapterResponse>> result = chapterController.updateChapterName(principal, "chapter-public-id", request);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(chapterService).updateChapterName(principal.getPublicId(), "chapter-public-id", "트랜잭션");
+    }
+
+    private UserPrincipal principal(String userPublicId) {
+        User user = User.create(userPublicId, "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return UserPrincipal.from(user);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/chapter/service/ChapterServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/chapter/service/ChapterServiceTest.java
@@ -1,0 +1,121 @@
+package com.f1.quiket.domain.chapter.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.chapter.dto.ChapterResponse;
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ChapterServiceTest {
+
+    private UserRepository userRepository;
+    private ChapterRepository chapterRepository;
+    private SubjectRepository subjectRepository;
+    private ChapterService chapterService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        chapterRepository = mock(ChapterRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        chapterService = new ChapterService(userRepository, chapterRepository, subjectRepository);
+    }
+
+    @Test
+    void updateChapterName_returns_updated_response() {
+        User user = user(1L, "user-public-id");
+        Chapter chapter = chapter(10L, "chapter-public-id", 100L, 1L, "기존 챕터", 1);
+        Subject subject = subject(100L, "subject-public-id", 1L, "데이터베이스");
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(chapterRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(chapter.getPublicId(), user.getId())).thenReturn(Optional.of(chapter));
+        when(subjectRepository.findById(chapter.getSubjectId())).thenReturn(Optional.of(subject));
+
+        ChapterResponse response = chapterService.updateChapterName(user.getPublicId(), chapter.getPublicId(), "트랜잭션");
+
+        assertThat(response.getId()).isEqualTo(chapter.getPublicId());
+        assertThat(response.getSubjectId()).isEqualTo(subject.getPublicId());
+        assertThat(response.getName()).isEqualTo("트랜잭션");
+        assertThat(chapter.getName()).isEqualTo("트랜잭션");
+    }
+
+    @Test
+    void updateChapterName_throws_auth_user_not_found_when_user_missing() {
+        when(userRepository.findByPublicIdAndDeletedAtIsNull("missing-user")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chapterService.updateChapterName("missing-user", "chapter-public-id", "트랜잭션"))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
+    }
+
+    @Test
+    void updateChapterName_throws_not_found_when_chapter_missing() {
+        User user = user(1L, "user-public-id");
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(chapterRepository.findByPublicIdAndUserIdAndDeletedAtIsNull("missing-chapter", user.getId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chapterService.updateChapterName(user.getPublicId(), "missing-chapter", "트랜잭션"))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    @Test
+    void updateChapterName_throws_not_found_when_subject_missing() {
+        User user = user(1L, "user-public-id");
+        Chapter chapter = chapter(10L, "chapter-public-id", 100L, 1L, "기존 챕터", 1);
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(chapterRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(chapter.getPublicId(), user.getId())).thenReturn(Optional.of(chapter));
+        when(subjectRepository.findById(chapter.getSubjectId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> chapterService.updateChapterName(user.getPublicId(), chapter.getPublicId(), "트랜잭션"))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    private User user(Long id, String publicId) {
+        User user = User.create(publicId, "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Chapter chapter(Long id, String publicId, Long subjectId, Long userId, String name, Integer displayOrder) {
+        Chapter chapter = newEntity(Chapter.class);
+        ReflectionTestUtils.setField(chapter, "id", id);
+        ReflectionTestUtils.setField(chapter, "publicId", publicId);
+        ReflectionTestUtils.setField(chapter, "subjectId", subjectId);
+        ReflectionTestUtils.setField(chapter, "userId", userId);
+        ReflectionTestUtils.setField(chapter, "name", name);
+        ReflectionTestUtils.setField(chapter, "displayOrder", displayOrder);
+        return chapter;
+    }
+
+    private Subject subject(Long id, String publicId, Long userId, String name) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculatorTest.java
+++ b/src/test/java/com/f1/quiket/domain/gamification/service/GamificationLevelCalculatorTest.java
@@ -1,0 +1,89 @@
+package com.f1.quiket.domain.gamification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * 명세 GAMIF-002 — 레벨 구간 경계값과 만렙 진입선이 정책과 일치하는지 단언한다.
+ */
+class GamificationLevelCalculatorTest {
+
+    @Test
+    void levelOf_maps_each_band_min_xp_to_expected_level() {
+        assertThat(GamificationLevelCalculator.levelOf(0)).isEqualTo(1);
+        assertThat(GamificationLevelCalculator.levelOf(99)).isEqualTo(1);
+        assertThat(GamificationLevelCalculator.levelOf(100)).isEqualTo(2);
+        assertThat(GamificationLevelCalculator.levelOf(349)).isEqualTo(2);
+        assertThat(GamificationLevelCalculator.levelOf(350)).isEqualTo(3);
+        assertThat(GamificationLevelCalculator.levelOf(849)).isEqualTo(3);
+        assertThat(GamificationLevelCalculator.levelOf(850)).isEqualTo(4);
+        assertThat(GamificationLevelCalculator.levelOf(1749)).isEqualTo(4);
+        assertThat(GamificationLevelCalculator.levelOf(1750)).isEqualTo(5);
+        assertThat(GamificationLevelCalculator.levelOf(3249)).isEqualTo(5);
+        assertThat(GamificationLevelCalculator.levelOf(3250)).isEqualTo(6);
+        assertThat(GamificationLevelCalculator.levelOf(5749)).isEqualTo(6);
+        assertThat(GamificationLevelCalculator.levelOf(5750)).isEqualTo(7);
+        assertThat(GamificationLevelCalculator.levelOf(9749)).isEqualTo(7);
+        assertThat(GamificationLevelCalculator.levelOf(9750)).isEqualTo(8);
+        assertThat(GamificationLevelCalculator.levelOf(16249)).isEqualTo(8);
+        assertThat(GamificationLevelCalculator.levelOf(16250)).isEqualTo(9);
+        assertThat(GamificationLevelCalculator.levelOf(26249)).isEqualTo(9);
+        assertThat(GamificationLevelCalculator.levelOf(26250)).isEqualTo(10);
+        assertThat(GamificationLevelCalculator.levelOf(99999)).isEqualTo(10);
+    }
+
+    @Test
+    void levelOf_normalizes_null_and_negative_xp_to_level_1() {
+        assertThat(GamificationLevelCalculator.levelOf(null)).isEqualTo(1);
+        assertThat(GamificationLevelCalculator.levelOf(-500)).isEqualTo(1);
+    }
+
+    @Test
+    void max_level_min_xp_matches_specification() {
+        // 명세 GAMIF-002 — Lv.10: 26,250 XP 이상 (만렙)
+        assertThat(GamificationLevelCalculator.MAX_LEVEL_MIN_XP).isEqualTo(26250);
+        assertThat(GamificationLevelCalculator.MAX_LEVEL).isEqualTo(10);
+    }
+
+    @Test
+    void current_level_min_xp_returns_band_start_for_each_level() {
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(1)).isZero();
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(2)).isEqualTo(100);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(3)).isEqualTo(350);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(4)).isEqualTo(850);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(5)).isEqualTo(1750);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(6)).isEqualTo(3250);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(7)).isEqualTo(5750);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(8)).isEqualTo(9750);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(9)).isEqualTo(16250);
+        assertThat(GamificationLevelCalculator.currentLevelMinXp(10)).isEqualTo(26250);
+    }
+
+    @Test
+    void next_level_returns_null_when_max_level() {
+        assertThat(GamificationLevelCalculator.nextLevel(10)).isNull();
+        assertThat(GamificationLevelCalculator.nextLevelRequiredXp(10)).isNull();
+    }
+
+    @Test
+    void next_level_required_xp_returns_next_band_start() {
+        assertThat(GamificationLevelCalculator.nextLevel(1)).isEqualTo(2);
+        assertThat(GamificationLevelCalculator.nextLevelRequiredXp(1)).isEqualTo(100);
+        assertThat(GamificationLevelCalculator.nextLevelRequiredXp(9)).isEqualTo(26250);
+    }
+
+    @Test
+    void progress_pct_clamps_to_0_and_100() {
+        // 경계 — 현재 레벨 시작값
+        assertThat(GamificationLevelCalculator.progressPct(0, 1)).isZero();
+        assertThat(GamificationLevelCalculator.progressPct(100, 2)).isZero();
+        // 다음 레벨 진입 직전(현재 레벨 마지막 1XP 전) → 99%
+        assertThat(GamificationLevelCalculator.progressPct(99, 1)).isEqualTo(99);
+        // 만렙은 항상 100
+        assertThat(GamificationLevelCalculator.progressPct(26250, 10)).isEqualTo(100);
+        assertThat(GamificationLevelCalculator.progressPct(99999, 10)).isEqualTo(100);
+        // 레벨/XP 불일치(데이터 손상) 시 음수 → 0으로 클램프
+        assertThat(GamificationLevelCalculator.progressPct(0, 3)).isZero();
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
@@ -1,0 +1,174 @@
+package com.f1.quiket.domain.gamification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.gamification.entity.UserDotoriLog;
+import com.f1.quiket.domain.gamification.entity.UserStreakLog;
+import com.f1.quiket.domain.gamification.entity.UserXpLog;
+import com.f1.quiket.domain.gamification.repository.UserDotoriLogRepository;
+import com.f1.quiket.domain.gamification.repository.UserStreakLogRepository;
+import com.f1.quiket.domain.gamification.repository.UserXpLogRepository;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.user.entity.User;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class GamificationRewardServiceTest {
+
+    private UserXpLogRepository userXpLogRepository;
+    private UserDotoriLogRepository userDotoriLogRepository;
+    private UserStreakLogRepository userStreakLogRepository;
+    private GamificationRewardService gamificationRewardService;
+
+    @BeforeEach
+    void setUp() {
+        userXpLogRepository = mock(UserXpLogRepository.class);
+        userDotoriLogRepository = mock(UserDotoriLogRepository.class);
+        userStreakLogRepository = mock(UserStreakLogRepository.class);
+        gamificationRewardService = new GamificationRewardService(
+                userXpLogRepository,
+                userDotoriLogRepository,
+                userStreakLogRepository
+        );
+    }
+
+    @Test
+    void applyQuizReward_rewards_dotori_and_xp_for_first_play() {
+        User user = user(1L, 10, 360, 3);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "medium");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        LocalDate today = today();
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today))
+                .thenReturn(Optional.empty());
+        when(userStreakLogRepository.findTopByUserIdAndStudyDateBeforeOrderByStudyDateDesc(user.getId(), today))
+                .thenReturn(Optional.empty());
+        when(userStreakLogRepository.save(any(UserStreakLog.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 2);
+
+        assertThat(result.dotoriEarned()).isEqualTo(2);
+        assertThat(result.xpEarned()).isEqualTo(8);
+        assertThat(result.leveledUp()).isFalse();
+        assertThat(result.currentDotoriBalance()).isEqualTo(12);
+        assertThat(result.currentXpTotal()).isEqualTo(368);
+        assertThat(user.getDotoriBalance()).isEqualTo(12);
+        assertThat(user.getXpTotal()).isEqualTo(368);
+        assertThat(user.getCurrentLevel()).isEqualTo(3);
+
+        ArgumentCaptor<UserDotoriLog> dotoriCaptor = ArgumentCaptor.forClass(UserDotoriLog.class);
+        verify(userDotoriLogRepository).save(dotoriCaptor.capture());
+        assertThat(dotoriCaptor.getValue().getAmount()).isEqualTo(2);
+        assertThat(dotoriCaptor.getValue().getBalanceBefore()).isEqualTo(10);
+        assertThat(dotoriCaptor.getValue().getBalanceAfter()).isEqualTo(12);
+
+        ArgumentCaptor<UserXpLog> xpCaptor = ArgumentCaptor.forClass(UserXpLog.class);
+        verify(userXpLogRepository).save(xpCaptor.capture());
+        assertThat(xpCaptor.getValue().getXpType()).isEqualTo("quiz_correct");
+        assertThat(xpCaptor.getValue().getBaseXp()).isEqualTo(8);
+        assertThat(xpCaptor.getValue().getStreakMultiplier()).isEqualByComparingTo(BigDecimal.valueOf(1.0));
+        assertThat(xpCaptor.getValue().getEarnedXp()).isEqualTo(8);
+        assertThat(xpCaptor.getValue().getXpBefore()).isEqualTo(360);
+        assertThat(xpCaptor.getValue().getXpAfter()).isEqualTo(368);
+    }
+
+    @Test
+    void applyQuizReward_updates_level_when_xp_crosses_threshold() {
+        User user = user(1L, 0, 98, 1);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "medium");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        UserStreakLog streak = UserStreakLog.create(user.getId(), today(), 1, BigDecimal.valueOf(1.0));
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today()))
+                .thenReturn(Optional.of(streak));
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 1);
+
+        assertThat(result.xpEarned()).isEqualTo(4);
+        assertThat(result.leveledUp()).isTrue();
+        assertThat(result.newLevel()).isEqualTo(2);
+        assertThat(user.getXpTotal()).isEqualTo(102);
+        assertThat(user.getCurrentLevel()).isEqualTo(2);
+    }
+
+    @Test
+    void applyQuizReward_applies_consecutive_streak_multiplier() {
+        User user = user(1L, 0, 0, 1);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "medium");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        LocalDate today = today();
+        UserStreakLog previous = UserStreakLog.create(user.getId(), today.minusDays(1), 2, BigDecimal.valueOf(1.1));
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today))
+                .thenReturn(Optional.empty());
+        when(userStreakLogRepository.findTopByUserIdAndStudyDateBeforeOrderByStudyDateDesc(user.getId(), today))
+                .thenReturn(Optional.of(previous));
+        when(userStreakLogRepository.save(any(UserStreakLog.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 2);
+
+        assertThat(result.xpEarned()).isEqualTo(9);
+
+        ArgumentCaptor<UserStreakLog> streakCaptor = ArgumentCaptor.forClass(UserStreakLog.class);
+        verify(userStreakLogRepository).save(streakCaptor.capture());
+        assertThat(streakCaptor.getValue().getStreakCount()).isEqualTo(3);
+        assertThat(streakCaptor.getValue().getMultiplier()).isEqualByComparingTo(BigDecimal.valueOf(1.2));
+    }
+
+    private LocalDate today() {
+        return LocalDate.now(ZoneId.of("Asia/Seoul"));
+    }
+
+    private User user(Long id, Integer dotoriBalance, Integer xpTotal, Integer currentLevel) {
+        User user = User.create("user-public-id", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", id);
+        ReflectionTestUtils.setField(user, "dotoriBalance", dotoriBalance);
+        ReflectionTestUtils.setField(user, "xpTotal", xpTotal);
+        ReflectionTestUtils.setField(user, "currentLevel", currentLevel);
+        return user;
+    }
+
+    private QuizSession quizSession(Long id, Long userId, Long subjectId, String difficulty) {
+        QuizSession quizSession = QuizSession.create(
+                "quiz-session-public-id",
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                2,
+                "one_by_one",
+                true,
+                "per_question",
+                60,
+                difficulty,
+                "completed",
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizPlaySession playSession(Long id, Long quizSessionId, Long userId, Long subjectId) {
+        QuizPlaySession playSession = QuizPlaySession.createFirst(
+                "client-session-id",
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
@@ -131,6 +131,8 @@ class GamificationRewardServiceTest {
     @Test
     void applyQuizReward_blocks_xp_after_max_level_reached() {
         // 명세 GAMIF-002 — 만렙(Lv.10) 도달 후 추가 풀이는 XP 누적 X.
+        // 단, 명세 예외 "만렙 도달 후 추가 풀이: 레벨업 모달 노출 X, 일반 도토리 모달만 노출"에 따라
+        // 도토리는 first 풀이라면 정상 적립되어야 한다 — XP만 cap 대상이고 도토리는 GAMIF-001 정책 그대로 동작.
         User user = user(1L, 0, GamificationLevelCalculator.MAX_LEVEL_MIN_XP, 10);
         QuizSession quizSession = quizSession(500L, user.getId(), 20L, "hard");
         QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
@@ -142,10 +144,49 @@ class GamificationRewardServiceTest {
 
         assertThat(result.xpEarned()).isZero();
         assertThat(result.leveledUp()).isFalse();
+        assertThat(result.newLevel()).isNull();
         assertThat(user.getXpTotal()).isEqualTo(GamificationLevelCalculator.MAX_LEVEL_MIN_XP);
         assertThat(user.getCurrentLevel()).isEqualTo(10);
 
-        // 적립값이 0이면 UserXpLog는 남기지 않는다 (saveRewardLogs 조건)
+        // 도토리는 first 풀이 정답 3개 → +3 정상 적립
+        assertThat(result.dotoriEarned()).isEqualTo(3);
+        assertThat(user.getDotoriBalance()).isEqualTo(3);
+        ArgumentCaptor<UserDotoriLog> dotoriCaptor = ArgumentCaptor.forClass(UserDotoriLog.class);
+        verify(userDotoriLogRepository).save(dotoriCaptor.capture());
+        assertThat(dotoriCaptor.getValue().getAmount()).isEqualTo(3);
+        assertThat(dotoriCaptor.getValue().getBalanceAfter()).isEqualTo(3);
+
+        // XP 적립값이 0이면 UserXpLog는 남기지 않는다 (saveRewardLogs 조건)
+        verify(userXpLogRepository, never()).save(any(UserXpLog.class));
+    }
+
+    @Test
+    void applyQuizReward_records_streak_but_no_logs_when_zero_correct() {
+        // 명세 GAMIF-001/002 — 정답이 0개라도 학습 행동(풀이 제출) 자체는 발생했으므로 streak는 기록한다.
+        // 다만 적립값이 0인 도토리/XP 로그는 saveRewardLogs 조건상 저장되지 않는다.
+        User user = user(1L, 0, 0, 1);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "medium");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        LocalDate today = today();
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today))
+                .thenReturn(Optional.empty());
+        when(userStreakLogRepository.findTopByUserIdAndStudyDateBeforeOrderByStudyDateDesc(user.getId(), today))
+                .thenReturn(Optional.empty());
+        when(userStreakLogRepository.save(any(UserStreakLog.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 0);
+
+        assertThat(result.dotoriEarned()).isZero();
+        assertThat(result.xpEarned()).isZero();
+        assertThat(result.leveledUp()).isFalse();
+        assertThat(result.newLevel()).isNull();
+        assertThat(user.getDotoriBalance()).isZero();
+        assertThat(user.getXpTotal()).isZero();
+        assertThat(user.getCurrentLevel()).isEqualTo(1);
+
+        verify(userStreakLogRepository).save(any(UserStreakLog.class));
+        verify(userDotoriLogRepository, never()).save(any(UserDotoriLog.class));
         verify(userXpLogRepository, never()).save(any(UserXpLog.class));
     }
 

--- a/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/gamification/service/GamificationRewardServiceTest.java
@@ -3,6 +3,7 @@ package com.f1.quiket.domain.gamification.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -102,6 +103,72 @@ class GamificationRewardServiceTest {
     }
 
     @Test
+    void applyQuizReward_caps_xp_to_max_level_when_user_approaches_max() {
+        // 명세 GAMIF-002 — 만렙 도달 후 추가 XP 누적 X. 진입선까지의 잔여 분만 적립.
+        User user = user(1L, 0, GamificationLevelCalculator.MAX_LEVEL_MIN_XP - 2, 9);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "hard");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        LocalDate today = today();
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today))
+                .thenReturn(Optional.of(UserStreakLog.create(user.getId(), today, 1, BigDecimal.valueOf(1.0))));
+
+        // first hard 정답 1개 → raw 5XP, 잔여 2XP만 적립되어야 함
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 1);
+
+        assertThat(result.xpEarned()).isEqualTo(2);
+        assertThat(user.getXpTotal()).isEqualTo(GamificationLevelCalculator.MAX_LEVEL_MIN_XP);
+        assertThat(user.getCurrentLevel()).isEqualTo(10);
+        assertThat(result.leveledUp()).isTrue();
+        assertThat(result.newLevel()).isEqualTo(10);
+
+        ArgumentCaptor<UserXpLog> xpCaptor = ArgumentCaptor.forClass(UserXpLog.class);
+        verify(userXpLogRepository).save(xpCaptor.capture());
+        // 로그 적립 값도 cap 후 값과 일치 (응답·로그·user.xpTotal 일관성)
+        assertThat(xpCaptor.getValue().getEarnedXp()).isEqualTo(2);
+        assertThat(xpCaptor.getValue().getXpAfter()).isEqualTo(GamificationLevelCalculator.MAX_LEVEL_MIN_XP);
+    }
+
+    @Test
+    void applyQuizReward_blocks_xp_after_max_level_reached() {
+        // 명세 GAMIF-002 — 만렙(Lv.10) 도달 후 추가 풀이는 XP 누적 X.
+        User user = user(1L, 0, GamificationLevelCalculator.MAX_LEVEL_MIN_XP, 10);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, "hard");
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        LocalDate today = today();
+        when(userStreakLogRepository.findByUserIdAndStudyDate(user.getId(), today))
+                .thenReturn(Optional.of(UserStreakLog.create(user.getId(), today, 1, BigDecimal.valueOf(1.0))));
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, 3);
+
+        assertThat(result.xpEarned()).isZero();
+        assertThat(result.leveledUp()).isFalse();
+        assertThat(user.getXpTotal()).isEqualTo(GamificationLevelCalculator.MAX_LEVEL_MIN_XP);
+        assertThat(user.getCurrentLevel()).isEqualTo(10);
+
+        // 적립값이 0이면 UserXpLog는 남기지 않는다 (saveRewardLogs 조건)
+        verify(userXpLogRepository, never()).save(any(UserXpLog.class));
+    }
+
+    @Test
+    void applyQuizReward_uses_first_play_xp_table_by_difficulty() {
+        // 명세 GAMIF-002 — 첫 풀이 정답 1문항당 easy 3 / medium 4 / hard 5 XP
+        assertThat(firstPlayXpForCorrect("easy", 2)).isEqualTo(6);
+        assertThat(firstPlayXpForCorrect("medium", 2)).isEqualTo(8);
+        assertThat(firstPlayXpForCorrect("hard", 2)).isEqualTo(10);
+    }
+
+    @Test
+    void applyQuizReward_uses_retry_xp_table_by_difficulty() {
+        // 명세 GAMIF-002 — 전체 다시풀기/오답 복습 정답 1문항당 easy 2 / medium 3 / hard 4 XP
+        assertThat(retryPlayXpForCorrect("retry_all", "easy", 2)).isEqualTo(4);
+        assertThat(retryPlayXpForCorrect("retry_all", "medium", 2)).isEqualTo(6);
+        assertThat(retryPlayXpForCorrect("retry_all", "hard", 2)).isEqualTo(8);
+        assertThat(retryPlayXpForCorrect("retry_wrong", "easy", 2)).isEqualTo(4);
+        assertThat(retryPlayXpForCorrect("retry_wrong", "medium", 2)).isEqualTo(6);
+        assertThat(retryPlayXpForCorrect("retry_wrong", "hard", 2)).isEqualTo(8);
+    }
+
+    @Test
     void applyQuizReward_applies_consecutive_streak_multiplier() {
         User user = user(1L, 0, 0, 1);
         QuizSession quizSession = quizSession(500L, user.getId(), 20L, "medium");
@@ -123,6 +190,64 @@ class GamificationRewardServiceTest {
         verify(userStreakLogRepository).save(streakCaptor.capture());
         assertThat(streakCaptor.getValue().getStreakCount()).isEqualTo(3);
         assertThat(streakCaptor.getValue().getMultiplier()).isEqualByComparingTo(BigDecimal.valueOf(1.2));
+    }
+
+    private int firstPlayXpForCorrect(String difficulty, int correctCount) {
+        User user = user(1L, 0, 0, 1);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, difficulty);
+        QuizPlaySession playSession = playSession(700L, quizSession.getId(), user.getId(), quizSession.getSubjectId());
+        stubTodayStreak(user.getId());
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, correctCount);
+        return result.xpEarned();
+    }
+
+    private int retryPlayXpForCorrect(String playType, String difficulty, int correctCount) {
+        User user = user(1L, 0, 0, 1);
+        QuizSession quizSession = quizSession(500L, user.getId(), 20L, difficulty);
+        QuizPlaySession playSession = retryPlaySession(700L, playType, quizSession);
+        stubTodayStreak(user.getId());
+
+        QuizRewardResult result = gamificationRewardService.applyQuizReward(user, playSession, quizSession, correctCount);
+        return result.xpEarned();
+    }
+
+    private void stubTodayStreak(Long userId) {
+        LocalDate today = today();
+        when(userStreakLogRepository.findByUserIdAndStudyDate(userId, today))
+                .thenReturn(Optional.of(UserStreakLog.create(userId, today, 1, BigDecimal.valueOf(1.0))));
+    }
+
+    private QuizPlaySession retryPlaySession(Long id, String playType, QuizSession quizSession) {
+        QuizPlaySession playSession;
+        if ("retry_all".equals(playType)) {
+            playSession = QuizPlaySession.createRetryAll(
+                    "client-session-" + id,
+                    quizSession.getId(),
+                    quizSession.getUserId(),
+                    quizSession.getSubjectId(),
+                    false,
+                    true,
+                    null
+            );
+        } else if ("retry_wrong".equals(playType)) {
+            playSession = QuizPlaySession.createRetryWrong(
+                    "client-session-" + id,
+                    quizSession.getId(),
+                    quizSession.getUserId(),
+                    quizSession.getSubjectId(),
+                    999L,
+                    quizSession.getId(),
+                    1,
+                    false,
+                    true,
+                    null
+            );
+        } else {
+            throw new IllegalArgumentException("unsupported playType for retry helper: " + playType);
+        }
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
     }
 
     private LocalDate today() {

--- a/src/test/java/com/f1/quiket/domain/gamification/service/GamificationServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/gamification/service/GamificationServiceTest.java
@@ -1,0 +1,82 @@
+package com.f1.quiket.domain.gamification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.gamification.dto.GamificationResponse;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class GamificationServiceTest {
+
+    private UserRepository userRepository;
+    private GamificationService gamificationService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        gamificationService = new GamificationService(userRepository);
+    }
+
+    @Test
+    void getMyGamification_returns_level_progress() {
+        User user = user(20, 360, 3);
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId()))
+                .thenReturn(Optional.of(user));
+
+        GamificationResponse response = gamificationService.getMyGamification(user.getPublicId());
+
+        assertThat(response.getDotoriBalance()).isEqualTo(20);
+        assertThat(response.getXpTotal()).isEqualTo(360);
+        assertThat(response.getCurrentLevel()).isEqualTo(3);
+        assertThat(response.getCurrentLevelName()).isEqualTo("펜굴리는 다람쥐");
+        assertThat(response.getMaxLevel()).isEqualTo(10);
+        assertThat(response.getNextLevel()).isEqualTo(4);
+        assertThat(response.getNextLevelName()).isEqualTo("노력형 다람쥐");
+        assertThat(response.getCurrentLevelMinXp()).isEqualTo(350);
+        assertThat(response.getNextLevelRequiredXp()).isEqualTo(850);
+        assertThat(response.getLevelProgressPct()).isEqualTo(2);
+    }
+
+    @Test
+    void getMyGamification_returns_max_level_without_next_level() {
+        User user = user(99, 30000, 10);
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId()))
+                .thenReturn(Optional.of(user));
+
+        GamificationResponse response = gamificationService.getMyGamification(user.getPublicId());
+
+        assertThat(response.getCurrentLevel()).isEqualTo(10);
+        assertThat(response.getNextLevel()).isNull();
+        assertThat(response.getNextLevelName()).isNull();
+        assertThat(response.getNextLevelRequiredXp()).isNull();
+        assertThat(response.getLevelProgressPct()).isEqualTo(100);
+    }
+
+    @Test
+    void getMyGamification_throws_not_found_when_user_missing() {
+        when(userRepository.findByPublicIdAndDeletedAtIsNull("missing-user"))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> gamificationService.getMyGamification("missing-user"))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_USER_NOT_FOUND);
+    }
+
+    private User user(Integer dotoriBalance, Integer xpTotal, Integer currentLevel) {
+        User user = User.create("user-public-id", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "dotoriBalance", dotoriBalance);
+        ReflectionTestUtils.setField(user, "xpTotal", xpTotal);
+        ReflectionTestUtils.setField(user, "currentLevel", currentLevel);
+        return user;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizAiResponseValidatorTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizAiResponseValidatorTest.java
@@ -1,0 +1,154 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationRequest;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationResponse;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.global.error.CustomException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizAiResponseValidatorTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final QuizAiResponseValidator validator = new QuizAiResponseValidator();
+
+    @Test
+    void validate_passes_multiple_choice_response() throws Exception {
+        QuizAiGenerationRequest request = request("multiple_choice", 4, 1);
+        QuizAiGenerationResponse response = response("""
+                {
+                  "questions": [
+                    {
+                      "partId": "part-public-id",
+                      "questionType": "multiple_choice",
+                      "difficulty": "medium",
+                      "summary": "정규화 핵심 개념",
+                      "body": "정규화의 목적은 무엇인가요?",
+                      "options": [
+                        {"optionNumber": 1, "content": "중복 최소화"},
+                        {"optionNumber": 2, "content": "중복 최대화"},
+                        {"optionNumber": 3, "content": "테이블 삭제"},
+                        {"optionNumber": 4, "content": "인덱스 제거"}
+                      ],
+                      "answerValue": "1",
+                      "correctExplanation": "정규화는 데이터 중복을 줄입니다.",
+                      "incorrectExplanation": "다른 선택지는 정규화 목적과 다릅니다."
+                    }
+                  ]
+                }
+                """);
+
+        validator.validate(request, response);
+    }
+
+    @Test
+    void validate_passes_ox_response() throws Exception {
+        QuizAiGenerationRequest request = request("ox", null, 1);
+        QuizAiGenerationResponse response = response("""
+                {
+                  "questions": [
+                    {
+                      "partId": "part-public-id",
+                      "questionType": "ox",
+                      "difficulty": "medium",
+                      "summary": "정규화 중복 감소",
+                      "body": "정규화는 데이터 중복을 줄인다.",
+                      "options": [],
+                      "answerValue": "O",
+                      "correctExplanation": "정규화는 중복 최소화를 돕습니다.",
+                      "incorrectExplanation": "중복을 늘리는 과정이 아닙니다."
+                    }
+                  ]
+                }
+                """);
+
+        validator.validate(request, response);
+    }
+
+    @Test
+    void validate_throws_when_part_id_is_out_of_scope() throws Exception {
+        QuizAiGenerationRequest request = request("multiple_choice", 4, 1);
+        QuizAiGenerationResponse response = response("""
+                {
+                  "questions": [
+                    {
+                      "partId": "other-part-id",
+                      "questionType": "multiple_choice",
+                      "difficulty": "medium",
+                      "summary": "정규화 핵심 개념",
+                      "body": "정규화의 목적은 무엇인가요?",
+                      "options": [
+                        {"optionNumber": 1, "content": "중복 최소화"},
+                        {"optionNumber": 2, "content": "중복 최대화"},
+                        {"optionNumber": 3, "content": "테이블 삭제"},
+                        {"optionNumber": 4, "content": "인덱스 제거"}
+                      ],
+                      "answerValue": "1",
+                      "correctExplanation": "정규화는 데이터 중복을 줄입니다.",
+                      "incorrectExplanation": "다른 선택지는 정규화 목적과 다릅니다."
+                    }
+                  ]
+                }
+                """);
+
+        assertThatThrownBy(() -> validator.validate(request, response))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("출제 범위 밖 partId가 포함되었습니다.");
+    }
+
+    @Test
+    void validate_throws_when_question_count_differs() throws Exception {
+        QuizAiGenerationRequest request = request("multiple_choice", 4, 2);
+        QuizAiGenerationResponse response = response("""
+                {
+                  "questions": []
+                }
+                """);
+
+        assertThatThrownBy(() -> validator.validate(request, response))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("AI 퀴즈 문항 수가 요청과 다릅니다.");
+    }
+
+    private QuizAiGenerationRequest request(String quizType, Integer choiceCount, Integer questionCount) {
+        return new QuizAiGenerationRequest(
+                subject(),
+                List.of(part()),
+                quizType,
+                choiceCount,
+                questionCount,
+                "one_by_one",
+                false,
+                null,
+                null,
+                "medium"
+        );
+    }
+
+    private QuizAiGenerationResponse response(String json) throws JsonProcessingException {
+        return objectMapper.readValue(json, QuizAiGenerationResponse.class);
+    }
+
+    private Subject subject() {
+        Subject subject = org.springframework.beans.BeanUtils.instantiateClass(Subject.class);
+        ReflectionTestUtils.setField(subject, "name", "데이터베이스");
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private Part part() {
+        Part part = org.springframework.beans.BeanUtils.instantiateClass(Part.class);
+        ReflectionTestUtils.setField(part, "publicId", "part-public-id");
+        ReflectionTestUtils.setField(part, "chapterId", 10L);
+        ReflectionTestUtils.setField(part, "partNumber", 1);
+        ReflectionTestUtils.setField(part, "name", "정규화");
+        ReflectionTestUtils.setField(part, "content", "정규화는 중복을 줄이는 과정입니다.");
+        return part;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationEnqueueListenerTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationEnqueueListenerTest.java
@@ -1,0 +1,99 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.event.QuizGenerationEnqueueRequestedEvent;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizGenerationEnqueueListenerTest {
+
+    private QuizGenerationQueue quizGenerationQueue;
+    private QuizGenerationJobRepository quizGenerationJobRepository;
+    private QuizGenerationEnqueueListener quizGenerationEnqueueListener;
+
+    @BeforeEach
+    void setUp() {
+        quizGenerationQueue = mock(QuizGenerationQueue.class);
+        quizGenerationJobRepository = mock(QuizGenerationJobRepository.class);
+        quizGenerationEnqueueListener = new QuizGenerationEnqueueListener(
+                quizGenerationQueue,
+                quizGenerationJobRepository
+        );
+    }
+
+    @Test
+    void handle_enqueues_and_assigns_message_id_on_success() {
+        QuizGenerationJob generationJob = job(900L);
+        QuizGenerationEnqueueRequestedEvent event = new QuizGenerationEnqueueRequestedEvent(message());
+
+        when(quizGenerationQueue.enqueue(any(QuizGenerationQueueMessage.class)))
+                .thenReturn("1748130000000-0");
+        when(quizGenerationJobRepository.findById(900L)).thenReturn(Optional.of(generationJob));
+
+        quizGenerationEnqueueListener.handle(event);
+
+        assertThat(generationJob.getMqMessageId()).isEqualTo("1748130000000-0");
+        assertThat(generationJob.getStatus()).isEqualTo("pending");
+    }
+
+    @Test
+    void handle_marks_job_failed_when_enqueue_throws() {
+        QuizGenerationJob generationJob = job(900L);
+        QuizGenerationEnqueueRequestedEvent event = new QuizGenerationEnqueueRequestedEvent(message());
+
+        when(quizGenerationQueue.enqueue(any(QuizGenerationQueueMessage.class)))
+                .thenThrow(new CustomException(ErrorCode.SERVICE_UNAVAILABLE));
+        when(quizGenerationJobRepository.findById(900L)).thenReturn(Optional.of(generationJob));
+
+        quizGenerationEnqueueListener.handle(event);
+
+        assertThat(generationJob.getStatus()).isEqualTo("failed");
+        assertThat(generationJob.getFailCode()).isEqualTo("enqueue_failed");
+        assertThat(generationJob.getFailReason()).isEqualTo("퀴즈 생성 큐 발행에 실패했습니다.");
+        assertThat(generationJob.isRetryable()).isTrue();
+        assertThat(generationJob.getMqMessageId()).isNull();
+    }
+
+    @Test
+    void handle_skips_silently_when_job_missing_on_enqueue_success() {
+        QuizGenerationEnqueueRequestedEvent event = new QuizGenerationEnqueueRequestedEvent(message());
+
+        when(quizGenerationQueue.enqueue(any(QuizGenerationQueueMessage.class)))
+                .thenReturn("1748130000000-0");
+        when(quizGenerationJobRepository.findById(900L)).thenReturn(Optional.empty());
+
+        // 매우 드문 케이스 — job이 사라진 상태로 listener 도달. 예외 던지지 않고 정상 종료
+        quizGenerationEnqueueListener.handle(event);
+
+        verify(quizGenerationJobRepository).findById(900L);
+        verify(quizGenerationJobRepository, never()).save(any());
+    }
+
+    private QuizGenerationJob job(Long id) {
+        QuizGenerationJob job = QuizGenerationJob.create(500L, 1L, null);
+        ReflectionTestUtils.setField(job, "id", id);
+        return job;
+    }
+
+    private QuizGenerationQueueMessage message() {
+        return new QuizGenerationQueueMessage(
+                900L,
+                500L,
+                "quiz-session-public-id",
+                "quiz-job-public-id",
+                1L
+        );
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessorTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationJobProcessorTest.java
@@ -1,0 +1,288 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.BeanUtils;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+class QuizGenerationJobProcessorTest {
+
+    private QuizAiClient quizAiClient;
+    private QuizGenerationJobRepository quizGenerationJobRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private QuizSessionScopeRepository quizSessionScopeRepository;
+    private SubjectRepository subjectRepository;
+    private PartRepository partRepository;
+    private QuestionRepository questionRepository;
+    private QuestionOptionRepository questionOptionRepository;
+    private QuestionAnswerRepository questionAnswerRepository;
+    private QuizGenerationJobProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        quizAiClient = mock(QuizAiClient.class);
+        quizGenerationJobRepository = mock(QuizGenerationJobRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        quizSessionScopeRepository = mock(QuizSessionScopeRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        partRepository = mock(PartRepository.class);
+        questionRepository = mock(QuestionRepository.class);
+        questionOptionRepository = mock(QuestionOptionRepository.class);
+        questionAnswerRepository = mock(QuestionAnswerRepository.class);
+
+        PlatformTransactionManager transactionManager = mock(PlatformTransactionManager.class);
+        when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
+        doNothing().when(transactionManager).commit(any(TransactionStatus.class));
+        doNothing().when(transactionManager).rollback(any(TransactionStatus.class));
+
+        processor = new QuizGenerationJobProcessor(
+                quizAiClient,
+                new QuizGenerationPromptBuilder(),
+                new QuizAiResponseValidator(),
+                quizGenerationJobRepository,
+                quizSessionRepository,
+                quizSessionScopeRepository,
+                subjectRepository,
+                partRepository,
+                questionRepository,
+                questionOptionRepository,
+                questionAnswerRepository,
+                new TransactionTemplate(transactionManager)
+        );
+    }
+
+    @Test
+    void process_saves_generated_questions_and_marks_completed() {
+        QuizGenerationJob job = job(900L, 500L, 1L);
+        QuizSession quizSession = quizSession(500L, 1L, 10L, "pending");
+        Subject subject = subject(10L, 1L);
+        Part part = part(100L, "part-public-id", 200L, 10L, 1L);
+        stubGenerationContext(job, quizSession, subject, part);
+        when(quizAiClient.generate(any())).thenReturn(aiResponse());
+        stubQuestionSave();
+
+        boolean processed = processor.process(message());
+
+        assertThat(processed).isTrue();
+        assertThat(job.getStatus()).isEqualTo("completed");
+        assertThat(job.getProgressPct()).isEqualTo(100);
+        assertThat(job.isRetryable()).isFalse();
+        assertThat(quizSession.getStatus()).isEqualTo("completed");
+        assertThat(quizSession.getGeneratedCount()).isEqualTo(1);
+
+        ArgumentCaptor<Question> questionCaptor = ArgumentCaptor.forClass(Question.class);
+        verify(questionRepository).save(questionCaptor.capture());
+        Question question = questionCaptor.getValue();
+        assertThat(question.getQuizSessionId()).isEqualTo(500L);
+        assertThat(question.getUserId()).isEqualTo(1L);
+        assertThat(question.getSubjectId()).isEqualTo(10L);
+        assertThat(question.getChapterId()).isEqualTo(200L);
+        assertThat(question.getPartId()).isEqualTo(100L);
+        assertThat(question.getQuestionType()).isEqualTo("multiple_choice");
+        assertThat(question.getSummary()).isEqualTo("데이터모델링핵심");
+        assertThat(question.getDisplayOrder()).isEqualTo(1);
+
+        ArgumentCaptor<Iterable<QuestionOption>> optionsCaptor = ArgumentCaptor.forClass(Iterable.class);
+        verify(questionOptionRepository).saveAll(optionsCaptor.capture());
+        List<QuestionOption> options = toList(optionsCaptor.getValue());
+        assertThat(options).hasSize(4);
+        assertThat(options.get(0).getQuestionId()).isEqualTo(1000L);
+        assertThat(options.get(0).getOptionNumber()).isEqualTo(1);
+        assertThat(options.get(0).getCorrect()).isTrue();
+        assertThat(options.get(1).getCorrect()).isFalse();
+
+        ArgumentCaptor<QuestionAnswer> answerCaptor = ArgumentCaptor.forClass(QuestionAnswer.class);
+        verify(questionAnswerRepository).save(answerCaptor.capture());
+        assertThat(answerCaptor.getValue().getQuestionId()).isEqualTo(1000L);
+        assertThat(answerCaptor.getValue().getAnswerValue()).isEqualTo("1");
+    }
+
+    @Test
+    void process_marks_failed_when_ai_client_fails() {
+        QuizGenerationJob job = job(900L, 500L, 1L);
+        QuizSession quizSession = quizSession(500L, 1L, 10L, "pending");
+        Subject subject = subject(10L, 1L);
+        Part part = part(100L, "part-public-id", 200L, 10L, 1L);
+        stubGenerationContext(job, quizSession, subject, part);
+        when(quizAiClient.generate(any()))
+                .thenThrow(new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AOAI 호출 실패"));
+
+        boolean processed = processor.process(message());
+
+        assertThat(processed).isTrue();
+        assertThat(job.getStatus()).isEqualTo("failed");
+        assertThat(job.getRetryCount()).isEqualTo(1);
+        assertThat(job.getFailCode()).isEqualTo(ErrorCode.SERVICE_UNAVAILABLE.getCode());
+        assertThat(job.getFailReason()).isEqualTo("AOAI 호출 실패");
+        assertThat(job.isRetryable()).isTrue();
+        assertThat(quizSession.getStatus()).isEqualTo("failed");
+        assertThat(quizSession.getFailReason()).isEqualTo("AOAI 호출 실패");
+        verifyNoInteractions(questionRepository, questionOptionRepository, questionAnswerRepository);
+    }
+
+    @Test
+    void markTimedOutJobs_marks_job_timeout_and_session_failed() {
+        QuizGenerationJob job = job(900L, 500L, 1L);
+        job.markInProgress();
+        ReflectionTestUtils.setField(job, "timeoutAt", LocalDateTime.now().minusSeconds(1));
+        QuizSession quizSession = quizSession(500L, 1L, 10L, "in_progress");
+
+        when(quizGenerationJobRepository.findAllByStatusAndTimeoutAtBefore(any(), any()))
+                .thenReturn(List.of(job));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(500L, 1L))
+                .thenReturn(Optional.of(quizSession));
+
+        int count = processor.markTimedOutJobs();
+
+        assertThat(count).isEqualTo(1);
+        assertThat(job.getStatus()).isEqualTo("timeout");
+        assertThat(job.getFailCode()).isEqualTo("timeout");
+        assertThat(job.getFailReason()).isEqualTo("퀴즈 생성 작업이 제한 시간을 초과했습니다.");
+        assertThat(quizSession.getStatus()).isEqualTo("failed");
+        assertThat(quizSession.getFailReason()).isEqualTo("퀴즈 생성 작업이 제한 시간을 초과했습니다.");
+    }
+
+    private void stubGenerationContext(QuizGenerationJob job, QuizSession quizSession, Subject subject, Part part) {
+        when(quizGenerationJobRepository.findById(900L)).thenReturn(Optional.of(job));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(500L, 1L)).thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(10L, 1L)).thenReturn(Optional.of(subject));
+        when(quizSessionScopeRepository.findAllByQuizSessionId(500L))
+                .thenReturn(List.of(QuizSessionScope.create(500L, 100L, 200L)));
+        when(partRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(List.of(100L), 1L))
+                .thenReturn(List.of(part));
+    }
+
+    private void stubQuestionSave() {
+        AtomicLong sequence = new AtomicLong(1000L);
+        when(questionRepository.save(any(Question.class))).thenAnswer(invocation -> {
+            Question question = invocation.getArgument(0);
+            ReflectionTestUtils.setField(question, "id", sequence.getAndIncrement());
+            return question;
+        });
+    }
+
+    private QuizGenerationQueueMessage message() {
+        return new QuizGenerationQueueMessage(900L, 500L, "quiz-session-public-id", "quiz-job-public-id", 1L);
+    }
+
+    private QuizGenerationJob job(Long id, Long quizSessionId, Long userId) {
+        QuizGenerationJob job = QuizGenerationJob.create(quizSessionId, userId, null);
+        ReflectionTestUtils.setField(job, "id", id);
+        return job;
+    }
+
+    private QuizSession quizSession(Long id, Long userId, Long subjectId, String status) {
+        QuizSession quizSession = BeanUtils.instantiateClass(QuizSession.class);
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        ReflectionTestUtils.setField(quizSession, "publicId", "quiz-session-public-id");
+        ReflectionTestUtils.setField(quizSession, "userId", userId);
+        ReflectionTestUtils.setField(quizSession, "subjectId", subjectId);
+        ReflectionTestUtils.setField(quizSession, "quizType", "multiple_choice");
+        ReflectionTestUtils.setField(quizSession, "choiceCount", 4);
+        ReflectionTestUtils.setField(quizSession, "questionCount", 1);
+        ReflectionTestUtils.setField(quizSession, "playMode", "one_by_one");
+        ReflectionTestUtils.setField(quizSession, "timerEnabled", false);
+        ReflectionTestUtils.setField(quizSession, "difficulty", "medium");
+        ReflectionTestUtils.setField(quizSession, "status", status);
+        ReflectionTestUtils.setField(quizSession, "jobId", "quiz-job-public-id");
+        return quizSession;
+    }
+
+    private Subject subject(Long id, Long userId) {
+        Subject subject = BeanUtils.instantiateClass(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", "subject-public-id");
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", "데이터 모델링");
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private Part part(Long id, String publicId, Long chapterId, Long subjectId, Long userId) {
+        Part part = BeanUtils.instantiateClass(Part.class);
+        ReflectionTestUtils.setField(part, "id", id);
+        ReflectionTestUtils.setField(part, "publicId", publicId);
+        ReflectionTestUtils.setField(part, "chapterId", chapterId);
+        ReflectionTestUtils.setField(part, "subjectId", subjectId);
+        ReflectionTestUtils.setField(part, "userId", userId);
+        ReflectionTestUtils.setField(part, "name", "데이터 모델링 개요");
+        ReflectionTestUtils.setField(part, "partNumber", 1);
+        ReflectionTestUtils.setField(part, "content", "데이터 모델링은 현실 세계의 데이터를 추상화하고 구조화하는 과정입니다.");
+        return part;
+    }
+
+    private QuizAiGenerationResponse aiResponse() {
+        try {
+            return new ObjectMapper().readValue("""
+                    {
+                      "questions": [
+                        {
+                          "partId": "part-public-id",
+                          "questionType": "multiple_choice",
+                          "difficulty": "medium",
+                          "summary": "데이터모델링핵심",
+                          "body": "다음 중 데이터 모델링의 설명으로 올바른 것은?",
+                          "options": [
+                            {"optionNumber": 1, "content": "현실 세계의 데이터를 추상화한다"},
+                            {"optionNumber": 2, "content": "서버 배포만 자동화한다"},
+                            {"optionNumber": 3, "content": "UI 색상만 정리한다"},
+                            {"optionNumber": 4, "content": "로그 파일만 삭제한다"}
+                          ],
+                          "answerValue": "1",
+                          "correctExplanation": "데이터 모델링은 현실 데이터를 추상화합니다.",
+                          "incorrectExplanation": "다른 선택지는 데이터 모델링의 핵심과 맞지 않습니다."
+                        }
+                      ]
+                    }
+                    """, QuizAiGenerationResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private <T> List<T> toList(Iterable<T> iterable) {
+        List<T> values = new ArrayList<>();
+        iterable.forEach(values::add);
+        return values;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationPromptBuilderTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationPromptBuilderTest.java
@@ -1,0 +1,67 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationPrompt;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationRequest;
+import com.f1.quiket.domain.subject.entity.Subject;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizGenerationPromptBuilderTest {
+
+    private final QuizGenerationPromptBuilder promptBuilder = new QuizGenerationPromptBuilder();
+
+    @Test
+    void build_includes_subject_parts_and_quiz_options() {
+        Subject subject = subject(10L, "데이터베이스", "exam");
+        Part part = part(100L, "018f8c2e-aaaa-7b6a-b9f0-111111111111", 20L, "정규화", "정규화는 중복을 줄이는 과정입니다.");
+        QuizAiGenerationRequest request = new QuizAiGenerationRequest(
+                subject,
+                List.of(part),
+                "multiple_choice",
+                4,
+                3,
+                "one_by_one",
+                true,
+                "per_question",
+                60,
+                "medium"
+        );
+
+        QuizAiGenerationPrompt prompt = promptBuilder.build(request);
+
+        assertThat(prompt.systemMessage()).contains("JSON Schema");
+        assertThat(prompt.userMessage())
+                .contains("데이터베이스")
+                .contains("exam")
+                .contains("multiple_choice")
+                .contains("문제 수: 3")
+                .contains("객관식 보기 수: 4")
+                .contains("per_question")
+                .contains("018f8c2e-aaaa-7b6a-b9f0-111111111111")
+                .contains("정규화는 중복을 줄이는 과정입니다.")
+                .contains("questions 배열 길이는 요청 문제 수와 정확히 같아야 한다");
+    }
+
+    private Subject subject(Long id, String name, String purpose) {
+        Subject subject = org.springframework.beans.BeanUtils.instantiateClass(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", purpose);
+        return subject;
+    }
+
+    private Part part(Long id, String publicId, Long chapterId, String name, String content) {
+        Part part = org.springframework.beans.BeanUtils.instantiateClass(Part.class);
+        ReflectionTestUtils.setField(part, "id", id);
+        ReflectionTestUtils.setField(part, "publicId", publicId);
+        ReflectionTestUtils.setField(part, "chapterId", chapterId);
+        ReflectionTestUtils.setField(part, "partNumber", 1);
+        ReflectionTestUtils.setField(part, "name", name);
+        ReflectionTestUtils.setField(part, "content", content);
+        return part;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizGenerationStatusServiceTest.java
@@ -6,7 +6,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.f1.quiket.domain.quiz.dto.QuizGenerationStatusResponse;
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
@@ -18,20 +20,28 @@ import org.springframework.test.util.ReflectionTestUtils;
 class QuizGenerationStatusServiceTest {
 
     private QuizSessionRepository quizSessionRepository;
+    private QuizGenerationJobRepository quizGenerationJobRepository;
     private QuizGenerationStatusService quizGenerationStatusService;
 
     @BeforeEach
     void setUp() {
         quizSessionRepository = mock(QuizSessionRepository.class);
-        quizGenerationStatusService = new QuizGenerationStatusService(quizSessionRepository);
+        quizGenerationJobRepository = mock(QuizGenerationJobRepository.class);
+        quizGenerationStatusService = new QuizGenerationStatusService(
+                quizSessionRepository,
+                quizGenerationJobRepository
+        );
     }
 
     @Test
     void getGenerationStatus_returns_pending_status() {
         Long userId = 1L;
-        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "pending", "quiz-job-1", null, null);
+        QuizSession quizSession = quizSession(100L, "quiz-session-public-id", userId, "pending", "quiz-job-1", null, null);
+        QuizGenerationJob generationJob = generationJob(900L, quizSession.getId(), userId, "pending", 0, null, null);
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(quizGenerationJobRepository.findByQuizSessionId(quizSession.getId()))
+                .thenReturn(Optional.of(generationJob));
 
         QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
                 userId,
@@ -50,9 +60,12 @@ class QuizGenerationStatusServiceTest {
     @Test
     void getGenerationStatus_returns_in_progress_status() {
         Long userId = 1L;
-        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "in_progress", "quiz-job-1", null, null);
+        QuizSession quizSession = quizSession(100L, "quiz-session-public-id", userId, "pending", "quiz-job-1", null, null);
+        QuizGenerationJob generationJob = generationJob(900L, quizSession.getId(), userId, "in_progress", 10, null, null);
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(quizGenerationJobRepository.findByQuizSessionId(quizSession.getId()))
+                .thenReturn(Optional.of(generationJob));
 
         QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
                 userId,
@@ -60,7 +73,7 @@ class QuizGenerationStatusServiceTest {
         );
 
         assertThat(response.getStatus()).isEqualTo("in_progress");
-        assertThat(response.getProgressPct()).isEqualTo(50);
+        assertThat(response.getProgressPct()).isEqualTo(10);
         assertThat(response.getGeneratedCount()).isNull();
         assertThat(response.getFailReason()).isNull();
     }
@@ -68,9 +81,12 @@ class QuizGenerationStatusServiceTest {
     @Test
     void getGenerationStatus_returns_completed_status() {
         Long userId = 1L;
-        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "completed", "quiz-job-1", 8, null);
+        QuizSession quizSession = quizSession(100L, "quiz-session-public-id", userId, "completed", "quiz-job-1", 8, null);
+        QuizGenerationJob generationJob = generationJob(900L, quizSession.getId(), userId, "completed", 100, null, null);
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(quizGenerationJobRepository.findByQuizSessionId(quizSession.getId()))
+                .thenReturn(Optional.of(generationJob));
 
         QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
                 userId,
@@ -86,9 +102,20 @@ class QuizGenerationStatusServiceTest {
     @Test
     void getGenerationStatus_returns_failed_status() {
         Long userId = 1L;
-        QuizSession quizSession = quizSession("quiz-session-public-id", userId, "failed", "quiz-job-1", null, "텍스트 길이 부족");
+        QuizSession quizSession = quizSession(100L, "quiz-session-public-id", userId, "failed", "quiz-job-1", null, null);
+        QuizGenerationJob generationJob = generationJob(
+                900L,
+                quizSession.getId(),
+                userId,
+                "failed",
+                100,
+                null,
+                "AI 응답 검증 실패"
+        );
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(quizGenerationJobRepository.findByQuizSessionId(quizSession.getId()))
+                .thenReturn(Optional.of(generationJob));
 
         QuizGenerationStatusResponse response = quizGenerationStatusService.getGenerationStatus(
                 userId,
@@ -98,7 +125,7 @@ class QuizGenerationStatusServiceTest {
         assertThat(response.getStatus()).isEqualTo("failed");
         assertThat(response.getProgressPct()).isEqualTo(100);
         assertThat(response.getGeneratedCount()).isNull();
-        assertThat(response.getFailReason()).isEqualTo("텍스트 길이 부족");
+        assertThat(response.getFailReason()).isEqualTo("AI 응답 검증 실패");
     }
 
     @Test
@@ -115,6 +142,7 @@ class QuizGenerationStatusServiceTest {
     }
 
     private QuizSession quizSession(
+            Long id,
             String publicId,
             Long userId,
             String status,
@@ -123,6 +151,7 @@ class QuizGenerationStatusServiceTest {
             String failReason
     ) {
         QuizSession quizSession = org.springframework.beans.BeanUtils.instantiateClass(QuizSession.class);
+        ReflectionTestUtils.setField(quizSession, "id", id);
         ReflectionTestUtils.setField(quizSession, "publicId", publicId);
         ReflectionTestUtils.setField(quizSession, "userId", userId);
         ReflectionTestUtils.setField(quizSession, "status", status);
@@ -130,5 +159,25 @@ class QuizGenerationStatusServiceTest {
         ReflectionTestUtils.setField(quizSession, "generatedCount", generatedCount);
         ReflectionTestUtils.setField(quizSession, "failReason", failReason);
         return quizSession;
+    }
+
+    private QuizGenerationJob generationJob(
+            Long id,
+            Long quizSessionId,
+            Long userId,
+            String status,
+            Integer progressPct,
+            Integer estimatedSeconds,
+            String failReason
+    ) {
+        QuizGenerationJob generationJob = org.springframework.beans.BeanUtils.instantiateClass(QuizGenerationJob.class);
+        ReflectionTestUtils.setField(generationJob, "id", id);
+        ReflectionTestUtils.setField(generationJob, "quizSessionId", quizSessionId);
+        ReflectionTestUtils.setField(generationJob, "userId", userId);
+        ReflectionTestUtils.setField(generationJob, "status", status);
+        ReflectionTestUtils.setField(generationJob, "progressPct", progressPct);
+        ReflectionTestUtils.setField(generationJob, "estimatedSeconds", estimatedSeconds);
+        ReflectionTestUtils.setField(generationJob, "failReason", failReason);
+        return generationJob;
     }
 }

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizPlaySessionStartServiceTest.java
@@ -1,0 +1,191 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizPlayStartRequest;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizPlaySessionStartServiceTest {
+
+    private QuizSessionRepository quizSessionRepository;
+    private QuizPlaySessionRepository quizPlaySessionRepository;
+    private QuizPlaySessionStartService quizPlaySessionStartService;
+
+    @BeforeEach
+    void setUp() {
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        quizPlaySessionStartService = new QuizPlaySessionStartService(
+                quizSessionRepository,
+                quizPlaySessionRepository
+        );
+    }
+
+    @Test
+    void start_creates_first_play_session() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizPlayStartRequest request = request("client-session-id", "first", null, true, false, "seed-1");
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.empty());
+        when(quizPlaySessionRepository.save(any(QuizPlaySession.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizPlaySessionResponse response = quizPlaySessionStartService.start(userId, quizSession.getPublicId(), request);
+
+        ArgumentCaptor<QuizPlaySession> playSessionCaptor = ArgumentCaptor.forClass(QuizPlaySession.class);
+        verify(quizPlaySessionRepository).save(playSessionCaptor.capture());
+        QuizPlaySession savedPlaySession = playSessionCaptor.getValue();
+        assertThat(savedPlaySession.getClientSessionId()).isEqualTo("client-session-id");
+        assertThat(savedPlaySession.getQuizSessionId()).isEqualTo(quizSession.getId());
+        assertThat(savedPlaySession.getUserId()).isEqualTo(userId);
+        assertThat(savedPlaySession.getSubjectId()).isEqualTo(quizSession.getSubjectId());
+        assertThat(savedPlaySession.getPlayType()).isEqualTo("first");
+        assertThat(savedPlaySession.getStatus()).isEqualTo("in_progress");
+        assertThat(savedPlaySession.getLastQuestionIndex()).isZero();
+        assertThat(savedPlaySession.getElapsedMs()).isZero();
+        assertThat(savedPlaySession.getQuestionShuffled()).isTrue();
+        assertThat(savedPlaySession.getOptionShuffled()).isFalse();
+        assertThat(savedPlaySession.getShuffleSeed()).isEqualTo("seed-1");
+
+        assertThat(response.getPlaySessionId()).isEqualTo("client-session-id");
+        assertThat(response.getClientSessionId()).isEqualTo("client-session-id");
+        assertThat(response.getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        assertThat(response.getPlayType()).isEqualTo("first");
+        assertThat(response.getStatus()).isEqualTo("in_progress");
+    }
+
+    @Test
+    void start_returns_existing_when_same_client_session_id_is_retried() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizPlayStartRequest request = request("client-session-id", "first", null, null, null, null);
+        QuizPlaySession existing = playSession("client-session-id", quizSession.getId(), userId, quizSession.getSubjectId());
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+
+        QuizPlaySessionResponse response = quizPlaySessionStartService.start(userId, quizSession.getPublicId(), request);
+
+        assertThat(response.getPlaySessionId()).isEqualTo(existing.getClientSessionId());
+        assertThat(response.getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        verify(quizPlaySessionRepository).findByClientSessionId(request.getClientSessionId());
+    }
+
+    @Test
+    void start_throws_conflict_when_client_session_id_belongs_to_other_session() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizPlayStartRequest request = request("client-session-id", "first", null, null, null, null);
+        QuizPlaySession existing = playSession("client-session-id", 999L, userId, quizSession.getSubjectId());
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> quizPlaySessionStartService.start(userId, quizSession.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    @Test
+    void start_throws_not_completed_when_quiz_generation_is_not_completed() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "pending");
+        QuizPlayStartRequest request = request("client-session-id", "first", null, null, null, null);
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+
+        assertThatThrownBy(() -> quizPlaySessionStartService.start(userId, quizSession.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_SESSION_NOT_COMPLETED);
+
+        verifyNoInteractions(quizPlaySessionRepository);
+    }
+
+    @Test
+    void start_throws_invalid_option_when_play_type_is_not_first() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizPlayStartRequest request = request("client-session-id", "retry_all", null, null, null, null);
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+
+        assertThatThrownBy(() -> quizPlaySessionStartService.start(userId, quizSession.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_OPTION_INVALID);
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId, String status) {
+        QuizSession quizSession = QuizSession.create(
+                publicId,
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                10,
+                "one_by_one",
+                false,
+                null,
+                null,
+                "medium",
+                status,
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizPlaySession playSession(String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        return QuizPlaySession.createFirst(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+    }
+
+    private QuizPlayStartRequest request(
+            String clientSessionId,
+            String playType,
+            String parentPlaySessionId,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizPlayStartRequest request = new QuizPlayStartRequest();
+        ReflectionTestUtils.setField(request, "clientSessionId", clientSessionId);
+        ReflectionTestUtils.setField(request, "playType", playType);
+        ReflectionTestUtils.setField(request, "parentPlaySessionId", parentPlaySessionId);
+        ReflectionTestUtils.setField(request, "questionShuffled", questionShuffled);
+        ReflectionTestUtils.setField(request, "optionShuffled", optionShuffled);
+        ReflectionTestUtils.setField(request, "shuffleSeed", shuffleSeed);
+        return request;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultQueryServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultQueryServiceTest.java
@@ -1,0 +1,289 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizResultQueryServiceTest {
+
+    private QuizResultRepository quizResultRepository;
+    private QuizPlaySessionRepository quizPlaySessionRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private SubjectRepository subjectRepository;
+    private UserRepository userRepository;
+    private QuestionRepository questionRepository;
+    private QuestionOptionRepository questionOptionRepository;
+    private QuestionAnswerRepository questionAnswerRepository;
+    private QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private QuizResultQueryService quizResultQueryService;
+
+    @BeforeEach
+    void setUp() {
+        quizResultRepository = mock(QuizResultRepository.class);
+        quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        userRepository = mock(UserRepository.class);
+        questionRepository = mock(QuestionRepository.class);
+        questionOptionRepository = mock(QuestionOptionRepository.class);
+        questionAnswerRepository = mock(QuestionAnswerRepository.class);
+        quizPlayAnswerRepository = mock(QuizPlayAnswerRepository.class);
+        quizResultQueryService = new QuizResultQueryService(
+                quizResultRepository,
+                quizPlaySessionRepository,
+                quizSessionRepository,
+                subjectRepository,
+                userRepository,
+                questionRepository,
+                questionOptionRepository,
+                questionAnswerRepository,
+                quizPlayAnswerRepository,
+                new QuizResultResponseAssembler()
+        );
+    }
+
+    @Test
+    void getQuizResult_returns_saved_result_detail() {
+        Long userId = 1L;
+        User user = user(userId, 20, 400, 3);
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId());
+        QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption correctOption = option(1000L, question.getId(), 1, "정답", true);
+        QuestionOption wrongOption = option(1001L, question.getId(), 2, "오답", false);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizPlayAnswer playAnswer = playAnswer(playSession.getId(), question.getId(), userId, correctOption.getId(), true, false);
+        QuizResult result = result(3000L, "result-public-id", playSession, quizSession, subject, 1, 1, 0, 0, 100);
+
+        when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                .thenReturn(Optional.of(user));
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizPlaySessionRepository.findByIdAndUserId(playSession.getId(), userId))
+                .thenReturn(Optional.of(playSession));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subject.getId(), userId))
+                .thenReturn(Optional.of(subject));
+        when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(quizSession.getId(), userId))
+                .thenReturn(List.of(question));
+        when(questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(List.of(question.getId())))
+                .thenReturn(List.of(correctOption, wrongOption));
+        when(questionAnswerRepository.findAllByQuestionIdIn(List.of(question.getId())))
+                .thenReturn(List.of(answer));
+        when(quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId()))
+                .thenReturn(List.of(playAnswer));
+
+        QuizResultResponse response = quizResultQueryService.getQuizResult(userId, result.getPublicId());
+
+        assertThat(response.getResultId()).isEqualTo(result.getPublicId());
+        assertThat(response.getPlaySessionId()).isEqualTo(playSession.getClientSessionId());
+        assertThat(response.getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        assertThat(response.getSubjectName()).isEqualTo(subject.getName());
+        assertThat(response.getCorrectCount()).isEqualTo(1);
+        assertThat(response.getRewards().getDotoriEarned()).isEqualTo(1);
+        assertThat(response.getRewards().getCurrentDotoriBalance()).isEqualTo(20);
+        assertThat(response.getReviewItems()).hasSize(1);
+        assertThat(response.getReviewItems().get(0).getQuestionId()).isEqualTo(question.getPublicId());
+        assertThat(response.getReviewItems().get(0).getSelectedOptionId()).isEqualTo(String.valueOf(correctOption.getId()));
+        assertThat(response.getReviewItems().get(0).getAnswerValue()).isEqualTo("1");
+        assertThat(response.getReviewItems().get(0).getCorrectServer()).isTrue();
+    }
+
+    @Test
+    void getQuizResult_throws_not_found_when_result_missing() {
+        Long userId = 1L;
+        User user = user(userId, 20, 400, 3);
+        when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                .thenReturn(Optional.of(user));
+        when(quizResultRepository.findByPublicIdAndUserId("missing-result-id", userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizResultQueryService.getQuizResult(userId, "missing-result-id"))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_RESULT_NOT_FOUND);
+    }
+
+    private User user(Long id, Integer dotoriBalance, Integer xpTotal, Integer currentLevel) {
+        User user = User.create("user-public-id", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", id);
+        ReflectionTestUtils.setField(user, "emailVerified", true);
+        ReflectionTestUtils.setField(user, "dotoriBalance", dotoriBalance);
+        ReflectionTestUtils.setField(user, "xpTotal", xpTotal);
+        ReflectionTestUtils.setField(user, "currentLevel", currentLevel);
+        return user;
+    }
+
+    private Subject subject(Long id, String publicId, Long userId, String name) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId) {
+        QuizSession quizSession = QuizSession.create(
+                publicId,
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                1,
+                "one_by_one",
+                true,
+                "per_question",
+                60,
+                "medium",
+                "completed",
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizPlaySession playSession(Long id, String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        QuizPlaySession playSession = QuizPlaySession.createFirst(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        playSession.submit(430000);
+        return playSession;
+    }
+
+    private Question question(Long id, String publicId, Long quizSessionId, Long userId, Long subjectId, Integer displayOrder) {
+        Question question = newEntity(Question.class);
+        ReflectionTestUtils.setField(question, "id", id);
+        ReflectionTestUtils.setField(question, "publicId", publicId);
+        ReflectionTestUtils.setField(question, "quizSessionId", quizSessionId);
+        ReflectionTestUtils.setField(question, "userId", userId);
+        ReflectionTestUtils.setField(question, "subjectId", subjectId);
+        ReflectionTestUtils.setField(question, "chapterId", 100L + displayOrder);
+        ReflectionTestUtils.setField(question, "partId", 200L + displayOrder);
+        ReflectionTestUtils.setField(question, "questionType", "multiple_choice");
+        ReflectionTestUtils.setField(question, "difficulty", "medium");
+        ReflectionTestUtils.setField(question, "summary", "핵심 개념 확인");
+        ReflectionTestUtils.setField(question, "body", "다음 중 올바른 것은?");
+        ReflectionTestUtils.setField(question, "correctExplanation", "정답 해설");
+        ReflectionTestUtils.setField(question, "incorrectExplanation", "오답 해설");
+        ReflectionTestUtils.setField(question, "displayOrder", displayOrder);
+        return question;
+    }
+
+    private QuestionOption option(Long id, Long questionId, Integer optionNumber, String content, Boolean correct) {
+        QuestionOption option = newEntity(QuestionOption.class);
+        ReflectionTestUtils.setField(option, "id", id);
+        ReflectionTestUtils.setField(option, "questionId", questionId);
+        ReflectionTestUtils.setField(option, "optionNumber", optionNumber);
+        ReflectionTestUtils.setField(option, "content", content);
+        ReflectionTestUtils.setField(option, "correct", correct);
+        return option;
+    }
+
+    private QuestionAnswer answer(Long id, Long questionId, String answerValue) {
+        QuestionAnswer answer = newEntity(QuestionAnswer.class);
+        ReflectionTestUtils.setField(answer, "id", id);
+        ReflectionTestUtils.setField(answer, "questionId", questionId);
+        ReflectionTestUtils.setField(answer, "answerValue", answerValue);
+        return answer;
+    }
+
+    private QuizResult result(
+            Long id,
+            String publicId,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            Integer totalCount,
+            Integer correctCount,
+            Integer wrongCount,
+            Integer skipCount,
+            Integer accuracyPct
+    ) {
+        QuizResult result = QuizResult.create(
+                publicId,
+                playSession.getId(),
+                quizSession.getId(),
+                playSession.getUserId(),
+                subject.getId(),
+                totalCount,
+                correctCount,
+                wrongCount,
+                skipCount,
+                accuracyPct,
+                playSession.getElapsedMs(),
+                1,
+                4,
+                false,
+                null,
+                true,
+                false
+        );
+        ReflectionTestUtils.setField(result, "id", id);
+        return result;
+    }
+
+    private QuizPlayAnswer playAnswer(
+            Long playSessionId,
+            Long questionId,
+            Long userId,
+            Long selectedOptionId,
+            Boolean correctServer,
+            Boolean skipped
+    ) {
+        return QuizPlayAnswer.create(
+                playSessionId,
+                questionId,
+                userId,
+                selectedOptionId,
+                null,
+                correctServer,
+                correctServer,
+                skipped,
+                15000,
+                false
+        );
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllServiceTest.java
@@ -1,0 +1,212 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizResultRetryAllServiceTest {
+
+    private QuizResultRepository quizResultRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private QuizPlaySessionRepository quizPlaySessionRepository;
+    private QuizResultRetryAllService quizResultRetryAllService;
+
+    @BeforeEach
+    void setUp() {
+        quizResultRepository = mock(QuizResultRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        quizResultRetryAllService = new QuizResultRetryAllService(
+                quizResultRepository,
+                quizSessionRepository,
+                quizPlaySessionRepository
+        );
+    }
+
+    @Test
+    void retryAll_creates_retry_all_play_session() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizResult result = result(3000L, "result-public-id", quizSession, userId, 700L);
+        QuizRetryRequest request = request("retry-client-session-id", true, false, "seed-1");
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.empty());
+        when(quizPlaySessionRepository.save(any(QuizPlaySession.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizPlaySessionResponse response = quizResultRetryAllService.retryAll(userId, result.getPublicId(), request);
+
+        ArgumentCaptor<QuizPlaySession> playSessionCaptor = ArgumentCaptor.forClass(QuizPlaySession.class);
+        verify(quizPlaySessionRepository).save(playSessionCaptor.capture());
+        QuizPlaySession savedPlaySession = playSessionCaptor.getValue();
+        assertThat(savedPlaySession.getClientSessionId()).isEqualTo("retry-client-session-id");
+        assertThat(savedPlaySession.getQuizSessionId()).isEqualTo(quizSession.getId());
+        assertThat(savedPlaySession.getUserId()).isEqualTo(userId);
+        assertThat(savedPlaySession.getSubjectId()).isEqualTo(quizSession.getSubjectId());
+        assertThat(savedPlaySession.getPlayType()).isEqualTo("retry_all");
+        assertThat(savedPlaySession.getStatus()).isEqualTo("in_progress");
+        assertThat(savedPlaySession.getQuestionShuffled()).isTrue();
+        assertThat(savedPlaySession.getOptionShuffled()).isFalse();
+        assertThat(savedPlaySession.getShuffleSeed()).isEqualTo("seed-1");
+
+        assertThat(response.getPlaySessionId()).isEqualTo("retry-client-session-id");
+        assertThat(response.getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        assertThat(response.getPlayType()).isEqualTo("retry_all");
+        assertThat(response.getStatus()).isEqualTo("in_progress");
+    }
+
+    @Test
+    void retryAll_returns_existing_when_same_client_session_id_is_retried() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizResult result = result(3000L, "result-public-id", quizSession, userId, 700L);
+        QuizRetryRequest request = request("retry-client-session-id", null, null, null);
+        QuizPlaySession existing = retryAllPlaySession("retry-client-session-id", quizSession.getId(), userId, quizSession.getSubjectId());
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+
+        QuizPlaySessionResponse response = quizResultRetryAllService.retryAll(userId, result.getPublicId(), request);
+
+        assertThat(response.getPlaySessionId()).isEqualTo(existing.getClientSessionId());
+        assertThat(response.getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        assertThat(response.getPlayType()).isEqualTo("retry_all");
+    }
+
+    @Test
+    void retryAll_throws_not_found_when_result_missing() {
+        Long userId = 1L;
+        QuizRetryRequest request = request("retry-client-session-id", null, null, null);
+        when(quizResultRepository.findByPublicIdAndUserId("missing-result-id", userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizResultRetryAllService.retryAll(userId, "missing-result-id", request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_RESULT_NOT_FOUND);
+    }
+
+    @Test
+    void retryAll_throws_conflict_when_client_session_id_belongs_to_other_session() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizResult result = result(3000L, "result-public-id", quizSession, userId, 700L);
+        QuizRetryRequest request = request("retry-client-session-id", null, null, null);
+        QuizPlaySession existing = QuizPlaySession.createFirst(
+                "retry-client-session-id",
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                false,
+                true,
+                null
+        );
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> quizResultRetryAllService.retryAll(userId, result.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId, String status) {
+        QuizSession quizSession = QuizSession.create(
+                publicId,
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                10,
+                "one_by_one",
+                false,
+                null,
+                null,
+                "medium",
+                status,
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizResult result(Long id, String publicId, QuizSession quizSession, Long userId, Long playSessionId) {
+        QuizResult result = QuizResult.create(
+                publicId,
+                playSessionId,
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                10,
+                8,
+                2,
+                0,
+                80,
+                430000,
+                8,
+                32,
+                false,
+                null,
+                true,
+                false
+        );
+        ReflectionTestUtils.setField(result, "id", id);
+        return result;
+    }
+
+    private QuizPlaySession retryAllPlaySession(String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        return QuizPlaySession.createRetryAll(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+    }
+
+    private QuizRetryRequest request(
+            String clientSessionId,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizRetryRequest request = new QuizRetryRequest();
+        ReflectionTestUtils.setField(request, "clientSessionId", clientSessionId);
+        ReflectionTestUtils.setField(request, "questionShuffled", questionShuffled);
+        ReflectionTestUtils.setField(request, "optionShuffled", optionShuffled);
+        ReflectionTestUtils.setField(request, "shuffleSeed", shuffleSeed);
+        return request;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryAllServiceTest.java
@@ -15,6 +15,8 @@ import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import java.util.Optional;
@@ -28,6 +30,7 @@ class QuizResultRetryAllServiceTest {
     private QuizResultRepository quizResultRepository;
     private QuizSessionRepository quizSessionRepository;
     private QuizPlaySessionRepository quizPlaySessionRepository;
+    private SubjectRepository subjectRepository;
     private QuizResultRetryAllService quizResultRetryAllService;
 
     @BeforeEach
@@ -35,10 +38,12 @@ class QuizResultRetryAllServiceTest {
         quizResultRepository = mock(QuizResultRepository.class);
         quizSessionRepository = mock(QuizSessionRepository.class);
         quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
         quizResultRetryAllService = new QuizResultRetryAllService(
                 quizResultRepository,
                 quizSessionRepository,
-                quizPlaySessionRepository
+                quizPlaySessionRepository,
+                subjectRepository
         );
     }
 
@@ -52,6 +57,8 @@ class QuizResultRetryAllServiceTest {
                 .thenReturn(Optional.of(result));
         when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getSubjectId(), userId))
+                .thenReturn(Optional.of(subject(quizSession.getSubjectId(), userId)));
         when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
                 .thenReturn(Optional.empty());
         when(quizPlaySessionRepository.save(any(QuizPlaySession.class)))
@@ -89,6 +96,8 @@ class QuizResultRetryAllServiceTest {
                 .thenReturn(Optional.of(result));
         when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getSubjectId(), userId))
+                .thenReturn(Optional.of(subject(quizSession.getSubjectId(), userId)));
         when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
                 .thenReturn(Optional.of(existing));
 
@@ -131,6 +140,8 @@ class QuizResultRetryAllServiceTest {
                 .thenReturn(Optional.of(result));
         when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
                 .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getSubjectId(), userId))
+                .thenReturn(Optional.of(subject(quizSession.getSubjectId(), userId)));
         when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
                 .thenReturn(Optional.of(existing));
 
@@ -138,6 +149,32 @@ class QuizResultRetryAllServiceTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    @Test
+    void retryAll_throws_subject_not_found_when_subject_is_deleted() {
+        Long userId = 1L;
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, 10L, "completed");
+        QuizResult result = result(3000L, "result-public-id", quizSession, userId, 700L);
+        QuizRetryRequest request = request("retry-client-session-id", null, null, null);
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getSubjectId(), userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizResultRetryAllService.retryAll(userId, result.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.SUBJECT_NOT_FOUND);
+    }
+
+    private Subject subject(Long id, Long userId) {
+        Subject subject = org.springframework.beans.BeanUtils.instantiateClass(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        return subject;
     }
 
     private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId, String status) {

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongServiceTest.java
@@ -89,7 +89,7 @@ class QuizResultRetryWrongServiceTest {
         QuestionOption wrongQuestionWrongOption = option(1003L, wrongQuestion.getId(), 2, "틀린 문제 오답", false);
         QuestionAnswer correctAnswer = answer(2001L, correctQuestion.getId(), "1");
         QuestionAnswer wrongAnswer = answer(2002L, wrongQuestion.getId(), "1");
-        QuizRetryRequest request = request("retry-wrong-client-session-id", null, null, "seed-1");
+        QuizRetryRequest request = request("retry-wrong-client-session-id", true, null, "seed-1");
         mockBaseData(userId, result, parentPlaySession, parentQuizSession);
         when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
                 .thenReturn(Optional.empty());

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultRetryWrongServiceTest.java
@@ -1,0 +1,491 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.dto.QuizPlaySessionResponse;
+import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizResultRetryWrongServiceTest {
+
+    private QuizResultRepository quizResultRepository;
+    private QuizPlaySessionRepository quizPlaySessionRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private SubjectRepository subjectRepository;
+    private QuestionRepository questionRepository;
+    private QuestionOptionRepository questionOptionRepository;
+    private QuestionAnswerRepository questionAnswerRepository;
+    private QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private QuizSessionScopeRepository quizSessionScopeRepository;
+    private QuizResultRetryWrongService quizResultRetryWrongService;
+
+    @BeforeEach
+    void setUp() {
+        quizResultRepository = mock(QuizResultRepository.class);
+        quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        questionRepository = mock(QuestionRepository.class);
+        questionOptionRepository = mock(QuestionOptionRepository.class);
+        questionAnswerRepository = mock(QuestionAnswerRepository.class);
+        quizPlayAnswerRepository = mock(QuizPlayAnswerRepository.class);
+        quizSessionScopeRepository = mock(QuizSessionScopeRepository.class);
+        quizResultRetryWrongService = new QuizResultRetryWrongService(
+                quizResultRepository,
+                quizPlaySessionRepository,
+                quizSessionRepository,
+                subjectRepository,
+                questionRepository,
+                questionOptionRepository,
+                questionAnswerRepository,
+                quizPlayAnswerRepository,
+                quizSessionScopeRepository
+        );
+    }
+
+    @Test
+    void retryWrong_creates_child_quiz_session_and_retry_wrong_play_session() {
+        Long userId = 1L;
+        QuizSession parentQuizSession = quizSession(500L, "parent-quiz-session-id", userId, 10L, "completed", 2);
+        QuizPlaySession parentPlaySession = firstPlaySession(700L, "parent-play-session-id", parentQuizSession);
+        QuizResult result = result(3000L, "result-public-id", parentPlaySession, parentQuizSession, userId);
+        Question correctQuestion = question(901L, "correct-question-id", parentQuizSession, 1);
+        Question wrongQuestion = question(902L, "wrong-question-id", parentQuizSession, 2);
+        QuestionOption correctQuestionOption = option(1001L, correctQuestion.getId(), 1, "맞은 문제 정답", true);
+        QuestionOption wrongQuestionCorrectOption = option(1002L, wrongQuestion.getId(), 1, "틀린 문제 정답", true);
+        QuestionOption wrongQuestionWrongOption = option(1003L, wrongQuestion.getId(), 2, "틀린 문제 오답", false);
+        QuestionAnswer correctAnswer = answer(2001L, correctQuestion.getId(), "1");
+        QuestionAnswer wrongAnswer = answer(2002L, wrongQuestion.getId(), "1");
+        QuizRetryRequest request = request("retry-wrong-client-session-id", null, null, "seed-1");
+        mockBaseData(userId, result, parentPlaySession, parentQuizSession);
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.empty());
+        mockParentQuestionData(
+                parentQuizSession,
+                userId,
+                List.of(correctQuestion, wrongQuestion),
+                List.of(
+                        playAnswer(parentPlaySession.getId(), correctQuestion.getId(), userId, correctQuestionOption.getId(), true, false),
+                        playAnswer(parentPlaySession.getId(), wrongQuestion.getId(), userId, wrongQuestionWrongOption.getId(), false, false)
+                ),
+                List.of(correctQuestionOption, wrongQuestionCorrectOption, wrongQuestionWrongOption),
+                List.of(correctAnswer, wrongAnswer)
+        );
+        mockChildSaves();
+
+        QuizPlaySessionResponse response = quizResultRetryWrongService.retryWrong(userId, result.getPublicId(), request);
+
+        assertThat(response.getPlaySessionId()).isEqualTo(request.getClientSessionId());
+        assertThat(response.getQuizSessionId()).isNotEqualTo(parentQuizSession.getPublicId());
+        assertThat(response.getPlayType()).isEqualTo("retry_wrong");
+        assertThat(response.getStatus()).isEqualTo("in_progress");
+
+        ArgumentCaptor<QuizSession> quizSessionCaptor = ArgumentCaptor.forClass(QuizSession.class);
+        verify(quizSessionRepository).save(quizSessionCaptor.capture());
+        QuizSession childQuizSession = quizSessionCaptor.getValue();
+        assertThat(childQuizSession.getSubjectId()).isEqualTo(parentQuizSession.getSubjectId());
+        assertThat(childQuizSession.getQuestionCount()).isEqualTo(1);
+        assertThat(childQuizSession.getStatus()).isEqualTo("completed");
+        assertThat(childQuizSession.getGeneratedCount()).isEqualTo(1);
+        assertThat(childQuizSession.getPlayMode()).isEqualTo(parentQuizSession.getPlayMode());
+
+        ArgumentCaptor<Iterable<QuizSessionScope>> scopeCaptor = iterableCaptor();
+        verify(quizSessionScopeRepository).saveAll(scopeCaptor.capture());
+        List<QuizSessionScope> savedScopes = toList(scopeCaptor.getValue());
+        assertThat(savedScopes).hasSize(1);
+        assertThat(savedScopes.get(0).getQuizSessionId()).isEqualTo(childQuizSession.getId());
+        assertThat(savedScopes.get(0).getPartId()).isEqualTo(wrongQuestion.getPartId());
+
+        ArgumentCaptor<Question> questionCaptor = ArgumentCaptor.forClass(Question.class);
+        verify(questionRepository).save(questionCaptor.capture());
+        Question childQuestion = questionCaptor.getValue();
+        assertThat(childQuestion.getQuizSessionId()).isEqualTo(childQuizSession.getId());
+        assertThat(childQuestion.getBody()).isEqualTo(wrongQuestion.getBody());
+        assertThat(childQuestion.getDisplayOrder()).isEqualTo(1);
+
+        ArgumentCaptor<Iterable<QuestionOption>> optionCaptor = iterableCaptor();
+        verify(questionOptionRepository).saveAll(optionCaptor.capture());
+        List<QuestionOption> childOptions = toList(optionCaptor.getValue());
+        assertThat(childOptions).hasSize(2);
+        assertThat(childOptions)
+                .extracting(QuestionOption::getQuestionId)
+                .containsOnly(childQuestion.getId());
+
+        ArgumentCaptor<QuestionAnswer> answerCaptor = ArgumentCaptor.forClass(QuestionAnswer.class);
+        verify(questionAnswerRepository).save(answerCaptor.capture());
+        assertThat(answerCaptor.getValue().getQuestionId()).isEqualTo(childQuestion.getId());
+        assertThat(answerCaptor.getValue().getAnswerValue()).isEqualTo(wrongAnswer.getAnswerValue());
+
+        ArgumentCaptor<QuizPlaySession> playSessionCaptor = ArgumentCaptor.forClass(QuizPlaySession.class);
+        verify(quizPlaySessionRepository).save(playSessionCaptor.capture());
+        QuizPlaySession retryWrongPlaySession = playSessionCaptor.getValue();
+        assertThat(retryWrongPlaySession.getQuizSessionId()).isEqualTo(childQuizSession.getId());
+        assertThat(retryWrongPlaySession.getPlayType()).isEqualTo("retry_wrong");
+        assertThat(retryWrongPlaySession.getParentPlaySessionId()).isEqualTo(parentPlaySession.getId());
+        assertThat(retryWrongPlaySession.getParentQuizSessionId()).isEqualTo(parentQuizSession.getId());
+        assertThat(retryWrongPlaySession.getGeneration()).isEqualTo(1);
+        assertThat(retryWrongPlaySession.getQuestionShuffled()).isTrue();
+        assertThat(retryWrongPlaySession.getOptionShuffled()).isTrue();
+    }
+
+    @Test
+    void retryWrong_returns_existing_when_same_client_session_id_is_retried() {
+        Long userId = 1L;
+        QuizSession parentQuizSession = quizSession(500L, "parent-quiz-session-id", userId, 10L, "completed", 2);
+        QuizSession childQuizSession = quizSession(600L, "child-quiz-session-id", userId, 10L, "completed", 1);
+        QuizPlaySession parentPlaySession = firstPlaySession(700L, "parent-play-session-id", parentQuizSession);
+        QuizPlaySession existing = retryWrongPlaySession(
+                701L,
+                "retry-wrong-client-session-id",
+                childQuizSession,
+                parentPlaySession,
+                parentQuizSession
+        );
+        QuizResult result = result(3000L, "result-public-id", parentPlaySession, parentQuizSession, userId);
+        QuizRetryRequest request = request(existing.getClientSessionId(), null, null, null);
+        mockBaseData(userId, result, parentPlaySession, parentQuizSession);
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(childQuizSession.getId(), userId))
+                .thenReturn(Optional.of(childQuizSession));
+
+        QuizPlaySessionResponse response = quizResultRetryWrongService.retryWrong(userId, result.getPublicId(), request);
+
+        assertThat(response.getPlaySessionId()).isEqualTo(existing.getClientSessionId());
+        assertThat(response.getQuizSessionId()).isEqualTo(childQuizSession.getPublicId());
+        assertThat(response.getPlayType()).isEqualTo("retry_wrong");
+        verify(quizSessionRepository, never()).save(any());
+        verify(questionRepository, never()).save(any());
+    }
+
+    @Test
+    void retryWrong_throws_conflict_when_wrong_question_is_empty() {
+        Long userId = 1L;
+        QuizSession parentQuizSession = quizSession(500L, "parent-quiz-session-id", userId, 10L, "completed", 1);
+        QuizPlaySession parentPlaySession = firstPlaySession(700L, "parent-play-session-id", parentQuizSession);
+        QuizResult result = result(3000L, "result-public-id", parentPlaySession, parentQuizSession, userId);
+        Question question = question(901L, "question-id", parentQuizSession, 1);
+        QuestionOption option = option(1001L, question.getId(), 1, "정답", true);
+        QuestionAnswer answer = answer(2001L, question.getId(), "1");
+        QuizRetryRequest request = request("retry-wrong-client-session-id", null, null, null);
+        mockBaseData(userId, result, parentPlaySession, parentQuizSession);
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.empty());
+        mockParentQuestionData(
+                parentQuizSession,
+                userId,
+                List.of(question),
+                List.of(playAnswer(parentPlaySession.getId(), question.getId(), userId, option.getId(), true, false)),
+                List.of(option),
+                List.of(answer)
+        );
+
+        assertThatThrownBy(() -> quizResultRetryWrongService.retryWrong(userId, result.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    @Test
+    void retryWrong_throws_conflict_when_client_session_id_belongs_to_other_session() {
+        Long userId = 1L;
+        QuizSession parentQuizSession = quizSession(500L, "parent-quiz-session-id", userId, 10L, "completed", 1);
+        QuizPlaySession parentPlaySession = firstPlaySession(700L, "parent-play-session-id", parentQuizSession);
+        QuizPlaySession existing = firstPlaySession(701L, "retry-wrong-client-session-id", parentQuizSession);
+        QuizResult result = result(3000L, "result-public-id", parentPlaySession, parentQuizSession, userId);
+        QuizRetryRequest request = request(existing.getClientSessionId(), null, null, null);
+        mockBaseData(userId, result, parentPlaySession, parentQuizSession);
+        when(quizPlaySessionRepository.findByClientSessionId(request.getClientSessionId()))
+                .thenReturn(Optional.of(existing));
+
+        assertThatThrownBy(() -> quizResultRetryWrongService.retryWrong(userId, result.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.CONFLICT);
+    }
+
+    private void mockBaseData(
+            Long userId,
+            QuizResult result,
+            QuizPlaySession parentPlaySession,
+            QuizSession parentQuizSession
+    ) {
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId))
+                .thenReturn(Optional.of(result));
+        when(quizPlaySessionRepository.findByIdAndUserId(parentPlaySession.getId(), userId))
+                .thenReturn(Optional.of(parentPlaySession));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(parentQuizSession.getId(), userId))
+                .thenReturn(Optional.of(parentQuizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(parentQuizSession.getSubjectId(), userId))
+                .thenReturn(Optional.of(subject(parentQuizSession.getSubjectId(), userId)));
+    }
+
+    private void mockParentQuestionData(
+            QuizSession parentQuizSession,
+            Long userId,
+            List<Question> questions,
+            List<QuizPlayAnswer> playAnswers,
+            List<QuestionOption> options,
+            List<QuestionAnswer> answers
+    ) {
+        List<Long> questionIds = questions.stream().map(Question::getId).toList();
+        when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(parentQuizSession.getId(), userId))
+                .thenReturn(questions);
+        when(quizPlayAnswerRepository.findAllByPlaySessionId(playAnswers.get(0).getPlaySessionId()))
+                .thenReturn(playAnswers);
+        when(questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(questionIds))
+                .thenReturn(options);
+        when(questionAnswerRepository.findAllByQuestionIdIn(questionIds))
+                .thenReturn(answers);
+    }
+
+    private void mockChildSaves() {
+        AtomicLong questionId = new AtomicLong(9000L);
+        when(quizSessionRepository.save(any(QuizSession.class)))
+                .thenAnswer(invocation -> {
+                    QuizSession quizSession = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(quizSession, "id", 600L);
+                    return quizSession;
+                });
+        when(quizSessionScopeRepository.saveAll(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(questionRepository.save(any(Question.class)))
+                .thenAnswer(invocation -> {
+                    Question question = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(question, "id", questionId.incrementAndGet());
+                    return question;
+                });
+        when(questionOptionRepository.saveAll(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(questionAnswerRepository.save(any(QuestionAnswer.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(quizPlaySessionRepository.save(any(QuizPlaySession.class)))
+                .thenAnswer(invocation -> {
+                    QuizPlaySession playSession = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(playSession, "id", 800L);
+                    return playSession;
+                });
+    }
+
+    private Subject subject(Long id, Long userId) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        return subject;
+    }
+
+    private QuizSession quizSession(
+            Long id,
+            String publicId,
+            Long userId,
+            Long subjectId,
+            String status,
+            Integer questionCount
+    ) {
+        QuizSession quizSession = QuizSession.create(
+                publicId,
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                questionCount,
+                "one_by_one",
+                true,
+                "per_question",
+                60,
+                "medium",
+                status,
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizPlaySession firstPlaySession(Long id, String clientSessionId, QuizSession quizSession) {
+        QuizPlaySession playSession = QuizPlaySession.createFirst(
+                clientSessionId,
+                quizSession.getId(),
+                quizSession.getUserId(),
+                quizSession.getSubjectId(),
+                false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+
+    private QuizPlaySession retryWrongPlaySession(
+            Long id,
+            String clientSessionId,
+            QuizSession childQuizSession,
+            QuizPlaySession parentPlaySession,
+            QuizSession parentQuizSession
+    ) {
+        QuizPlaySession playSession = QuizPlaySession.createRetryWrong(
+                clientSessionId,
+                childQuizSession.getId(),
+                childQuizSession.getUserId(),
+                childQuizSession.getSubjectId(),
+                parentPlaySession.getId(),
+                parentQuizSession.getId(),
+                parentPlaySession.getGeneration() + 1,
+                true,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+
+    private QuizResult result(
+            Long id,
+            String publicId,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Long userId
+    ) {
+        QuizResult result = QuizResult.create(
+                publicId,
+                playSession.getId(),
+                quizSession.getId(),
+                userId,
+                quizSession.getSubjectId(),
+                2,
+                1,
+                1,
+                0,
+                50,
+                430000,
+                1,
+                4,
+                false,
+                null,
+                true,
+                false
+        );
+        ReflectionTestUtils.setField(result, "id", id);
+        return result;
+    }
+
+    private Question question(Long id, String publicId, QuizSession quizSession, Integer displayOrder) {
+        Question question = newEntity(Question.class);
+        ReflectionTestUtils.setField(question, "id", id);
+        ReflectionTestUtils.setField(question, "publicId", publicId);
+        ReflectionTestUtils.setField(question, "quizSessionId", quizSession.getId());
+        ReflectionTestUtils.setField(question, "userId", quizSession.getUserId());
+        ReflectionTestUtils.setField(question, "subjectId", quizSession.getSubjectId());
+        ReflectionTestUtils.setField(question, "chapterId", 100L + displayOrder);
+        ReflectionTestUtils.setField(question, "partId", 200L + displayOrder);
+        ReflectionTestUtils.setField(question, "questionType", "multiple_choice");
+        ReflectionTestUtils.setField(question, "difficulty", "medium");
+        ReflectionTestUtils.setField(question, "summary", "핵심 개념 확인");
+        ReflectionTestUtils.setField(question, "body", "문제 " + displayOrder);
+        ReflectionTestUtils.setField(question, "correctExplanation", "정답 해설");
+        ReflectionTestUtils.setField(question, "incorrectExplanation", "오답 해설");
+        ReflectionTestUtils.setField(question, "displayOrder", displayOrder);
+        return question;
+    }
+
+    private QuestionOption option(Long id, Long questionId, Integer optionNumber, String content, Boolean correct) {
+        QuestionOption option = newEntity(QuestionOption.class);
+        ReflectionTestUtils.setField(option, "id", id);
+        ReflectionTestUtils.setField(option, "questionId", questionId);
+        ReflectionTestUtils.setField(option, "optionNumber", optionNumber);
+        ReflectionTestUtils.setField(option, "content", content);
+        ReflectionTestUtils.setField(option, "correct", correct);
+        return option;
+    }
+
+    private QuestionAnswer answer(Long id, Long questionId, String answerValue) {
+        QuestionAnswer answer = newEntity(QuestionAnswer.class);
+        ReflectionTestUtils.setField(answer, "id", id);
+        ReflectionTestUtils.setField(answer, "questionId", questionId);
+        ReflectionTestUtils.setField(answer, "answerValue", answerValue);
+        return answer;
+    }
+
+    private QuizPlayAnswer playAnswer(
+            Long playSessionId,
+            Long questionId,
+            Long userId,
+            Long selectedOptionId,
+            Boolean correctServer,
+            Boolean skipped
+    ) {
+        return QuizPlayAnswer.create(
+                playSessionId,
+                questionId,
+                userId,
+                selectedOptionId,
+                null,
+                correctServer,
+                correctServer,
+                skipped,
+                15000,
+                false
+        );
+    }
+
+    private QuizRetryRequest request(
+            String clientSessionId,
+            Boolean questionShuffled,
+            Boolean optionShuffled,
+            String shuffleSeed
+    ) {
+        QuizRetryRequest request = new QuizRetryRequest();
+        ReflectionTestUtils.setField(request, "clientSessionId", clientSessionId);
+        ReflectionTestUtils.setField(request, "questionShuffled", questionShuffled);
+        ReflectionTestUtils.setField(request, "optionShuffled", optionShuffled);
+        ReflectionTestUtils.setField(request, "shuffleSeed", shuffleSeed);
+        return request;
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+
+    private <T> List<T> toList(Iterable<T> values) {
+        List<T> result = new ArrayList<>();
+        values.forEach(result::add);
+        return result;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private <T> ArgumentCaptor<Iterable<T>> iterableCaptor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(Iterable.class);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.f1.quiket.domain.gamification.service.GamificationRewardService;
+import com.f1.quiket.domain.gamification.service.QuizRewardResult;
 import com.f1.quiket.domain.quiz.dto.QuizAnswerSubmitItem;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
@@ -27,6 +29,8 @@ import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.subject.entity.Subject;
 import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import java.util.ArrayList;
@@ -47,6 +51,8 @@ class QuizResultSubmitServiceTest {
     private QuizPlaySessionRepository quizPlaySessionRepository;
     private QuizPlayAnswerRepository quizPlayAnswerRepository;
     private QuizResultRepository quizResultRepository;
+    private UserRepository userRepository;
+    private GamificationRewardService gamificationRewardService;
     private QuizResultSubmitService quizResultSubmitService;
 
     @BeforeEach
@@ -59,6 +65,8 @@ class QuizResultSubmitServiceTest {
         quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
         quizPlayAnswerRepository = mock(QuizPlayAnswerRepository.class);
         quizResultRepository = mock(QuizResultRepository.class);
+        userRepository = mock(UserRepository.class);
+        gamificationRewardService = mock(GamificationRewardService.class);
         quizResultSubmitService = new QuizResultSubmitService(
                 quizSessionRepository,
                 subjectRepository,
@@ -67,13 +75,16 @@ class QuizResultSubmitServiceTest {
                 questionAnswerRepository,
                 quizPlaySessionRepository,
                 quizPlayAnswerRepository,
-                quizResultRepository
+                quizResultRepository,
+                userRepository,
+                gamificationRewardService
         );
     }
 
     @Test
     void submit_creates_result_with_server_grading() {
         Long userId = 1L;
+        User user = user(userId, 12, 360, 3);
         Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
         QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
         QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
@@ -87,9 +98,10 @@ class QuizResultSubmitServiceTest {
                 430000,
                 List.of(answerItem(question.getPublicId(), String.valueOf(correctOption.getId()), true, false))
         );
-        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(correctOption, wrongOption), List.of(answer));
+        mockSubmitData(user, subject, quizSession, playSession, List.of(question), List.of(correctOption, wrongOption), List.of(answer));
         when(quizResultRepository.findByPlaySessionId(playSession.getId()))
                 .thenReturn(Optional.empty());
+        mockReward(user, playSession, quizSession, 1, 1, 4, false, null, 3);
         when(quizResultRepository.save(any(QuizResult.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -106,7 +118,10 @@ class QuizResultSubmitServiceTest {
         assertThat(outcome.getResponse().getAccuracyPct()).isEqualTo(100);
         assertThat(outcome.getResponse().getScoreMatched()).isTrue();
         assertThat(outcome.getResponse().getAbuseFlagged()).isFalse();
-        assertThat(outcome.getResponse().getRewards().getDotoriEarned()).isZero();
+        assertThat(outcome.getResponse().getRewards().getDotoriEarned()).isEqualTo(1);
+        assertThat(outcome.getResponse().getRewards().getXpEarned()).isEqualTo(4);
+        assertThat(outcome.getResponse().getRewards().getCurrentDotoriBalance()).isEqualTo(13);
+        assertThat(outcome.getResponse().getRewards().getCurrentXpTotal()).isEqualTo(364);
         assertThat(outcome.getResponse().getReviewItems()).hasSize(1);
         assertThat(outcome.getResponse().getReviewItems().get(0).getCorrectServer()).isTrue();
         assertThat(playSession.getStatus()).isEqualTo("submitted");
@@ -127,11 +142,15 @@ class QuizResultSubmitServiceTest {
         assertThat(savedResult.getAccuracyPct()).isEqualTo(100);
         assertThat(savedResult.getScoreMatched()).isTrue();
         assertThat(savedResult.getAbuseFlagged()).isFalse();
+        assertThat(savedResult.getDotoriEarned()).isEqualTo(1);
+        assertThat(savedResult.getXpEarned()).isEqualTo(4);
+        verify(gamificationRewardService).applyQuizReward(user, playSession, quizSession, 1);
     }
 
     @Test
     void submit_returns_existing_result_when_duplicate_request_is_retried() {
         Long userId = 1L;
+        User user = user(userId, 13, 364, 3);
         Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
         QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
         QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
@@ -146,7 +165,7 @@ class QuizResultSubmitServiceTest {
                 430000,
                 List.of(answerItem(question.getPublicId(), String.valueOf(option.getId()), true, false))
         );
-        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
+        mockSubmitData(user, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
         when(quizResultRepository.findByPlaySessionId(playSession.getId()))
                 .thenReturn(Optional.of(existingResult));
         when(quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId()))
@@ -157,13 +176,16 @@ class QuizResultSubmitServiceTest {
         assertThat(outcome.isCreated()).isFalse();
         assertThat(outcome.getResponse().getResultId()).isEqualTo("result-public-id");
         assertThat(outcome.getResponse().getCorrectCount()).isEqualTo(1);
+        assertThat(outcome.getResponse().getRewards().getCurrentDotoriBalance()).isEqualTo(13);
         verify(quizPlayAnswerRepository, never()).saveAll(any());
         verify(quizResultRepository, never()).save(any());
+        verify(gamificationRewardService, never()).applyQuizReward(any(), any(), any(), any());
     }
 
     @Test
     void submit_flags_score_mismatch_and_abuse_when_client_score_differs() {
         Long userId = 1L;
+        User user = user(userId, 12, 360, 3);
         Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
         QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
         QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
@@ -183,7 +205,7 @@ class QuizResultSubmitServiceTest {
                 )
         );
         mockSubmitData(
-                userId,
+                user,
                 subject,
                 quizSession,
                 playSession,
@@ -193,6 +215,7 @@ class QuizResultSubmitServiceTest {
         );
         when(quizResultRepository.findByPlaySessionId(playSession.getId()))
                 .thenReturn(Optional.empty());
+        mockReward(user, playSession, quizSession, 1, 1, 4, false, null, 3);
         when(quizResultRepository.save(any(QuizResult.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -207,6 +230,7 @@ class QuizResultSubmitServiceTest {
     @Test
     void submit_throws_invalid_option_when_answer_question_is_missing() {
         Long userId = 1L;
+        User user = user(userId, 12, 360, 3);
         Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
         QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
         QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
@@ -219,7 +243,7 @@ class QuizResultSubmitServiceTest {
                 430000,
                 List.of(answerItem("unknown-question-id", String.valueOf(option.getId()), true, false))
         );
-        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
+        mockSubmitData(user, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
         when(quizResultRepository.findByPlaySessionId(playSession.getId()))
                 .thenReturn(Optional.empty());
 
@@ -230,7 +254,7 @@ class QuizResultSubmitServiceTest {
     }
 
     private void mockSubmitData(
-            Long userId,
+            User user,
             Subject subject,
             QuizSession quizSession,
             QuizPlaySession playSession,
@@ -238,6 +262,9 @@ class QuizResultSubmitServiceTest {
             List<QuestionOption> options,
             List<QuestionAnswer> answers
     ) {
+        Long userId = user.getId();
+        when(userRepository.findByIdAndDeletedAtIsNull(userId))
+                .thenReturn(Optional.of(user));
         when(quizPlaySessionRepository.findByClientSessionId(playSession.getClientSessionId()))
                 .thenReturn(Optional.of(playSession));
         when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
@@ -277,6 +304,41 @@ class QuizResultSubmitServiceTest {
         ReflectionTestUtils.setField(item, "answerElapsedMs", 15000);
         ReflectionTestUtils.setField(item, "marked", false);
         return item;
+    }
+
+    private void mockReward(
+            User user,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Integer correctCount,
+            Integer dotoriEarned,
+            Integer xpEarned,
+            Boolean leveledUp,
+            Integer newLevel,
+            Integer levelAfter
+    ) {
+        when(gamificationRewardService.applyQuizReward(user, playSession, quizSession, correctCount))
+                .thenAnswer(invocation -> {
+                    user.applyQuizReward(dotoriEarned, xpEarned, levelAfter);
+                    return new QuizRewardResult(
+                            dotoriEarned,
+                            xpEarned,
+                            leveledUp,
+                            newLevel,
+                            user.getDotoriBalance(),
+                            user.getXpTotal()
+                    );
+                });
+    }
+
+    private User user(Long id, Integer dotoriBalance, Integer xpTotal, Integer currentLevel) {
+        User user = User.create("user-public-id", "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", id);
+        ReflectionTestUtils.setField(user, "emailVerified", true);
+        ReflectionTestUtils.setField(user, "dotoriBalance", dotoriBalance);
+        ReflectionTestUtils.setField(user, "xpTotal", xpTotal);
+        ReflectionTestUtils.setField(user, "currentLevel", currentLevel);
+        return user;
     }
 
     private Subject subject(Long id, String publicId, Long userId, String name) {
@@ -384,6 +446,10 @@ class QuizResultSubmitServiceTest {
                 skipCount,
                 accuracyPct,
                 playSession.getElapsedMs(),
+                1,
+                4,
+                false,
+                null,
                 true,
                 false
         );

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
@@ -1,0 +1,430 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.quiz.dto.QuizAnswerSubmitItem;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
+import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
+import com.f1.quiket.domain.quiz.entity.Question;
+import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
+import com.f1.quiket.domain.quiz.entity.QuestionOption;
+import com.f1.quiket.domain.quiz.entity.QuizPlayAnswer;
+import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import com.f1.quiket.domain.quiz.entity.QuizResult;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuestionAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionOptionRepository;
+import com.f1.quiket.domain.quiz.repository.QuestionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlayAnswerRepository;
+import com.f1.quiket.domain.quiz.repository.QuizPlaySessionRepository;
+import com.f1.quiket.domain.quiz.repository.QuizResultRepository;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizResultSubmitServiceTest {
+
+    private QuizSessionRepository quizSessionRepository;
+    private SubjectRepository subjectRepository;
+    private QuestionRepository questionRepository;
+    private QuestionOptionRepository questionOptionRepository;
+    private QuestionAnswerRepository questionAnswerRepository;
+    private QuizPlaySessionRepository quizPlaySessionRepository;
+    private QuizPlayAnswerRepository quizPlayAnswerRepository;
+    private QuizResultRepository quizResultRepository;
+    private QuizResultSubmitService quizResultSubmitService;
+
+    @BeforeEach
+    void setUp() {
+        quizSessionRepository = mock(QuizSessionRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        questionRepository = mock(QuestionRepository.class);
+        questionOptionRepository = mock(QuestionOptionRepository.class);
+        questionAnswerRepository = mock(QuestionAnswerRepository.class);
+        quizPlaySessionRepository = mock(QuizPlaySessionRepository.class);
+        quizPlayAnswerRepository = mock(QuizPlayAnswerRepository.class);
+        quizResultRepository = mock(QuizResultRepository.class);
+        quizResultSubmitService = new QuizResultSubmitService(
+                quizSessionRepository,
+                subjectRepository,
+                questionRepository,
+                questionOptionRepository,
+                questionAnswerRepository,
+                quizPlaySessionRepository,
+                quizPlayAnswerRepository,
+                quizResultRepository
+        );
+    }
+
+    @Test
+    void submit_creates_result_with_server_grading() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption correctOption = option(1000L, question.getId(), 1, "정답", true);
+        QuestionOption wrongOption = option(1001L, question.getId(), 2, "오답", false);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                430000,
+                List.of(answerItem(question.getPublicId(), String.valueOf(correctOption.getId()), true, false))
+        );
+        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(correctOption, wrongOption), List.of(answer));
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.empty());
+        when(quizResultRepository.save(any(QuizResult.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(userId, request);
+
+        assertThat(outcome.isCreated()).isTrue();
+        assertThat(outcome.getResponse().getPlaySessionId()).isEqualTo(playSession.getClientSessionId());
+        assertThat(outcome.getResponse().getQuizSessionId()).isEqualTo(quizSession.getPublicId());
+        assertThat(outcome.getResponse().getSubjectId()).isEqualTo(subject.getPublicId());
+        assertThat(outcome.getResponse().getTotalCount()).isEqualTo(1);
+        assertThat(outcome.getResponse().getCorrectCount()).isEqualTo(1);
+        assertThat(outcome.getResponse().getWrongCount()).isZero();
+        assertThat(outcome.getResponse().getSkipCount()).isZero();
+        assertThat(outcome.getResponse().getAccuracyPct()).isEqualTo(100);
+        assertThat(outcome.getResponse().getScoreMatched()).isTrue();
+        assertThat(outcome.getResponse().getAbuseFlagged()).isFalse();
+        assertThat(outcome.getResponse().getRewards().getDotoriEarned()).isZero();
+        assertThat(outcome.getResponse().getReviewItems()).hasSize(1);
+        assertThat(outcome.getResponse().getReviewItems().get(0).getCorrectServer()).isTrue();
+        assertThat(playSession.getStatus()).isEqualTo("submitted");
+        assertThat(playSession.getElapsedMs()).isEqualTo(430000);
+
+        ArgumentCaptor<Iterable<QuizPlayAnswer>> answersCaptor = answerIterableCaptor();
+        verify(quizPlayAnswerRepository).saveAll(answersCaptor.capture());
+        List<QuizPlayAnswer> savedAnswers = toList(answersCaptor.getValue());
+        assertThat(savedAnswers).hasSize(1);
+        assertThat(savedAnswers.get(0).getQuestionId()).isEqualTo(question.getId());
+        assertThat(savedAnswers.get(0).getSelectedOptionId()).isEqualTo(correctOption.getId());
+        assertThat(savedAnswers.get(0).getCorrectServer()).isTrue();
+
+        ArgumentCaptor<QuizResult> resultCaptor = ArgumentCaptor.forClass(QuizResult.class);
+        verify(quizResultRepository).save(resultCaptor.capture());
+        QuizResult savedResult = resultCaptor.getValue();
+        assertThat(savedResult.getCorrectCount()).isEqualTo(1);
+        assertThat(savedResult.getAccuracyPct()).isEqualTo(100);
+        assertThat(savedResult.getScoreMatched()).isTrue();
+        assertThat(savedResult.getAbuseFlagged()).isFalse();
+    }
+
+    @Test
+    void submit_returns_existing_result_when_duplicate_request_is_retried() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption option = option(1000L, question.getId(), 1, "정답", true);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizResult existingResult = result(3000L, "result-public-id", playSession, quizSession, subject, 1, 1, 0, 0, 100);
+        QuizPlayAnswer existingAnswer = playAnswer(playSession.getId(), question.getId(), userId, option.getId(), true, false);
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                430000,
+                List.of(answerItem(question.getPublicId(), String.valueOf(option.getId()), true, false))
+        );
+        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.of(existingResult));
+        when(quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId()))
+                .thenReturn(List.of(existingAnswer));
+
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(userId, request);
+
+        assertThat(outcome.isCreated()).isFalse();
+        assertThat(outcome.getResponse().getResultId()).isEqualTo("result-public-id");
+        assertThat(outcome.getResponse().getCorrectCount()).isEqualTo(1);
+        verify(quizPlayAnswerRepository, never()).saveAll(any());
+        verify(quizResultRepository, never()).save(any());
+    }
+
+    @Test
+    void submit_flags_score_mismatch_and_abuse_when_client_score_differs() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question1 = question(901L, "question-public-id-1", quizSession.getId(), userId, subject.getId(), 1);
+        Question question2 = question(902L, "question-public-id-2", quizSession.getId(), userId, subject.getId(), 2);
+        QuestionOption q1Correct = option(1001L, question1.getId(), 1, "정답", true);
+        QuestionOption q2Wrong = option(1002L, question2.getId(), 2, "오답", false);
+        QuestionAnswer answer1 = answer(2001L, question1.getId(), "1");
+        QuestionAnswer answer2 = answer(2002L, question2.getId(), "1");
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                120000,
+                List.of(
+                        answerItem(question1.getPublicId(), String.valueOf(q1Correct.getId()), true, false),
+                        answerItem(question2.getPublicId(), String.valueOf(q2Wrong.getId()), true, false)
+                )
+        );
+        mockSubmitData(
+                userId,
+                subject,
+                quizSession,
+                playSession,
+                List.of(question1, question2),
+                List.of(q1Correct, q2Wrong),
+                List.of(answer1, answer2)
+        );
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.empty());
+        when(quizResultRepository.save(any(QuizResult.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(userId, request);
+
+        assertThat(outcome.getResponse().getCorrectCount()).isEqualTo(1);
+        assertThat(outcome.getResponse().getWrongCount()).isEqualTo(1);
+        assertThat(outcome.getResponse().getScoreMatched()).isFalse();
+        assertThat(outcome.getResponse().getAbuseFlagged()).isTrue();
+    }
+
+    @Test
+    void submit_throws_invalid_option_when_answer_question_is_missing() {
+        Long userId = 1L;
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption option = option(1000L, question.getId(), 1, "정답", true);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                430000,
+                List.of(answerItem("unknown-question-id", String.valueOf(option.getId()), true, false))
+        );
+        mockSubmitData(userId, subject, quizSession, playSession, List.of(question), List.of(option), List.of(answer));
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> quizResultSubmitService.submit(userId, request))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_OPTION_INVALID);
+    }
+
+    private void mockSubmitData(
+            Long userId,
+            Subject subject,
+            QuizSession quizSession,
+            QuizPlaySession playSession,
+            List<Question> questions,
+            List<QuestionOption> options,
+            List<QuestionAnswer> answers
+    ) {
+        when(quizPlaySessionRepository.findByClientSessionId(playSession.getClientSessionId()))
+                .thenReturn(Optional.of(playSession));
+        when(quizSessionRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(quizSession.getPublicId(), userId))
+                .thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subject.getId(), userId))
+                .thenReturn(Optional.of(subject));
+        when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(quizSession.getId(), userId))
+                .thenReturn(questions);
+        when(questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(
+                questions.stream().map(Question::getId).toList()
+        )).thenReturn(options);
+        when(questionAnswerRepository.findAllByQuestionIdIn(questions.stream().map(Question::getId).toList()))
+                .thenReturn(answers);
+    }
+
+    private QuizResultSubmitRequest request(
+            String clientSessionId,
+            String quizSessionId,
+            Integer elapsedMs,
+            List<QuizAnswerSubmitItem> answers
+    ) {
+        QuizResultSubmitRequest request = newEntity(QuizResultSubmitRequest.class);
+        ReflectionTestUtils.setField(request, "clientSessionId", clientSessionId);
+        ReflectionTestUtils.setField(request, "quizSessionId", quizSessionId);
+        ReflectionTestUtils.setField(request, "playType", "first");
+        ReflectionTestUtils.setField(request, "elapsedMs", elapsedMs);
+        ReflectionTestUtils.setField(request, "answers", answers);
+        return request;
+    }
+
+    private QuizAnswerSubmitItem answerItem(String questionId, String selectedOptionId, Boolean correctClient, Boolean skipped) {
+        QuizAnswerSubmitItem item = newEntity(QuizAnswerSubmitItem.class);
+        ReflectionTestUtils.setField(item, "questionId", questionId);
+        ReflectionTestUtils.setField(item, "selectedOptionId", selectedOptionId);
+        ReflectionTestUtils.setField(item, "correctClient", correctClient);
+        ReflectionTestUtils.setField(item, "skipped", skipped);
+        ReflectionTestUtils.setField(item, "answerElapsedMs", 15000);
+        ReflectionTestUtils.setField(item, "marked", false);
+        return item;
+    }
+
+    private Subject subject(Long id, String publicId, Long userId, String name) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId, String status) {
+        QuizSession quizSession = QuizSession.create(
+                publicId,
+                userId,
+                subjectId,
+                "multiple_choice",
+                4,
+                1,
+                "one_by_one",
+                true,
+                "per_question",
+                60,
+                "medium",
+                status,
+                "quiz-job-id"
+        );
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        return quizSession;
+    }
+
+    private QuizPlaySession playSession(Long id, String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        QuizPlaySession playSession = QuizPlaySession.createFirst(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+
+    private Question question(Long id, String publicId, Long quizSessionId, Long userId, Long subjectId, Integer displayOrder) {
+        Question question = newEntity(Question.class);
+        ReflectionTestUtils.setField(question, "id", id);
+        ReflectionTestUtils.setField(question, "publicId", publicId);
+        ReflectionTestUtils.setField(question, "quizSessionId", quizSessionId);
+        ReflectionTestUtils.setField(question, "userId", userId);
+        ReflectionTestUtils.setField(question, "subjectId", subjectId);
+        ReflectionTestUtils.setField(question, "chapterId", 100L + displayOrder);
+        ReflectionTestUtils.setField(question, "partId", 200L + displayOrder);
+        ReflectionTestUtils.setField(question, "questionType", "multiple_choice");
+        ReflectionTestUtils.setField(question, "difficulty", "medium");
+        ReflectionTestUtils.setField(question, "summary", "핵심 개념 확인");
+        ReflectionTestUtils.setField(question, "body", "다음 중 올바른 것은?");
+        ReflectionTestUtils.setField(question, "correctExplanation", "정답 해설");
+        ReflectionTestUtils.setField(question, "incorrectExplanation", "오답 해설");
+        ReflectionTestUtils.setField(question, "displayOrder", displayOrder);
+        return question;
+    }
+
+    private QuestionOption option(Long id, Long questionId, Integer optionNumber, String content, Boolean correct) {
+        QuestionOption option = newEntity(QuestionOption.class);
+        ReflectionTestUtils.setField(option, "id", id);
+        ReflectionTestUtils.setField(option, "questionId", questionId);
+        ReflectionTestUtils.setField(option, "optionNumber", optionNumber);
+        ReflectionTestUtils.setField(option, "content", content);
+        ReflectionTestUtils.setField(option, "correct", correct);
+        return option;
+    }
+
+    private QuestionAnswer answer(Long id, Long questionId, String answerValue) {
+        QuestionAnswer answer = newEntity(QuestionAnswer.class);
+        ReflectionTestUtils.setField(answer, "id", id);
+        ReflectionTestUtils.setField(answer, "questionId", questionId);
+        ReflectionTestUtils.setField(answer, "answerValue", answerValue);
+        return answer;
+    }
+
+    private QuizResult result(
+            Long id,
+            String publicId,
+            QuizPlaySession playSession,
+            QuizSession quizSession,
+            Subject subject,
+            Integer totalCount,
+            Integer correctCount,
+            Integer wrongCount,
+            Integer skipCount,
+            Integer accuracyPct
+    ) {
+        QuizResult result = QuizResult.create(
+                publicId,
+                playSession.getId(),
+                quizSession.getId(),
+                playSession.getUserId(),
+                subject.getId(),
+                totalCount,
+                correctCount,
+                wrongCount,
+                skipCount,
+                accuracyPct,
+                playSession.getElapsedMs(),
+                true,
+                false
+        );
+        ReflectionTestUtils.setField(result, "id", id);
+        return result;
+    }
+
+    private QuizPlayAnswer playAnswer(
+            Long playSessionId,
+            Long questionId,
+            Long userId,
+            Long selectedOptionId,
+            Boolean correctServer,
+            Boolean skipped
+    ) {
+        return QuizPlayAnswer.create(
+                playSessionId,
+                questionId,
+                userId,
+                selectedOptionId,
+                null,
+                correctServer,
+                correctServer,
+                skipped,
+                15000,
+                false
+        );
+    }
+
+    private List<QuizPlayAnswer> toList(Iterable<QuizPlayAnswer> answers) {
+        List<QuizPlayAnswer> result = new ArrayList<>();
+        answers.forEach(result::add);
+        return result;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private ArgumentCaptor<Iterable<QuizPlayAnswer>> answerIterableCaptor() {
+        return (ArgumentCaptor) ArgumentCaptor.forClass(Iterable.class);
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
@@ -77,7 +77,8 @@ class QuizResultSubmitServiceTest {
                 quizPlayAnswerRepository,
                 quizResultRepository,
                 userRepository,
-                gamificationRewardService
+                gamificationRewardService,
+                new QuizResultResponseAssembler()
         );
     }
 

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
@@ -264,6 +264,41 @@ class QuizResultSubmitServiceTest {
     }
 
     @Test
+    void submit_creates_retry_wrong_result_with_review_reward() {
+        Long userId = 1L;
+        User user = user(userId, 13, 364, 3);
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = retryWrongPlaySession(702L, "retry-wrong-client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption correctOption = option(1000L, question.getId(), 1, "정답", true);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                "retry_wrong",
+                210000,
+                List.of(answerItem(question.getPublicId(), String.valueOf(correctOption.getId()), true, false))
+        );
+        mockSubmitData(user, subject, quizSession, playSession, List.of(question), List.of(correctOption), List.of(answer));
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.empty());
+        mockReward(user, playSession, quizSession, 1, 0, 3, false, null, 3);
+        when(quizResultRepository.save(any(QuizResult.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(userId, request);
+
+        assertThat(outcome.isCreated()).isTrue();
+        assertThat(outcome.getResponse().getPlaySessionId()).isEqualTo(playSession.getClientSessionId());
+        assertThat(outcome.getResponse().getRewards().getDotoriEarned()).isZero();
+        assertThat(outcome.getResponse().getRewards().getXpEarned()).isEqualTo(3);
+        assertThat(outcome.getResponse().getRewards().getCurrentDotoriBalance()).isEqualTo(13);
+        assertThat(outcome.getResponse().getRewards().getCurrentXpTotal()).isEqualTo(367);
+        verify(gamificationRewardService).applyQuizReward(user, playSession, quizSession, 1);
+    }
+
+    @Test
     void submit_throws_invalid_option_when_answer_question_is_missing() {
         Long userId = 1L;
         User user = user(userId, 12, 360, 3);
@@ -438,6 +473,23 @@ class QuizResultSubmitServiceTest {
                 userId,
                 subjectId,
                 false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+
+    private QuizPlaySession retryWrongPlaySession(Long id, String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        QuizPlaySession playSession = QuizPlaySession.createRetryWrong(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                700L,
+                500L,
+                1,
+                true,
                 true,
                 null
         );

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultSubmitServiceTest.java
@@ -229,6 +229,41 @@ class QuizResultSubmitServiceTest {
     }
 
     @Test
+    void submit_creates_retry_all_result_with_review_reward() {
+        Long userId = 1L;
+        User user = user(userId, 13, 364, 3);
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId(), "completed");
+        QuizPlaySession playSession = retryAllPlaySession(701L, "retry-client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption correctOption = option(1000L, question.getId(), 1, "정답", true);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        QuizResultSubmitRequest request = request(
+                playSession.getClientSessionId(),
+                quizSession.getPublicId(),
+                "retry_all",
+                210000,
+                List.of(answerItem(question.getPublicId(), String.valueOf(correctOption.getId()), true, false))
+        );
+        mockSubmitData(user, subject, quizSession, playSession, List.of(question), List.of(correctOption), List.of(answer));
+        when(quizResultRepository.findByPlaySessionId(playSession.getId()))
+                .thenReturn(Optional.empty());
+        mockReward(user, playSession, quizSession, 1, 0, 3, false, null, 3);
+        when(quizResultRepository.save(any(QuizResult.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        QuizResultSubmitOutcome outcome = quizResultSubmitService.submit(userId, request);
+
+        assertThat(outcome.isCreated()).isTrue();
+        assertThat(outcome.getResponse().getPlaySessionId()).isEqualTo(playSession.getClientSessionId());
+        assertThat(outcome.getResponse().getRewards().getDotoriEarned()).isZero();
+        assertThat(outcome.getResponse().getRewards().getXpEarned()).isEqualTo(3);
+        assertThat(outcome.getResponse().getRewards().getCurrentDotoriBalance()).isEqualTo(13);
+        assertThat(outcome.getResponse().getRewards().getCurrentXpTotal()).isEqualTo(367);
+        verify(gamificationRewardService).applyQuizReward(user, playSession, quizSession, 1);
+    }
+
+    @Test
     void submit_throws_invalid_option_when_answer_question_is_missing() {
         Long userId = 1L;
         User user = user(userId, 12, 360, 3);
@@ -287,10 +322,20 @@ class QuizResultSubmitServiceTest {
             Integer elapsedMs,
             List<QuizAnswerSubmitItem> answers
     ) {
+        return request(clientSessionId, quizSessionId, "first", elapsedMs, answers);
+    }
+
+    private QuizResultSubmitRequest request(
+            String clientSessionId,
+            String quizSessionId,
+            String playType,
+            Integer elapsedMs,
+            List<QuizAnswerSubmitItem> answers
+    ) {
         QuizResultSubmitRequest request = newEntity(QuizResultSubmitRequest.class);
         ReflectionTestUtils.setField(request, "clientSessionId", clientSessionId);
         ReflectionTestUtils.setField(request, "quizSessionId", quizSessionId);
-        ReflectionTestUtils.setField(request, "playType", "first");
+        ReflectionTestUtils.setField(request, "playType", playType);
         ReflectionTestUtils.setField(request, "elapsedMs", elapsedMs);
         ReflectionTestUtils.setField(request, "answers", answers);
         return request;
@@ -374,6 +419,20 @@ class QuizResultSubmitServiceTest {
 
     private QuizPlaySession playSession(Long id, String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
         QuizPlaySession playSession = QuizPlaySession.createFirst(
+                clientSessionId,
+                quizSessionId,
+                userId,
+                subjectId,
+                false,
+                true,
+                null
+        );
+        ReflectionTestUtils.setField(playSession, "id", id);
+        return playSession;
+    }
+
+    private QuizPlaySession retryAllPlaySession(Long id, String clientSessionId, Long quizSessionId, Long userId, Long subjectId) {
+        QuizPlaySession playSession = QuizPlaySession.createRetryAll(
                 clientSessionId,
                 quizSessionId,
                 userId,

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
@@ -16,6 +16,7 @@ import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
 import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.event.QuizGenerationEnqueueRequestedEvent;
 import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
@@ -28,6 +29,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class QuizSessionCreateServiceTest {
@@ -37,8 +39,8 @@ class QuizSessionCreateServiceTest {
     private QuizSessionRepository quizSessionRepository;
     private QuizSessionScopeRepository quizSessionScopeRepository;
     private QuizGenerationJobRepository quizGenerationJobRepository;
-    private QuizGenerationQueue quizGenerationQueue;
     private QuizGenerationLockStore quizGenerationLockStore;
+    private ApplicationEventPublisher eventPublisher;
     private QuizSessionCreateService quizSessionCreateService;
 
     @BeforeEach
@@ -48,16 +50,16 @@ class QuizSessionCreateServiceTest {
         quizSessionRepository = mock(QuizSessionRepository.class);
         quizSessionScopeRepository = mock(QuizSessionScopeRepository.class);
         quizGenerationJobRepository = mock(QuizGenerationJobRepository.class);
-        quizGenerationQueue = mock(QuizGenerationQueue.class);
         quizGenerationLockStore = mock(QuizGenerationLockStore.class);
+        eventPublisher = mock(ApplicationEventPublisher.class);
         quizSessionCreateService = new QuizSessionCreateService(
                 subjectRepository,
                 partRepository,
                 quizSessionRepository,
                 quizSessionScopeRepository,
                 quizGenerationJobRepository,
-                quizGenerationQueue,
-                quizGenerationLockStore
+                quizGenerationLockStore,
+                eventPublisher
         );
     }
 
@@ -98,7 +100,7 @@ class QuizSessionCreateServiceTest {
                     ReflectionTestUtils.setField(quizSession, "id", 500L);
                     return quizSession;
                 });
-        stubGenerationJobSaveAndQueue(900L, "1748130000000-0");
+        stubGenerationJobSave(900L);
 
         QuizGenerationAcceptedResponse response = quizSessionCreateService.createQuizSession(userId, request);
 
@@ -141,12 +143,13 @@ class QuizSessionCreateServiceTest {
         assertThat(savedJob.getUserId()).isEqualTo(userId);
         assertThat(savedJob.getStatus()).isEqualTo("pending");
         assertThat(savedJob.getProgressPct()).isZero();
-        assertThat(savedJob.getMqMessageId()).isEqualTo("1748130000000-0");
+        // mqMessageId는 AFTER_COMMIT 리스너가 채움 — service 단위 테스트 범위 외
 
-        ArgumentCaptor<QuizGenerationQueueMessage> messageCaptor =
-                ArgumentCaptor.forClass(QuizGenerationQueueMessage.class);
-        verify(quizGenerationQueue).enqueue(messageCaptor.capture());
-        QuizGenerationQueueMessage queueMessage = messageCaptor.getValue();
+        // 실제 Redis 큐 발행은 리스너에서 수행 — service는 이벤트 발행만 검증
+        ArgumentCaptor<QuizGenerationEnqueueRequestedEvent> eventCaptor =
+                ArgumentCaptor.forClass(QuizGenerationEnqueueRequestedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        QuizGenerationQueueMessage queueMessage = eventCaptor.getValue().message();
         assertThat(queueMessage.generationJobId()).isEqualTo(900L);
         assertThat(queueMessage.quizSessionId()).isEqualTo(500L);
         assertThat(queueMessage.quizSessionPublicId()).isEqualTo(savedSession.getPublicId());
@@ -183,7 +186,7 @@ class QuizSessionCreateServiceTest {
                 .isEqualTo(ErrorCode.QUIZ_GENERATION_IN_PROGRESS);
 
         verifyNoInteractions(subjectRepository, partRepository, quizSessionScopeRepository,
-                quizGenerationJobRepository, quizGenerationQueue);
+                quizGenerationJobRepository, eventPublisher);
     }
 
     @Test
@@ -412,7 +415,7 @@ class QuizSessionCreateServiceTest {
                     ReflectionTestUtils.setField(quizSession, "id", 501L);
                     return quizSession;
                 });
-        stubGenerationJobSaveAndQueue(901L, "1748130000000-1");
+        stubGenerationJobSave(901L);
 
         quizSessionCreateService.createQuizSession(userId, request);
 
@@ -475,14 +478,13 @@ class QuizSessionCreateServiceTest {
                 .toList();
     }
 
-    private void stubGenerationJobSaveAndQueue(Long generationJobId, String messageId) {
+    private void stubGenerationJobSave(Long generationJobId) {
         when(quizGenerationJobRepository.save(any(QuizGenerationJob.class)))
                 .thenAnswer(invocation -> {
                     QuizGenerationJob generationJob = invocation.getArgument(0);
                     ReflectionTestUtils.setField(generationJob, "id", generationJobId);
                     return generationJob;
                 });
-        when(quizGenerationQueue.enqueue(any(QuizGenerationQueueMessage.class))).thenReturn(messageId);
     }
 
     private <T> T newEntity(Class<T> type) {

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizSessionCreateServiceTest.java
@@ -13,8 +13,10 @@ import com.f1.quiket.domain.part.entity.Part;
 import com.f1.quiket.domain.part.repository.PartRepository;
 import com.f1.quiket.domain.quiz.dto.QuizCreateRequest;
 import com.f1.quiket.domain.quiz.dto.QuizGenerationAcceptedResponse;
+import com.f1.quiket.domain.quiz.entity.QuizGenerationJob;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import com.f1.quiket.domain.quiz.entity.QuizSessionScope;
+import com.f1.quiket.domain.quiz.repository.QuizGenerationJobRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
 import com.f1.quiket.domain.quiz.repository.QuizSessionScopeRepository;
 import com.f1.quiket.domain.subject.entity.Subject;
@@ -34,6 +36,8 @@ class QuizSessionCreateServiceTest {
     private PartRepository partRepository;
     private QuizSessionRepository quizSessionRepository;
     private QuizSessionScopeRepository quizSessionScopeRepository;
+    private QuizGenerationJobRepository quizGenerationJobRepository;
+    private QuizGenerationQueue quizGenerationQueue;
     private QuizGenerationLockStore quizGenerationLockStore;
     private QuizSessionCreateService quizSessionCreateService;
 
@@ -43,12 +47,16 @@ class QuizSessionCreateServiceTest {
         partRepository = mock(PartRepository.class);
         quizSessionRepository = mock(QuizSessionRepository.class);
         quizSessionScopeRepository = mock(QuizSessionScopeRepository.class);
+        quizGenerationJobRepository = mock(QuizGenerationJobRepository.class);
+        quizGenerationQueue = mock(QuizGenerationQueue.class);
         quizGenerationLockStore = mock(QuizGenerationLockStore.class);
         quizSessionCreateService = new QuizSessionCreateService(
                 subjectRepository,
                 partRepository,
                 quizSessionRepository,
                 quizSessionScopeRepository,
+                quizGenerationJobRepository,
+                quizGenerationQueue,
                 quizGenerationLockStore
         );
     }
@@ -90,6 +98,7 @@ class QuizSessionCreateServiceTest {
                     ReflectionTestUtils.setField(quizSession, "id", 500L);
                     return quizSession;
                 });
+        stubGenerationJobSaveAndQueue(900L, "1748130000000-0");
 
         QuizGenerationAcceptedResponse response = quizSessionCreateService.createQuizSession(userId, request);
 
@@ -124,6 +133,26 @@ class QuizSessionCreateServiceTest {
                 .extracting(QuizSessionScope::getPartId)
                 .containsExactly(part1.getId(), part2.getId());
 
+        ArgumentCaptor<QuizGenerationJob> jobCaptor = ArgumentCaptor.forClass(QuizGenerationJob.class);
+        verify(quizGenerationJobRepository).save(jobCaptor.capture());
+        QuizGenerationJob savedJob = jobCaptor.getValue();
+        assertThat(savedJob.getId()).isEqualTo(900L);
+        assertThat(savedJob.getQuizSessionId()).isEqualTo(500L);
+        assertThat(savedJob.getUserId()).isEqualTo(userId);
+        assertThat(savedJob.getStatus()).isEqualTo("pending");
+        assertThat(savedJob.getProgressPct()).isZero();
+        assertThat(savedJob.getMqMessageId()).isEqualTo("1748130000000-0");
+
+        ArgumentCaptor<QuizGenerationQueueMessage> messageCaptor =
+                ArgumentCaptor.forClass(QuizGenerationQueueMessage.class);
+        verify(quizGenerationQueue).enqueue(messageCaptor.capture());
+        QuizGenerationQueueMessage queueMessage = messageCaptor.getValue();
+        assertThat(queueMessage.generationJobId()).isEqualTo(900L);
+        assertThat(queueMessage.quizSessionId()).isEqualTo(500L);
+        assertThat(queueMessage.quizSessionPublicId()).isEqualTo(savedSession.getPublicId());
+        assertThat(queueMessage.jobId()).isEqualTo(savedSession.getJobId());
+        assertThat(queueMessage.userId()).isEqualTo(userId);
+
         assertThat(response.getQuizSessionId()).isEqualTo(savedSession.getPublicId());
         assertThat(response.getJobId()).isEqualTo(savedSession.getJobId());
         assertThat(response.getStatus()).isEqualTo("pending");
@@ -153,7 +182,8 @@ class QuizSessionCreateServiceTest {
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(ErrorCode.QUIZ_GENERATION_IN_PROGRESS);
 
-        verifyNoInteractions(subjectRepository, partRepository, quizSessionScopeRepository);
+        verifyNoInteractions(subjectRepository, partRepository, quizSessionScopeRepository,
+                quizGenerationJobRepository, quizGenerationQueue);
     }
 
     @Test
@@ -382,6 +412,7 @@ class QuizSessionCreateServiceTest {
                     ReflectionTestUtils.setField(quizSession, "id", 501L);
                     return quizSession;
                 });
+        stubGenerationJobSaveAndQueue(901L, "1748130000000-1");
 
         quizSessionCreateService.createQuizSession(userId, request);
 
@@ -442,6 +473,16 @@ class QuizSessionCreateServiceTest {
     private List<QuizSessionScope> toList(Iterable<QuizSessionScope> scopes) {
         return java.util.stream.StreamSupport.stream(scopes.spliterator(), false)
                 .toList();
+    }
+
+    private void stubGenerationJobSaveAndQueue(Long generationJobId, String messageId) {
+        when(quizGenerationJobRepository.save(any(QuizGenerationJob.class)))
+                .thenAnswer(invocation -> {
+                    QuizGenerationJob generationJob = invocation.getArgument(0);
+                    ReflectionTestUtils.setField(generationJob, "id", generationJobId);
+                    return generationJob;
+                });
+        when(quizGenerationQueue.enqueue(any(QuizGenerationQueueMessage.class))).thenReturn(messageId);
     }
 
     private <T> T newEntity(Class<T> type) {

--- a/src/test/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueueTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueueTest.java
@@ -1,0 +1,81 @@
+package com.f1.quiket.domain.quiz.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.core.StreamOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+class RedisQuizGenerationQueueTest {
+
+    private StringRedisTemplate stringRedisTemplate;
+    private StreamOperations<String, Object, Object> streamOperations;
+    private RedisQuizGenerationQueue redisQuizGenerationQueue;
+
+    @BeforeEach
+    void setUp() {
+        stringRedisTemplate = mock(StringRedisTemplate.class);
+        streamOperations = mock(StreamOperations.class);
+        redisQuizGenerationQueue = new RedisQuizGenerationQueue(stringRedisTemplate);
+
+        when(stringRedisTemplate.opsForStream()).thenReturn(streamOperations);
+    }
+
+    @Test
+    void enqueue_adds_generation_job_to_redis_stream() {
+        QuizGenerationQueueMessage message = new QuizGenerationQueueMessage(
+                900L,
+                500L,
+                "quiz-session-public-id",
+                "quiz-job-public-id",
+                1L
+        );
+        when(streamOperations.add(eq("quiz:generation:jobs"), any(Map.class)))
+                .thenReturn(RecordId.of("1748130000000-0"));
+
+        String messageId = redisQuizGenerationQueue.enqueue(message);
+
+        assertThat(messageId).isEqualTo("1748130000000-0");
+
+        ArgumentCaptor<Map<String, String>> recordCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(streamOperations).add(eq("quiz:generation:jobs"), recordCaptor.capture());
+        assertThat(recordCaptor.getValue())
+                .containsEntry("generationJobId", "900")
+                .containsEntry("quizSessionId", "500")
+                .containsEntry("quizSessionPublicId", "quiz-session-public-id")
+                .containsEntry("jobId", "quiz-job-public-id")
+                .containsEntry("userId", "1");
+    }
+
+    @Test
+    void enqueue_throws_service_unavailable_when_redis_fails() {
+        QuizGenerationQueueMessage message = new QuizGenerationQueueMessage(
+                900L,
+                500L,
+                "quiz-session-public-id",
+                "quiz-job-public-id",
+                1L
+        );
+        when(streamOperations.add(eq("quiz:generation:jobs"), any(Map.class)))
+                .thenThrow(new DataAccessResourceFailureException("redis down"));
+
+        assertThatThrownBy(() -> redisQuizGenerationQueue.enqueue(message))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.SERVICE_UNAVAILABLE);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueueTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueueTest.java
@@ -10,11 +10,16 @@ import static org.mockito.Mockito.when;
 
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.data.domain.Range;
+import org.springframework.data.redis.connection.Limit;
+import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.RecordId;
 import org.springframework.data.redis.core.StreamOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -77,5 +82,37 @@ class RedisQuizGenerationQueueTest {
                 .isInstanceOf(CustomException.class)
                 .extracting(exception -> ((CustomException) exception).getErrorCode())
                 .isEqualTo(ErrorCode.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    void poll_returns_oldest_generation_job_record() {
+        MapRecord<String, Object, Object> record = MapRecord
+                .create("quiz:generation:jobs", Map.<Object, Object>of(
+                        "generationJobId", "900",
+                        "quizSessionId", "500",
+                        "quizSessionPublicId", "quiz-session-public-id",
+                        "jobId", "quiz-job-public-id",
+                        "userId", "1"
+                ))
+                .withId(RecordId.of("1748130000000-0"));
+        when(streamOperations.range(eq("quiz:generation:jobs"), any(Range.class), any(Limit.class)))
+                .thenReturn(List.of(record));
+
+        Optional<QuizGenerationQueueRecord> polledRecord = redisQuizGenerationQueue.poll();
+
+        assertThat(polledRecord).isPresent();
+        assertThat(polledRecord.get().messageId()).isEqualTo("1748130000000-0");
+        assertThat(polledRecord.get().message().generationJobId()).isEqualTo(900L);
+        assertThat(polledRecord.get().message().quizSessionId()).isEqualTo(500L);
+        assertThat(polledRecord.get().message().quizSessionPublicId()).isEqualTo("quiz-session-public-id");
+        assertThat(polledRecord.get().message().jobId()).isEqualTo("quiz-job-public-id");
+        assertThat(polledRecord.get().message().userId()).isEqualTo(1L);
+    }
+
+    @Test
+    void acknowledge_deletes_generation_job_record() {
+        redisQuizGenerationQueue.acknowledge("1748130000000-0");
+
+        verify(streamOperations).delete("quiz:generation:jobs", "1748130000000-0");
     }
 }

--- a/src/test/java/com/f1/quiket/domain/subject/controller/CertificateControllerTest.java
+++ b/src/test/java/com/f1/quiket/domain/subject/controller/CertificateControllerTest.java
@@ -1,0 +1,44 @@
+package com.f1.quiket.domain.subject.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.subject.dto.CertificateResponse;
+import com.f1.quiket.domain.subject.service.CertificateService;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class CertificateControllerTest {
+
+    private CertificateService certificateService;
+    private CertificateController certificateController;
+
+    @BeforeEach
+    void setUp() {
+        certificateService = mock(CertificateService.class);
+        certificateController = new CertificateController(certificateService);
+    }
+
+    @Test
+    void getCertificates_returns_ok_response() {
+        List<CertificateResponse> response = List.of(
+                CertificateResponse.builder().id(1L).name("정보처리기사").featured(true).displayOrder(1).build()
+        );
+        when(certificateService.getCertificates(true, "정보")).thenReturn(response);
+
+        ResponseEntity<ApiResponse<List<CertificateResponse>>> result = certificateController.getCertificates(true, "정보");
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(certificateService).getCertificates(true, "정보");
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/subject/controller/SubjectControllerTest.java
+++ b/src/test/java/com/f1/quiket/domain/subject/controller/SubjectControllerTest.java
@@ -1,0 +1,223 @@
+package com.f1.quiket.domain.subject.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.subject.dto.QuizScopeResponse;
+import com.f1.quiket.domain.subject.dto.SubjectCreateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectDetailResponse;
+import com.f1.quiket.domain.subject.dto.SubjectDetailUpdateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleResponse;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleUpsertRequest;
+import com.f1.quiket.domain.subject.dto.SubjectNameUpdateRequest;
+import com.f1.quiket.domain.subject.dto.SubjectPageResponse;
+import com.f1.quiket.domain.subject.dto.SubjectResponse;
+import com.f1.quiket.domain.subject.dto.SubjectSummaryResponse;
+import com.f1.quiket.domain.subject.service.SubjectService;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class SubjectControllerTest {
+
+    private SubjectService subjectService;
+    private SubjectController subjectController;
+    private UserPrincipal principal;
+
+    @BeforeEach
+    void setUp() {
+        subjectService = mock(SubjectService.class);
+        subjectController = new SubjectController(subjectService);
+        principal = principal("user-public-id");
+    }
+
+    @Test
+    void getSubjects_returns_ok_response() {
+        SubjectPageResponse response = SubjectPageResponse.builder()
+                .page(0)
+                .size(10)
+                .totalElements(1L)
+                .totalPages(1)
+                .last(true)
+                .content(List.of(SubjectSummaryResponse.builder()
+                        .id("subject-public-id")
+                        .name("데이터베이스")
+                        .purpose("exam")
+                        .build()))
+                .build();
+        when(subjectService.getSubjects(principal.getPublicId(), 0, 10)).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectPageResponse>> result = subjectController.getSubjects(principal, 0, 10);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).getSubjects(principal.getPublicId(), 0, 10);
+    }
+
+    @Test
+    void createSubject_returns_created_response() {
+        SubjectCreateRequest request = new SubjectCreateRequest();
+        ReflectionTestUtils.setField(request, "name", "데이터베이스");
+        ReflectionTestUtils.setField(request, "purpose", "exam");
+
+        SubjectResponse response = SubjectResponse.builder()
+                .id("subject-public-id")
+                .name("데이터베이스")
+                .purpose("exam")
+                .createdAt(LocalDateTime.now())
+                .build();
+        when(subjectService.createSubject(principal.getPublicId(), request)).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectResponse>> result = subjectController.createSubject(principal, request);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.CREATED.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).createSubject(principal.getPublicId(), request);
+    }
+
+    @Test
+    void getSubject_returns_ok_response() {
+        SubjectDetailResponse response = SubjectDetailResponse.builder()
+                .id("subject-public-id")
+                .name("데이터베이스")
+                .purpose("exam")
+                .build();
+        when(subjectService.getSubject(principal.getPublicId(), "subject-public-id")).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectDetailResponse>> result = subjectController.getSubject(principal, "subject-public-id");
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).getSubject(principal.getPublicId(), "subject-public-id");
+    }
+
+    @Test
+    void getQuizScope_returns_ok_response() {
+        QuizScopeResponse response = QuizScopeResponse.builder()
+                .subjectId("subject-public-id")
+                .subjectName("데이터베이스")
+                .chapters(List.of())
+                .build();
+        when(subjectService.getQuizScope(principal.getPublicId(), "subject-public-id")).thenReturn(response);
+
+        ResponseEntity<ApiResponse<QuizScopeResponse>> result = subjectController.getQuizScope(principal, "subject-public-id");
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).getQuizScope(principal.getPublicId(), "subject-public-id");
+    }
+
+    @Test
+    void deleteSubject_returns_ok_response() {
+        ResponseEntity<ApiResponse<Void>> result = subjectController.deleteSubject(principal, "subject-public-id");
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isNull();
+        verify(subjectService).deleteSubject(principal.getPublicId(), "subject-public-id");
+    }
+
+    @Test
+    void updateSubjectName_returns_ok_response() {
+        SubjectNameUpdateRequest request = new SubjectNameUpdateRequest();
+        ReflectionTestUtils.setField(request, "name", "운영체제");
+
+        SubjectResponse response = SubjectResponse.builder()
+                .id("subject-public-id")
+                .name("운영체제")
+                .purpose("exam")
+                .build();
+        when(subjectService.updateSubjectName(principal.getPublicId(), "subject-public-id", "운영체제")).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectResponse>> result = subjectController.updateSubjectName(principal, "subject-public-id", request);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).updateSubjectName(principal.getPublicId(), "subject-public-id", "운영체제");
+    }
+
+    @Test
+    void updateSubjectDetails_returns_ok_response() {
+        SubjectDetailUpdateRequest request = new SubjectDetailUpdateRequest();
+        ReflectionTestUtils.setField(request, "name", "운영체제");
+        ReflectionTestUtils.setField(request, "purpose", "review");
+
+        SubjectDetailResponse response = SubjectDetailResponse.builder()
+                .id("subject-public-id")
+                .name("운영체제")
+                .purpose("review")
+                .build();
+        when(subjectService.updateSubjectDetails(principal.getPublicId(), "subject-public-id", request)).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectDetailResponse>> result = subjectController.updateSubjectDetails(principal, "subject-public-id", request);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).updateSubjectDetails(principal.getPublicId(), "subject-public-id", request);
+    }
+
+    @Test
+    void upsertSubjectExamSchedule_returns_ok_response() {
+        SubjectExamScheduleUpsertRequest request = new SubjectExamScheduleUpsertRequest();
+        ReflectionTestUtils.setField(request, "examName", "정보처리기사");
+        ReflectionTestUtils.setField(request, "examDate", LocalDate.now().plusDays(30));
+
+        SubjectExamScheduleResponse response = SubjectExamScheduleResponse.builder()
+                .id("schedule-public-id")
+                .subjectId("subject-public-id")
+                .examName("정보처리기사")
+                .examDate(LocalDate.now().plusDays(30))
+                .dDay(30)
+                .build();
+        when(subjectService.upsertExamSchedule(principal.getPublicId(), "subject-public-id", request)).thenReturn(response);
+
+        ResponseEntity<ApiResponse<SubjectExamScheduleResponse>> result = subjectController.upsertSubjectExamSchedule(principal, "subject-public-id", request);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isSameAs(response);
+        verify(subjectService).upsertExamSchedule(principal.getPublicId(), "subject-public-id", request);
+    }
+
+    @Test
+    void deleteSubjectExamSchedule_returns_ok_response() {
+        ResponseEntity<ApiResponse<Void>> result = subjectController.deleteSubjectExamSchedule(principal, "subject-public-id");
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(result.getBody().isSuccess()).isTrue();
+        assertThat(result.getBody().getCode()).isEqualTo(SuccessCode.OK.getCode());
+        assertThat(result.getBody().getData()).isNull();
+        verify(subjectService).deleteExamSchedule(principal.getPublicId(), "subject-public-id");
+    }
+
+    private UserPrincipal principal(String userPublicId) {
+        User user = User.create(userPublicId, "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", 1L);
+        return UserPrincipal.from(user);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/subject/service/CertificateServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/subject/service/CertificateServiceTest.java
@@ -1,0 +1,91 @@
+package com.f1.quiket.domain.subject.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.subject.dto.CertificateResponse;
+import com.f1.quiket.domain.subject.entity.Certificate;
+import com.f1.quiket.domain.subject.repository.CertificateRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class CertificateServiceTest {
+
+    private CertificateRepository certificateRepository;
+    private CertificateService certificateService;
+
+    @BeforeEach
+    void setUp() {
+        certificateRepository = mock(CertificateRepository.class);
+        certificateService = new CertificateService(certificateRepository);
+    }
+
+    @Test
+    void getCertificates_uses_featured_and_keyword_query() {
+        Certificate certificate = certificate(1L, "정보처리기사", true, 1);
+        when(certificateRepository.findAllByFeaturedTrueAndNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc("정보"))
+                .thenReturn(List.of(certificate));
+
+        List<CertificateResponse> response = certificateService.getCertificates(true, "정보");
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getId()).isEqualTo(1L);
+        assertThat(response.get(0).getName()).isEqualTo("정보처리기사");
+        assertThat(response.get(0).getFeatured()).isTrue();
+        verify(certificateRepository).findAllByFeaturedTrueAndNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc("정보");
+        verifyNoMoreInteractions(certificateRepository);
+    }
+
+    @Test
+    void getCertificates_uses_featured_only_query() {
+        when(certificateRepository.findAllByFeaturedTrueOrderByDisplayOrderAscNameAsc())
+                .thenReturn(List.of(certificate(2L, "SQLD", true, 2)));
+
+        List<CertificateResponse> response = certificateService.getCertificates(true, null);
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getName()).isEqualTo("SQLD");
+        verify(certificateRepository).findAllByFeaturedTrueOrderByDisplayOrderAscNameAsc();
+        verifyNoMoreInteractions(certificateRepository);
+    }
+
+    @Test
+    void getCertificates_uses_keyword_only_query() {
+        when(certificateRepository.findAllByNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc("SQL"))
+                .thenReturn(List.of(certificate(3L, "SQLD", false, 3)));
+
+        List<CertificateResponse> response = certificateService.getCertificates(false, "SQL");
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getFeatured()).isFalse();
+        verify(certificateRepository).findAllByNameContainingIgnoreCaseOrderByDisplayOrderAscNameAsc("SQL");
+        verifyNoMoreInteractions(certificateRepository);
+    }
+
+    @Test
+    void getCertificates_uses_all_query_when_no_filter() {
+        when(certificateRepository.findAllByOrderByDisplayOrderAscNameAsc())
+                .thenReturn(List.of(certificate(4L, "네트워크관리사", false, 4)));
+
+        List<CertificateResponse> response = certificateService.getCertificates(null, " ");
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).getDisplayOrder()).isEqualTo(4);
+        verify(certificateRepository).findAllByOrderByDisplayOrderAscNameAsc();
+        verifyNoMoreInteractions(certificateRepository);
+    }
+
+    private Certificate certificate(Long id, String name, Boolean featured, Integer displayOrder) {
+        Certificate certificate = org.springframework.beans.BeanUtils.instantiateClass(Certificate.class);
+        ReflectionTestUtils.setField(certificate, "id", id);
+        ReflectionTestUtils.setField(certificate, "name", name);
+        ReflectionTestUtils.setField(certificate, "featured", featured);
+        ReflectionTestUtils.setField(certificate, "displayOrder", displayOrder);
+        return certificate;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/subject/service/SubjectServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/subject/service/SubjectServiceTest.java
@@ -1,0 +1,227 @@
+package com.f1.quiket.domain.subject.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.quiz.entity.QuizSession;
+import com.f1.quiket.domain.quiz.repository.QuizSessionRepository;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleResponse;
+import com.f1.quiket.domain.subject.dto.SubjectExamScheduleUpsertRequest;
+import com.f1.quiket.domain.subject.dto.SubjectPageResponse;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.entity.SubjectExamSchedule;
+import com.f1.quiket.domain.subject.repository.SubjectExamDetailRepository;
+import com.f1.quiket.domain.subject.repository.SubjectExamScheduleRepository;
+import com.f1.quiket.domain.subject.repository.SubjectOtherDetailRepository;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.domain.subject.repository.SubjectReviewDetailRepository;
+import com.f1.quiket.domain.user.entity.User;
+import com.f1.quiket.domain.user.repository.UserRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class SubjectServiceTest {
+
+    private UserRepository userRepository;
+    private SubjectRepository subjectRepository;
+    private SubjectExamDetailRepository subjectExamDetailRepository;
+    private SubjectReviewDetailRepository subjectReviewDetailRepository;
+    private SubjectOtherDetailRepository subjectOtherDetailRepository;
+    private SubjectExamScheduleRepository subjectExamScheduleRepository;
+    private ChapterRepository chapterRepository;
+    private PartRepository partRepository;
+    private QuizSessionRepository quizSessionRepository;
+    private SubjectService subjectService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        subjectExamDetailRepository = mock(SubjectExamDetailRepository.class);
+        subjectReviewDetailRepository = mock(SubjectReviewDetailRepository.class);
+        subjectOtherDetailRepository = mock(SubjectOtherDetailRepository.class);
+        subjectExamScheduleRepository = mock(SubjectExamScheduleRepository.class);
+        chapterRepository = mock(ChapterRepository.class);
+        partRepository = mock(PartRepository.class);
+        quizSessionRepository = mock(QuizSessionRepository.class);
+
+        subjectService = new SubjectService(
+                userRepository,
+                subjectRepository,
+                subjectExamDetailRepository,
+                subjectReviewDetailRepository,
+                subjectOtherDetailRepository,
+                subjectExamScheduleRepository,
+                chapterRepository,
+                partRepository,
+                quizSessionRepository
+        );
+    }
+
+    @Test
+    void getSubjects_returns_empty_page_with_normalized_page_and_size() {
+        User user = user(1L, "user-public-id");
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+
+        Page<Subject> page = new PageImpl<>(List.of(), org.springframework.data.domain.PageRequest.of(0, 100), 0);
+        when(subjectRepository.findByUserIdAndDeletedAtIsNull(eq(user.getId()), any(Pageable.class))).thenReturn(page);
+
+        SubjectPageResponse response = subjectService.getSubjects(user.getPublicId(), -1, 999);
+
+        assertThat(response.getPage()).isEqualTo(0);
+        assertThat(response.getSize()).isEqualTo(100);
+        assertThat(response.getContent()).isEmpty();
+        verify(subjectRepository).findByUserIdAndDeletedAtIsNull(eq(user.getId()), any(Pageable.class));
+        verifyNoInteractions(chapterRepository, partRepository, subjectExamScheduleRepository);
+    }
+
+    @Test
+    void upsertExamSchedule_creates_new_schedule_with_normalized_exam_name() {
+        User user = user(1L, "user-public-id");
+        Subject subject = subject(10L, "subject-public-id", user.getId(), "데이터베이스");
+        SubjectExamScheduleUpsertRequest request = new SubjectExamScheduleUpsertRequest();
+        ReflectionTestUtils.setField(request, "examName", " ");
+        ReflectionTestUtils.setField(request, "examDate", LocalDate.now().plusDays(7));
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), user.getId())).thenReturn(Optional.of(subject));
+        when(subjectExamScheduleRepository.findBySubjectId(subject.getId())).thenReturn(Optional.empty());
+        when(subjectExamScheduleRepository.save(any(SubjectExamSchedule.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        SubjectExamScheduleResponse response = subjectService.upsertExamSchedule(user.getPublicId(), subject.getPublicId(), request);
+
+        ArgumentCaptor<SubjectExamSchedule> captor = ArgumentCaptor.forClass(SubjectExamSchedule.class);
+        verify(subjectExamScheduleRepository).save(captor.capture());
+        assertThat(captor.getValue().getExamName()).isNull();
+        assertThat(captor.getValue().getExamDate()).isEqualTo(request.getExamDate());
+
+        assertThat(response.getSubjectId()).isEqualTo(subject.getPublicId());
+        assertThat(response.getExamName()).isEqualTo(subject.getName());
+        assertThat(response.getExamDate()).isEqualTo(request.getExamDate());
+    }
+
+    @Test
+    void deleteExamSchedule_throws_not_found_when_schedule_missing() {
+        User user = user(1L, "user-public-id");
+        Subject subject = subject(10L, "subject-public-id", user.getId(), "데이터베이스");
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), user.getId())).thenReturn(Optional.of(subject));
+        when(subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> subjectService.deleteExamSchedule(user.getPublicId(), subject.getPublicId()))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_FOUND);
+    }
+
+    @Test
+    void deleteSubject_soft_deletes_subject_and_children() {
+        User user = user(1L, "user-public-id");
+        Subject subject = subject(10L, "subject-public-id", user.getId(), "데이터베이스");
+        SubjectExamSchedule schedule = schedule(100L, "schedule-public-id", subject.getId(), user.getId(), "기말고사", LocalDate.now().plusDays(2));
+        Chapter chapter = chapter(200L, "chapter-public-id", subject.getId(), user.getId(), "트랜잭션", 1);
+        Part part = part(300L, "part-public-id", chapter.getId(), subject.getId(), user.getId(), "락", 1);
+        QuizSession quizSession = quizSession(400L, "quiz-public-id", user.getId(), subject.getId());
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), user.getId())).thenReturn(Optional.of(subject));
+        when(subjectExamScheduleRepository.findBySubjectIdAndDeletedAtIsNull(subject.getId())).thenReturn(Optional.of(schedule));
+        when(chapterRepository.findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByDisplayOrderAscCreatedAtAsc(subject.getId(), user.getId()))
+                .thenReturn(List.of(chapter));
+        when(partRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId())).thenReturn(List.of(part));
+        when(quizSessionRepository.findAllBySubjectIdAndDeletedAtIsNull(subject.getId())).thenReturn(List.of(quizSession));
+
+        subjectService.deleteSubject(user.getPublicId(), subject.getPublicId());
+
+        assertThat(schedule.getDeletedAt()).isNotNull();
+        assertThat(chapter.getDeletedAt()).isNotNull();
+        assertThat(part.getDeletedAt()).isNotNull();
+        assertThat(quizSession.getDeletedAt()).isNotNull();
+        assertThat(subject.getDeletedAt()).isNotNull();
+    }
+
+    private User user(Long id, String publicId) {
+        User user = User.create(publicId, "user@example.com", "도토리");
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Subject subject(Long id, String publicId, Long userId, String name) {
+        Subject subject = newEntity(Subject.class);
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        ReflectionTestUtils.setField(subject, "userId", userId);
+        ReflectionTestUtils.setField(subject, "name", name);
+        ReflectionTestUtils.setField(subject, "purpose", "exam");
+        return subject;
+    }
+
+    private SubjectExamSchedule schedule(Long id, String publicId, Long subjectId, Long userId, String examName, LocalDate examDate) {
+        SubjectExamSchedule schedule = newEntity(SubjectExamSchedule.class);
+        ReflectionTestUtils.setField(schedule, "id", id);
+        ReflectionTestUtils.setField(schedule, "publicId", publicId);
+        ReflectionTestUtils.setField(schedule, "subjectId", subjectId);
+        ReflectionTestUtils.setField(schedule, "userId", userId);
+        ReflectionTestUtils.setField(schedule, "examName", examName);
+        ReflectionTestUtils.setField(schedule, "examDate", examDate);
+        return schedule;
+    }
+
+    private Chapter chapter(Long id, String publicId, Long subjectId, Long userId, String name, Integer displayOrder) {
+        Chapter chapter = newEntity(Chapter.class);
+        ReflectionTestUtils.setField(chapter, "id", id);
+        ReflectionTestUtils.setField(chapter, "publicId", publicId);
+        ReflectionTestUtils.setField(chapter, "subjectId", subjectId);
+        ReflectionTestUtils.setField(chapter, "userId", userId);
+        ReflectionTestUtils.setField(chapter, "name", name);
+        ReflectionTestUtils.setField(chapter, "displayOrder", displayOrder);
+        return chapter;
+    }
+
+    private Part part(Long id, String publicId, Long chapterId, Long subjectId, Long userId, String name, Integer partNumber) {
+        Part part = newEntity(Part.class);
+        ReflectionTestUtils.setField(part, "id", id);
+        ReflectionTestUtils.setField(part, "publicId", publicId);
+        ReflectionTestUtils.setField(part, "chapterId", chapterId);
+        ReflectionTestUtils.setField(part, "subjectId", subjectId);
+        ReflectionTestUtils.setField(part, "userId", userId);
+        ReflectionTestUtils.setField(part, "name", name);
+        ReflectionTestUtils.setField(part, "partNumber", partNumber);
+        return part;
+    }
+
+    private QuizSession quizSession(Long id, String publicId, Long userId, Long subjectId) {
+        QuizSession quizSession = newEntity(QuizSession.class);
+        ReflectionTestUtils.setField(quizSession, "id", id);
+        ReflectionTestUtils.setField(quizSession, "publicId", publicId);
+        ReflectionTestUtils.setField(quizSession, "userId", userId);
+        ReflectionTestUtils.setField(quizSession, "subjectId", subjectId);
+        ReflectionTestUtils.setField(quizSession, "status", "completed");
+        return quizSession;
+    }
+
+    private <T> T newEntity(Class<T> type) {
+        return org.springframework.beans.BeanUtils.instantiateClass(type);
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/user/entity/type/UserLevelTest.java
+++ b/src/test/java/com/f1/quiket/domain/user/entity/type/UserLevelTest.java
@@ -1,0 +1,34 @@
+package com.f1.quiket.domain.user.entity.type;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * 명세 GAMIF-002 — 레벨별 다람쥐 명칭 매핑이 정책과 일치하는지 단언한다.
+ */
+class UserLevelTest {
+
+    @Test
+    void titleOf_matches_specification_for_each_level() {
+        assertThat(UserLevel.titleOf(1)).isEqualTo("첫걸음 다람쥐");
+        assertThat(UserLevel.titleOf(2)).isEqualTo("결심한 다람쥐");
+        assertThat(UserLevel.titleOf(3)).isEqualTo("펜굴리는 다람쥐");
+        assertThat(UserLevel.titleOf(4)).isEqualTo("노력형 다람쥐");
+        assertThat(UserLevel.titleOf(5)).isEqualTo("열공 다람쥐");
+        assertThat(UserLevel.titleOf(6)).isEqualTo("똑똑한 다람쥐");
+        assertThat(UserLevel.titleOf(7)).isEqualTo("박식한 다람쥐");
+        assertThat(UserLevel.titleOf(8)).isEqualTo("통달한 다람쥐");
+        assertThat(UserLevel.titleOf(9)).isEqualTo("현자 다람쥐");
+        assertThat(UserLevel.titleOf(10)).isEqualTo("레전드 다람쥐");
+    }
+
+    @Test
+    void titleOf_clamps_out_of_range_levels_to_band_edges() {
+        assertThat(UserLevel.titleOf(null)).isEqualTo("첫걸음 다람쥐");
+        assertThat(UserLevel.titleOf(0)).isEqualTo("첫걸음 다람쥐");
+        assertThat(UserLevel.titleOf(-3)).isEqualTo("첫걸음 다람쥐");
+        assertThat(UserLevel.titleOf(11)).isEqualTo("레전드 다람쥐");
+        assertThat(UserLevel.titleOf(999)).isEqualTo("레전드 다람쥐");
+    }
+}

--- a/src/test/java/com/f1/quiket/infra/aoai/client/AzureOpenAiQuizClientTest.java
+++ b/src/test/java/com/f1/quiket/infra/aoai/client/AzureOpenAiQuizClientTest.java
@@ -1,0 +1,117 @@
+package com.f1.quiket.infra.aoai.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationPrompt;
+import com.f1.quiket.domain.quiz.dto.QuizAiGenerationResponse;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.infra.aoai.config.AzureOpenAiProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class AzureOpenAiQuizClientTest {
+
+    private static final String CHAT_COMPLETIONS_URI =
+            "https://quiket-aoai.openai.azure.com/openai/deployments/quiz-deployment/chat/completions?api-version=2024-10-21";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private MockRestServiceServer mockServer;
+    private AzureOpenAiQuizClient azureOpenAiQuizClient;
+    private AzureOpenAiProperties properties;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        mockServer = MockRestServiceServer.bindTo(builder).build();
+        properties = properties();
+        azureOpenAiQuizClient = new AzureOpenAiQuizClient(builder.build(), properties);
+    }
+
+    @Test
+    void generate_calls_azure_openai_and_parses_structured_output() throws Exception {
+        mockServer.expect(requestTo(CHAT_COMPLETIONS_URI))
+                .andExpect(header("api-key", "aoai-key"))
+                .andExpect(content().string(containsString("json_schema")))
+                .andExpect(content().string(containsString("quiz_generation_response")))
+                .andRespond(withSuccess(chatCompletionResponse(), MediaType.APPLICATION_JSON));
+
+        QuizAiGenerationResponse response = azureOpenAiQuizClient.generate(
+                new QuizAiGenerationPrompt("system", "user")
+        );
+
+        assertThat(response.getQuestions()).hasSize(1);
+        assertThat(response.getQuestions().get(0).getPartId()).isEqualTo("part-public-id");
+        assertThat(response.getQuestions().get(0).getAnswerValue()).isEqualTo("1");
+        mockServer.verify();
+    }
+
+    @Test
+    void generate_throws_service_unavailable_when_properties_missing() {
+        properties.setApiKey("");
+
+        assertThatThrownBy(() -> azureOpenAiQuizClient.generate(new QuizAiGenerationPrompt("system", "user")))
+                .isInstanceOf(CustomException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.SERVICE_UNAVAILABLE);
+    }
+
+    private AzureOpenAiProperties properties() {
+        AzureOpenAiProperties properties = new AzureOpenAiProperties();
+        properties.setEndpoint("https://quiket-aoai.openai.azure.com");
+        properties.setApiKey("aoai-key");
+        properties.setDeploymentName("quiz-deployment");
+        properties.setApiVersion("2024-10-21");
+        properties.setMaxOutputTokens(4096);
+        properties.setTemperature(0.2);
+        return properties;
+    }
+
+    private String chatCompletionResponse() throws JsonProcessingException {
+        String content = """
+                {
+                  "questions": [
+                    {
+                      "partId": "part-public-id",
+                      "questionType": "multiple_choice",
+                      "difficulty": "medium",
+                      "summary": "정규화 핵심 개념",
+                      "body": "정규화의 목적은 무엇인가요?",
+                      "options": [
+                        {"optionNumber": 1, "content": "중복 최소화"},
+                        {"optionNumber": 2, "content": "중복 최대화"},
+                        {"optionNumber": 3, "content": "테이블 삭제"},
+                        {"optionNumber": 4, "content": "인덱스 제거"}
+                      ],
+                      "answerValue": "1",
+                      "correctExplanation": "정규화는 데이터 중복을 줄입니다.",
+                      "incorrectExplanation": "다른 선택지는 정규화 목적과 다릅니다."
+                    }
+                  ]
+                }
+                """;
+        return """
+                {
+                  "choices": [
+                    {
+                      "message": {
+                        "content": %s
+                      }
+                    }
+                  ]
+                }
+                """.formatted(objectMapper.writeValueAsString(content));
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 퀴즈 풀이→결과→복습 흐름 전체와 게임화·과목 관리 보완을 운영에 1차 노출하는 배포
- 머지 즉시 `deploy.yml` 트리거 → GHCR 이미지 빌드 → EC2 docker compose 재기동

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

### 퀴즈 풀이/결과 도메인
- **퀴즈 풀이 세션 시작** (#85)
  - POST `/quiz-sessions/{quizSessionId}/play-sessions`
  - clientSessionId 기반 idempotent 시작, `playType=first` MVP
- **퀴즈 결과 제출 + 서버 재채점** (#87)
  - POST `/quiz-results`
  - 클라이언트 답안 배열 → 서버 정답으로 재채점 → `score_matched`/`abuse_flagged` 플래그 + 리뷰 아이템 응답
  - clientSessionId 기준 중복 제출 차단 (`uq_quiz_results_play_session_id`)
- **과거 퀴즈 결과 상세 조회** (#91)
  - GET `/quiz-results/{resultId}`
  - 제출 응답과 동일 조립 로직 (`QuizResultResponseAssembler` 공통화)
- **과거 퀴즈 전체 다시풀기** (#93)
  - POST `/quiz-results/{resultId}/retry-all` — `playType=retry_all`, 기존 quizSession 그대로 재플레이
- **과거 퀴즈 틀린 문제만 다시풀기** (#95)
  - POST `/quiz-results/{resultId}/retry-wrong`
  - 오답 문항만 모아 자식 quiz_session 생성(`generation += 1`) + parent 추적

### 게임화 도메인
- **퀴즈 보상 적립** (#89)
  - 결과 제출 1회 호출에 포함, 서버 재채점 결과로 적립
  - 도토리: 첫 풀이 정답 1문항당 +1, retry는 0 (GAMIF-001)
  - XP: 첫 풀이 easy 3 / medium 4 / hard 5, 복습 easy 2 / medium 3 / hard 4 (GAMIF-002)
  - 연속 학습 배수 (1.0/1.1/1.2/1.5/2.0/2.5) 적용
- **게임화 조회 API** (#89)
  - GET `/gamification/me` — 레벨/명칭/다음 레벨/진행률
- **캐릭터 성장 XP 정책 보완** (#97)
  - 만렙(Lv.10) 도달 후 XP 누적 상한 적용 (`MAX_LEVEL_MIN_XP=26,250`)
  - GAMIF-002 명세 출처를 정책 코드에 Javadoc으로 명시
  - 명세 일치 단언 보강 (레벨 구간 경계 / 난이도별 XP / 레벨 명칭 / 만렙 cap / 정답 0개)

### 과목 관리 도메인
- **과목 관리 확장** (#33)
  - 학습 목적별 상세(시험/복습/기타) + 자격증 마스터 + 시험 일정 등록·수정
  - 컨트롤러/서비스 테스트 풀세트 추가

### 인프라 / 공통
- Flyway V10: `quiz_play_sessions`
- Flyway V11: `quiz_play_answers` + `quiz_results`
- Flyway V12: `user_xp_logs` + `user_dotori_logs` + `user_streak_logs`
- Flyway V13: subject 상세 테이블 `deleted_at` 컬럼 추가
- ErrorCode 신설: `QUIZ_PLAY_SESSION_NOT_FOUND(404)`, `QUIZ_RESULT_NOT_FOUND(404)`
- `User` 엔티티 `applyQuizReward(int, int, int)` 도메인 메서드 추가
- `QuizPlaySession` 팩토리 `createFirst`/`createRetryAll`/`createRetryWrong` 분리

> Auth/MyPage/Quiz 생성 흐름 등 기존 도메인은 이전 배포(#83)에서 이미 반영 완료. 본 PR diff에 포함되지 않습니다.

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. CI `build-and-test` 통과 확인
2. 머지 후 Actions `Deploy` 워크플로우 성공 확인
3. 운영 DB `flyway_schema_history`에 V10 / V11 / V12 / V13 적용 확인
4. 퀴즈 풀이 흐름 스모크
   - POST `/api/v1/quiz-sessions/{quizSessionId}/play-sessions`
   - POST `/api/v1/quiz-results` (정상/중복 제출 모두)
   - GET `/api/v1/quiz-results/{resultId}`
   - POST `/api/v1/quiz-results/{resultId}/retry-all`
   - POST `/api/v1/quiz-results/{resultId}/retry-wrong`
5. 게임화 스모크
   - GET `/api/v1/gamification/me`
   - xpTotal 26,248 사용자 → first hard 정답 1개 → +2XP만 적립, level=10 도달
   - xpTotal 26,250 사용자 → first hard 정답 3개 → earnedXp=0, 도토리는 +3 정상 적립
6. 과목 관리 스모크
   - 과목 추가(시험/복습/기타) → 수정 → soft delete → 시험 일정 등록·수정

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #101

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- **머지 방식 — Squash merge** (AGENTS.md PR #76 컨벤션). 커밋 메시지는 `[Chore] 네 번째 운영 배포 (#PR번호)` 형식.
- 운영 DB는 Flyway `baseline-on-migrate=false`. V1~V9가 적용된 상태에 V10 / V11 / V12 / V13만 신규 적용됨.
- 운영 환경변수(`PROD_ENV_FILE`)는 변경 없음 (AOAI/워커 설정은 직전 배포 #83에서 이미 반영).
- 자료 업로드 +10XP는 강의 업로드 도메인 미구현으로 본 배포 범위 외 — GAMIF-002 후속 이슈에서 처리.
- HISTORY-005 셔플은 클라이언트 처리, HISTORY-006 결과 공유는 OS 공유 시트 — 백엔드 변경 없음.
- 직전 배포 #84 머지 후 CI가 organization 계정 정지(403) 이슈로 일시 실패했던 이력이 있어, 본 PR도 같은 인프라 상태 영향 가능성 모니터링 필요.

---

## 🧑‍💻 Assignee

- @imclaremont