### PR TITLE
[Chore] soft delete 대상 deleted_at 컬럼 추가

### DIFF
--- a/docs/db/quiket-ddl-mvp.sql
+++ b/docs/db/quiket-ddl-mvp.sql
@@ -272,6 +272,7 @@ CREATE TABLE certificates (
     display_order       INT             NOT NULL DEFAULT 0               COMMENT '노출 순서',
     created_at          DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3)                          COMMENT '생성 시각',
     updated_at          DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at          DATETIME(3)     NULL                             COMMENT '삭제 시각 (soft delete)',
 
     PRIMARY KEY (id),
     UNIQUE KEY uq_certificates_name (name),
@@ -322,6 +323,7 @@ CREATE TABLE lecture_uploads (
     raw_text            MEDIUMTEXT      NULL                             COMMENT '추출된 원본 텍스트 (텍스트 직접입력 or OCR 결과)',
     created_at          DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3)                          COMMENT '생성 시각',
     updated_at          DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at          DATETIME(3)     NULL                             COMMENT '삭제 시각 (soft delete)',
 
     PRIMARY KEY (id),
     UNIQUE KEY uq_lecture_uploads_public_id (public_id),
@@ -347,6 +349,7 @@ CREATE TABLE lecture_upload_files (
     ocr_status          VARCHAR(20)     NULL                             COMMENT 'OCR 상태 (이미지 업로드 시): pending / success / failed',
     created_at          DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3)                          COMMENT '생성 시각',
     updated_at          DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at          DATETIME(3)     NULL                             COMMENT '삭제 시각 (soft delete)',
 
     PRIMARY KEY (id),
     KEY idx_lecture_upload_files_lecture_upload_id_order (lecture_upload_id, display_order),
@@ -539,6 +542,7 @@ CREATE TABLE questions (
 
     created_at              DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3)                          COMMENT '생성 시각',
     updated_at              DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at              DATETIME(3)     NULL                             COMMENT '삭제 시각 (soft delete)',
 
     PRIMARY KEY (id),
     UNIQUE KEY uq_questions_public_id (public_id),
@@ -668,6 +672,7 @@ CREATE TABLE quiz_play_sessions (
     submitted_at            DATETIME(3)     NULL                             COMMENT '결과 제출 시각',
     created_at              DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3)                          COMMENT '생성 시각 (풀이 시작 시각)',
     updated_at              DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at              DATETIME(3)     NULL                             COMMENT '삭제 시각 (soft delete)',
 
     PRIMARY KEY (id),
     UNIQUE KEY uq_quiz_play_sessions_client_session_id (client_session_id),
@@ -757,6 +762,7 @@ CREATE TABLE quiz_results (
 
     created_at              DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3)                          COMMENT '결과 저장 시각',
     updated_at              DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
+    deleted_at              DATETIME(3)     NULL                             COMMENT '삭제 시각 (soft delete)',
 
     PRIMARY KEY (id),
     UNIQUE KEY uq_quiz_results_public_id (public_id),
@@ -868,6 +874,7 @@ CREATE TABLE user_feedbacks (
     os_version              VARCHAR(50)     NULL                             COMMENT 'OS 버전',
     device_model            VARCHAR(100)    NULL                             COMMENT '디바이스 모델',
     created_at              DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '제출 시각',
+    deleted_at              DATETIME(3)     NULL                             COMMENT '삭제 시각 (soft delete)',
 
     PRIMARY KEY (id),
     KEY idx_user_feedbacks_user_id (user_id),

--- a/src/main/java/com/f1/quiket/domain/mypage/entity/UserFeedback.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/entity/UserFeedback.java
@@ -61,6 +61,9 @@ public class UserFeedback {
     @Column(name = "created_at", nullable = false, updatable = false)
     LocalDateTime createdAt;
 
+    @Column(name = "deleted_at")
+    LocalDateTime deletedAt;
+
     public static UserFeedback create(Long userId, FeedbackCreateRequest request) {
         UserFeedback feedback = new UserFeedback();
         feedback.userId = userId;

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/Question.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/Question.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -79,6 +80,9 @@ public class Question {
 
     @Column(name = "display_order", nullable = false)
     Integer displayOrder;
+
+    @Column(name = "deleted_at")
+    LocalDateTime deletedAt;
 
     public static Question create(
             String publicId,

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -105,6 +105,9 @@ public class QuizPlaySession {
     @Column(name = "updated_at", nullable = false)
     LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    LocalDateTime deletedAt;
+
     public static QuizPlaySession createFirst(
             String clientSessionId,
             Long quizSessionId,

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
@@ -104,6 +104,9 @@ public class QuizResult {
     @Column(name = "updated_at", nullable = false)
     LocalDateTime updatedAt;
 
+    @Column(name = "deleted_at")
+    LocalDateTime deletedAt;
+
     public static QuizResult create(
             String publicId,
             Long playSessionId,

--- a/src/main/java/com/f1/quiket/domain/subject/entity/Certificate.java
+++ b/src/main/java/com/f1/quiket/domain/subject/entity/Certificate.java
@@ -51,4 +51,7 @@ public class Certificate {
 
     @Column(name = "updated_at", nullable = false)
     LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    LocalDateTime deletedAt;
 }

--- a/src/main/resources/db/migration/V14__add_deleted_at_to_soft_delete_targets.sql
+++ b/src/main/resources/db/migration/V14__add_deleted_at_to_soft_delete_targets.sql
@@ -1,0 +1,161 @@
+-- soft delete 대상 테이블 삭제 시각 컬럼 추가
+SET @add_deleted_at_sql = (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = DATABASE()
+              AND table_name = 'certificates'
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'certificates'
+              AND column_name = 'deleted_at'
+        ),
+        'ALTER TABLE certificates ADD COLUMN deleted_at DATETIME(3) NULL COMMENT ''삭제 시각'' AFTER updated_at',
+        'SELECT 1'
+    )
+);
+PREPARE stmt FROM @add_deleted_at_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @add_deleted_at_sql = (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = DATABASE()
+              AND table_name = 'lecture_uploads'
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'lecture_uploads'
+              AND column_name = 'deleted_at'
+        ),
+        'ALTER TABLE lecture_uploads ADD COLUMN deleted_at DATETIME(3) NULL COMMENT ''삭제 시각'' AFTER updated_at',
+        'SELECT 1'
+    )
+);
+PREPARE stmt FROM @add_deleted_at_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @add_deleted_at_sql = (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = DATABASE()
+              AND table_name = 'lecture_upload_files'
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'lecture_upload_files'
+              AND column_name = 'deleted_at'
+        ),
+        'ALTER TABLE lecture_upload_files ADD COLUMN deleted_at DATETIME(3) NULL COMMENT ''삭제 시각'' AFTER updated_at',
+        'SELECT 1'
+    )
+);
+PREPARE stmt FROM @add_deleted_at_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @add_deleted_at_sql = (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = DATABASE()
+              AND table_name = 'questions'
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'questions'
+              AND column_name = 'deleted_at'
+        ),
+        'ALTER TABLE questions ADD COLUMN deleted_at DATETIME(3) NULL COMMENT ''삭제 시각'' AFTER updated_at',
+        'SELECT 1'
+    )
+);
+PREPARE stmt FROM @add_deleted_at_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @add_deleted_at_sql = (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = DATABASE()
+              AND table_name = 'quiz_play_sessions'
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'quiz_play_sessions'
+              AND column_name = 'deleted_at'
+        ),
+        'ALTER TABLE quiz_play_sessions ADD COLUMN deleted_at DATETIME(3) NULL COMMENT ''삭제 시각'' AFTER updated_at',
+        'SELECT 1'
+    )
+);
+PREPARE stmt FROM @add_deleted_at_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @add_deleted_at_sql = (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = DATABASE()
+              AND table_name = 'quiz_results'
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'quiz_results'
+              AND column_name = 'deleted_at'
+        ),
+        'ALTER TABLE quiz_results ADD COLUMN deleted_at DATETIME(3) NULL COMMENT ''삭제 시각'' AFTER updated_at',
+        'SELECT 1'
+    )
+);
+PREPARE stmt FROM @add_deleted_at_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @add_deleted_at_sql = (
+    SELECT IF(
+        EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = DATABASE()
+              AND table_name = 'user_feedbacks'
+        )
+        AND NOT EXISTS (
+            SELECT 1
+            FROM information_schema.columns
+            WHERE table_schema = DATABASE()
+              AND table_name = 'user_feedbacks'
+              AND column_name = 'deleted_at'
+        ),
+        'ALTER TABLE user_feedbacks ADD COLUMN deleted_at DATETIME(3) NULL COMMENT ''삭제 시각'' AFTER created_at',
+        'SELECT 1'
+    )
+);
+PREPARE stmt FROM @add_deleted_at_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
  ## 🧩 Description

  - 엔티티 정합성 유지와 soft delete 일관성 확보를 위해 삭제 시각 컬럼 `deleted_at` 추가
  - 예비 soft delete 대상 테이블에 DB 컬럼을 반영하고, 현재 도메인 엔티티가 존재하는 대상에 `deletedAt` 필드 매핑 추가

  ---

  ## 🛠️ Changes

  - `certificates`, `lecture_uploads`, `lecture_upload_files`, `questions`, `quiz_play_sessions`, `quiz_results`, `user_feedbacks` 대상 `deleted_at` 컬럼 추가 Flyway 작성
  - 테이블 및 컬럼 존재 여부 확인 후 `ALTER TABLE`을 수행하도록 마이그레이션 구성
  - `Certificate`, `Question`, `QuizPlaySession`, `QuizResult`, `UserFeedback` 엔티티에 `deletedAt` 필드 추가

  ---

  ## 🧪 How to Test

  1. `./gradlew compileJava`
  2. `./gradlew test`

  ---

  ## 🔗 Related Issue

  Closes #103

---

## ⚠️ Notes

- `./gradlew compileJava`, `./gradlew test` 통과
- `lecture_uploads`, `lecture_upload_files`는 현재 도메인 엔티티가 없어 Java 엔티티 변경 대상에서 제외
- 예비용 컬럼 추가 작업이므로 별도 soft delete 처리 로직과 조회 필터는 이번 변경에 포함하지 않음

---

## 🧑‍💻 Assignee

- @ja2hoon