### PR TITLE
[Fix] Gemini 일시 장애 재시도 추가

### DIFF
--- a/src/main/java/com/f1/quiket/infra/gemini/client/GeminiClient.java
+++ b/src/main/java/com/f1/quiket/infra/gemini/client/GeminiClient.java
@@ -16,9 +16,11 @@ import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -56,13 +58,7 @@ public class GeminiClient {
             log.debug("Gemini API request uri={}, body={}", maskApiKey(uri), toJsonForLog(requestBody));
 
             // Gemini generateContent 호출
-            String responseBody = restClient.post()
-                    .uri(uri)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .accept(MediaType.APPLICATION_JSON)
-                    .body(requestBody)
-                    .retrieve()
-                    .body(String.class);
+            String responseBody = requestWithRetry(uri, requestBody);
             log.debug("Gemini API response body={}", responseBody);
             return GeminiCompletionResponse.builder().content(parseResponse(responseBody)).build();
         } catch (CustomException e) {
@@ -124,6 +120,64 @@ public class GeminiClient {
                 "contents", List.of(Map.of("role", "user", "parts", parts)),
                 "generationConfig", generationConfig
         );
+    }
+
+    /**
+     * 일시 장애 응답 재시도
+     */
+    private String requestWithRetry(String uri, Map<String, Object> requestBody) {
+        int maxAttempts = Math.max(1, properties.getRetryMaxAttempts());
+        RestClientException lastException = null;
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return restClient.post()
+                        .uri(uri)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .body(requestBody)
+                        .retrieve()
+                        .body(String.class);
+            } catch (RestClientException e) {
+                lastException = e;
+                if (attempt >= maxAttempts || !isRetryable(e)) {
+                    throw e;
+                }
+                log.warn("Gemini API retry attempt={}/{} cause={}", attempt + 1, maxAttempts, e.getMessage());
+                sleepBeforeRetry();
+            }
+        }
+        throw lastException;
+    }
+
+    /**
+     * 재시도 가능 응답 여부
+     */
+    private boolean isRetryable(RestClientException e) {
+        if (!(e instanceof HttpStatusCodeException statusException)) {
+            return false;
+        }
+        HttpStatus status = HttpStatus.resolve(statusException.getStatusCode().value());
+        return status == HttpStatus.TOO_MANY_REQUESTS
+                || status == HttpStatus.SERVICE_UNAVAILABLE
+                || status == HttpStatus.BAD_GATEWAY
+                || status == HttpStatus.GATEWAY_TIMEOUT
+                || statusException.getStatusCode().is5xxServerError();
+    }
+
+    /**
+     * 재시도 대기
+     */
+    private void sleepBeforeRetry() {
+        long backoffMillis = Math.max(0L, properties.getRetryBackoffMillis());
+        if (backoffMillis == 0L) {
+            return;
+        }
+        try {
+            Thread.sleep(backoffMillis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Gemini API 재시도 대기가 중단되었습니다.", e);
+        }
     }
 
     /**

--- a/src/main/java/com/f1/quiket/infra/gemini/config/GeminiProperties.java
+++ b/src/main/java/com/f1/quiket/infra/gemini/config/GeminiProperties.java
@@ -22,6 +22,8 @@ public class GeminiProperties {
     private Double temperature = 0.2;
     private Integer connectTimeoutSeconds = 10;
     private Integer readTimeoutSeconds = 120;
+    private Integer retryMaxAttempts = 3;
+    private Long retryBackoffMillis = 1_000L;
 
     /**
      * Gemini 필수 설정값 존재 여부
@@ -33,4 +35,3 @@ public class GeminiProperties {
                 && StringUtils.hasText(model);
     }
 }
-

--- a/src/test/java/com/f1/quiket/infra/gemini/client/GeminiClientTest.java
+++ b/src/test/java/com/f1/quiket/infra/gemini/client/GeminiClientTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.f1.quiket.global.error.CustomException;
@@ -16,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
@@ -34,6 +36,7 @@ class GeminiClientTest {
         RestClient.Builder builder = RestClient.builder();
         mockServer = MockRestServiceServer.bindTo(builder).build();
         properties = properties();
+        properties.setRetryBackoffMillis(0L);
         geminiClient = new GeminiClient(builder.build(), properties);
     }
 
@@ -65,6 +68,48 @@ class GeminiClientTest {
                                 .mimeType("image/png")
                                 .bytes("img".getBytes(StandardCharsets.UTF_8))
                                 .build())
+                )
+                .getContent();
+
+        assertThat(response).contains("\"parts\"");
+        mockServer.verify();
+    }
+
+    @Test
+    void generate_retries_when_gemini_is_temporarily_unavailable() {
+        mockServer.expect(requestTo(URI))
+                .andRespond(withStatus(HttpStatus.SERVICE_UNAVAILABLE)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("""
+                                {
+                                  "error": {
+                                    "code": 503,
+                                    "message": "temporary high demand",
+                                    "status": "UNAVAILABLE"
+                                  }
+                                }
+                                """));
+        mockServer.expect(requestTo(URI))
+                .andRespond(withSuccess("""
+                        {
+                          "candidates": [
+                            {
+                              "content": {
+                                "parts": [
+                                  {"text":"{\\"parts\\":[{\\"partNumber\\":1,\\"name\\":\\"재시도\\",\\"content\\":\\"본문\\"}]}"}
+                                ]
+                              }
+                            }
+                          ]
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        String response = geminiClient.generate(
+                        GeminiCompletionRequest.builder()
+                                .systemMessage("system")
+                                .userMessage("user")
+                                .build(),
+                        List.of()
                 )
                 .getContent();
 


### PR DESCRIPTION
## 🧩 Description

  - Gemini API 일시 장애 응답으로 강의 자료 이미지/PDF AI 처리 실연동 테스트가 실패하는 문제 보완
  - 503, 429, 5xx 계열 응답에 대해 제한적 재시도 처리 추가

  ---

  ## 🛠️ Changes

  - Gemini `generateContent` 호출에 재시도 로직 추가
  - 재시도 대상 응답 코드 분기 추가
  - 재시도 횟수와 대기 시간 설정값 추가
  - Gemini 503 응답 후 성공하는 단위 테스트 추가

  ---

  ## 🧪 How to Test

  1. `./gradlew test --tests 'com.f1.quiket.infra.gemini.client.GeminiClientTest'`

  ---

  ## 🔗 Related Issue

  Closes #99

  ---

  ## ⚠️ Notes

  - Gemini 503/429/5xx 응답은 기본 3회, 1초 간격으로 재시도
  - 외부 API 고수요 상태가 장시간 지속되면 재시도 이후에도 기존처럼 `SERVICE_UNAVAILABLE` 예외가 반환됨
  - 이전 PR 머지 이후 로컬에 남아 있던 `c93c976` 커밋 반영용 PR

  ---

  ## 🧑‍💻 Assignee

  - @ja2hoon