### PR TITLE
[Fix] KakaoApiClient RestClient 빈 주입 오류 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,10 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
+tasks.withType(JavaCompile).configureEach {
+	options.compilerArgs.add('-parameters')
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 	testLogging {

--- a/src/main/java/com/f1/quiket/infra/kakao/client/KakaoApiClient.java
+++ b/src/main/java/com/f1/quiket/infra/kakao/client/KakaoApiClient.java
@@ -7,7 +7,7 @@ import com.f1.quiket.global.response.ErrorCode;
 import com.f1.quiket.infra.kakao.config.KakaoOAuthProperties;
 import com.f1.quiket.infra.kakao.dto.KakaoUserInfo;
 import java.io.IOException;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -19,7 +19,6 @@ import org.springframework.web.client.RestClientResponseException;
  * Kakao 사용자 정보 API 클라이언트
  */
 @Component
-@RequiredArgsConstructor
 public class KakaoApiClient {
 
     private static final String AUTHORIZATION = "Authorization";
@@ -28,6 +27,12 @@ public class KakaoApiClient {
     private final RestClient kakaoRestClient;
     private final KakaoOAuthProperties kakaoOAuthProperties;
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public KakaoApiClient(@Qualifier("kakaoRestClient") RestClient kakaoRestClient,
+                          KakaoOAuthProperties kakaoOAuthProperties) {
+        this.kakaoRestClient = kakaoRestClient;
+        this.kakaoOAuthProperties = kakaoOAuthProperties;
+    }
 
     public KakaoUserInfo getUserInfo(String kakaoAccessToken) {
         try {


### PR DESCRIPTION
## 🧩 Description

- Spring 6.1에서 컴파일러 `-parameters` 플래그 없이 생성자 파라미터 이름으로 빈 매칭 불가
- `RestClient` 타입 빈이 4개 존재하여 `KakaoApiClient` 주입 실패로 애플리케이션 기동 오류 발생

---

## 🛠️ Changes

- `build.gradle`에 `-parameters` 컴파일러 플래그 추가
- `KakaoApiClient` `@RequiredArgsConstructor` 제거 후 명시적 생성자로 교체
- `@Qualifier("kakaoRestClient")`로 주입 대상 빈 명시

---

## 🧪 How to Test

1. 애플리케이션 기동
2. `KakaoApiClient` 빈 주입 오류 없이 정상 기동 확인

---

## 🔗 Related Issue

Closes #107

---

## ⚠️ Notes

- IDE에서 직접 실행 시 `build.gradle` 플래그가 적용되지 않을 수 있어 `@Qualifier` 명시가 필수

---

## 🧑‍💻 Assignee

- @ja2hoon