### PR TITLE
[Fix] 엔티티 생성 시 deleted_at null 명시

### DIFF
--- a/src/main/java/com/f1/quiket/domain/mypage/entity/UserFeedback.java
+++ b/src/main/java/com/f1/quiket/domain/mypage/entity/UserFeedback.java
@@ -73,6 +73,7 @@ public class UserFeedback {
         feedback.appVersion = request.getAppVersion();
         feedback.osVersion = request.getOsVersion();
         feedback.deviceModel = request.getDeviceModel();
+        feedback.deletedAt = null;
         return feedback;
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/Question.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/Question.java
@@ -113,6 +113,7 @@ public class Question {
         question.correctExplanation = correctExplanation;
         question.incorrectExplanation = incorrectExplanation;
         question.displayOrder = displayOrder;
+        question.deletedAt = null;
         return question;
     }
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -204,6 +204,7 @@ public class QuizPlaySession {
         playSession.status = STATUS_IN_PROGRESS;
         playSession.lastQuestionIndex = 0;
         playSession.elapsedMs = 0;
+        playSession.deletedAt = null;
         return playSession;
     }
 

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizResult.java
@@ -144,6 +144,7 @@ public class QuizResult {
         result.newLevel = newLevel;
         result.scoreMatched = scoreMatched;
         result.abuseFlagged = abuseFlagged;
+        result.deletedAt = null;
         return result;
     }
 }

--- a/src/main/java/com/f1/quiket/global/entity/BaseEntity.java
+++ b/src/main/java/com/f1/quiket/global/entity/BaseEntity.java
@@ -39,7 +39,7 @@ public abstract class BaseEntity {
     LocalDateTime updatedAt;
 
     @Column(name = "deleted_at")
-    LocalDateTime deletedAt;
+    LocalDateTime deletedAt = null;
 
     public void delete() {
         this.deletedAt = LocalDateTime.now();


### PR DESCRIPTION
## 🧩 Description

- Java 참조 타입 기본값이 null이지만, 엔티티 생성 시 `deleted_at`이 null임을 코드에서 명시적으로 보장하지 않는 문제
- `BaseEntity`를 상속받지 않는 엔티티들은 팩토리 메서드에서 `deletedAt`을 별도로 지정하지 않아 의도가 불명확

---

## 🛠️ Changes

- `BaseEntity.deletedAt` 필드 초기값 `= null` 명시
- `BaseEntity` 비상속 엔티티 팩토리 메서드에 `deletedAt = null` 명시
  - `Question.create()`
  - `QuizResult.create()`
  - `QuizPlaySession.createBase()`
  - `UserFeedback.create()`

---

## 🧪 How to Test

1. 각 엔티티 생성 후 DB에서 `deleted_at` 컬럼 null 확인

---

## 🔗 Related Issue

Closes #111

---

## ⚠️ Notes

- 동작 변경 없음 — Java 기본값(null)을 코드 수준에서 명시한 것

---

## 🧑‍💻 Assignee

- @ja2hoon