### PR TITLE
[Feat] 파트 관리 기능 구현

### DIFF
--- a/src/main/java/com/f1/quiket/domain/chapter/controller/ChapterController.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/controller/ChapterController.java
@@ -32,7 +32,7 @@ public class ChapterController {
     @PatchMapping("/{chapterId}/name")
     public ResponseEntity<ApiResponse<ChapterResponse>> updateChapterName(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable String chapterId,
+            @PathVariable("chapterId") String chapterId,
             @Valid @RequestBody ChapterNameUpdateRequest request
     ) {
         ChapterResponse response = chapterService.updateChapterName(principal.getPublicId(), chapterId, request.getName());

--- a/src/main/java/com/f1/quiket/domain/chapter/controller/ChapterController.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/controller/ChapterController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/chapters")
+@RequestMapping("/api/v1/chapters")
 public class ChapterController {
 
     private final ChapterService chapterService;

--- a/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
@@ -1,10 +1,12 @@
 package com.f1.quiket.domain.chapter.repository;
 
 import com.f1.quiket.domain.chapter.entity.Chapter;
+import jakarta.persistence.LockModeType;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -37,6 +39,22 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
      * 공개 식별자 기반 사용자 챕터 조회
      */
     Optional<Chapter> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
+
+    /**
+     * 공개 식별자 기반 사용자 챕터 쓰기 잠금 조회
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select c
+            from Chapter c
+            where c.publicId = :publicId
+              and c.userId = :userId
+              and c.deletedAt is null
+            """)
+    Optional<Chapter> findForUpdateByPublicIdAndUserIdAndDeletedAtIsNull(
+            @Param("publicId") String publicId,
+            @Param("userId") Long userId
+    );
 
     /**
      * 사용자 챕터 목록 조회 (PK 컬렉션 기반)

--- a/src/main/java/com/f1/quiket/domain/lecture/entity/LectureUpload.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/entity/LectureUpload.java
@@ -85,6 +85,13 @@ public class LectureUpload extends BaseEntity {
     }
 
     /**
+     * 추출 원문 저장
+     */
+    public void storeRawText(String rawText) {
+        this.rawText = rawText;
+    }
+
+    /**
      * 처리 완료 상태 변경
      */
     public void markCompleted(String rawText) {

--- a/src/main/java/com/f1/quiket/domain/material/dto/StudyMaterialTextExtractionResult.java
+++ b/src/main/java/com/f1/quiket/domain/material/dto/StudyMaterialTextExtractionResult.java
@@ -1,5 +1,6 @@
 package com.f1.quiket.domain.material.dto;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,4 +14,5 @@ import lombok.Getter;
 public class StudyMaterialTextExtractionResult {
     private final String provider;
     private final String extractedText;
+    private final List<Integer> failedDisplayOrders;
 }

--- a/src/main/java/com/f1/quiket/domain/material/processor/StudyMaterialTextExtractor.java
+++ b/src/main/java/com/f1/quiket/domain/material/processor/StudyMaterialTextExtractor.java
@@ -10,7 +10,10 @@ import com.f1.quiket.domain.material.port.StudyMaterialAiGateway;
 import com.f1.quiket.domain.material.port.StudyMaterialPdfTextExtractor;
 import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -21,6 +24,7 @@ import org.springframework.util.StringUtils;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class StudyMaterialTextExtractor {
 
     private final StudyMaterialAiGateway studyMaterialAiGateway;
@@ -56,15 +60,34 @@ public class StudyMaterialTextExtractor {
      */
     private StudyMaterialTextExtractionResult extractImage(StudyMaterialTextExtractionRequest request) {
         StudyMaterialAiPrompt prompt = promptBuilder.buildOcrPrompt();
-        // Gemini 기반 이미지 OCR
-        String extractedText = studyMaterialAiGateway.generateFromImages(
-                prompt.systemMessage(),
-                prompt.userMessage(),
-                request.getFiles()
-        );
+        List<String> extractedTexts = new ArrayList<>();
+        List<Integer> failedDisplayOrders = new ArrayList<>();
+        for (int i = 0; i < request.getFiles().size(); i++) {
+            StudyMaterialFile imageFile = request.getFiles().get(i);
+            try {
+                // Gemini 기반 이미지 OCR
+                String extractedText = studyMaterialAiGateway.generateFromImages(
+                        prompt.systemMessage(),
+                        prompt.userMessage(),
+                        List.of(imageFile)
+                );
+                if (!StringUtils.hasText(extractedText)) {
+                    failedDisplayOrders.add(i + 1);
+                    continue;
+                }
+                extractedTexts.add(extractedText.trim());
+            } catch (Exception e) {
+                log.warn("Image OCR failed. displayOrder={}, fileName={}, reason={}",
+                        i + 1,
+                        imageFile.getFileName(),
+                        e.getMessage());
+                failedDisplayOrders.add(i + 1);
+            }
+        }
         return StudyMaterialTextExtractionResult.builder()
                 .provider("gemini")
-                .extractedText(extractedText.trim())
+                .extractedText(String.join("\n\n", extractedTexts))
+                .failedDisplayOrders(failedDisplayOrders)
                 .build();
     }
 

--- a/src/main/java/com/f1/quiket/domain/part/controller/PartController.java
+++ b/src/main/java/com/f1/quiket/domain/part/controller/PartController.java
@@ -1,0 +1,128 @@
+package com.f1.quiket.domain.part.controller;
+
+import com.f1.quiket.domain.lecture.dto.LectureUploadAcceptedResponse;
+import com.f1.quiket.domain.part.dto.PartResponse;
+import com.f1.quiket.domain.part.dto.PartTextAddRequest;
+import com.f1.quiket.domain.part.dto.PartUpdateRequest;
+import com.f1.quiket.domain.part.service.PartAddCreateService;
+import com.f1.quiket.domain.part.service.PartQueryService;
+import com.f1.quiket.global.auth.UserPrincipal;
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.SuccessCode;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 파트 관리 API 진입점
+ *
+ * 파트 상세 조회, 파트명/본문 수정, 기존 챕터 파트 추가를 제공
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class PartController {
+
+    private final PartQueryService partQueryService;
+    private final PartAddCreateService partAddCreateService;
+
+    /**
+     * 파트 상세 조회
+     *
+     * @param principal 인증 사용자
+     * @param partId 파트 공개 식별자
+     * @return 파트 상세 응답
+     */
+    @GetMapping("/parts/{partId}")
+    public ResponseEntity<ApiResponse<PartResponse>> getPart(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("partId") String partId
+    ) {
+        PartResponse response = partQueryService.getPart(principal.getUserId(), partId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 파트명 및 본문 수정
+     *
+     * @param principal 인증 사용자
+     * @param partId 파트 공개 식별자
+     * @param request 파트 수정 요청
+     * @return 수정된 파트 상세 응답
+     */
+    @PatchMapping("/parts/{partId}")
+    public ResponseEntity<ApiResponse<PartResponse>> updatePart(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("partId") String partId,
+            @RequestBody PartUpdateRequest request
+    ) {
+        PartResponse response = partQueryService.updatePart(principal.getUserId(), partId, request);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 텍스트 직접 입력 파트 추가 접수
+     *
+     * @param principal 인증 사용자
+     * @param chapterId 챕터 공개 식별자
+     * @param request 텍스트 파트 추가 요청
+     * @return 업로드 접수 응답
+     */
+    @PostMapping(value = "/chapters/{chapterId}/parts", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<LectureUploadAcceptedResponse>> addTextPart(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("chapterId") String chapterId,
+            @RequestBody PartTextAddRequest request
+    ) {
+        LectureUploadAcceptedResponse response = partAddCreateService.createTextPart(
+                principal.getUserId(),
+                chapterId,
+                request
+        );
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(ApiResponse.success(SuccessCode.ACCEPTED, response));
+    }
+
+    /**
+     * PDF 또는 이미지 파일 파트 추가 접수
+     *
+     * @param principal 인증 사용자
+     * @param chapterId 챕터 공개 식별자
+     * @param partName 파트명
+     * @param uploadType pdf 또는 image
+     * @param files 업로드 파일 목록
+     * @return 업로드 접수 응답
+     */
+    @PostMapping(value = "/chapters/{chapterId}/parts", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<LectureUploadAcceptedResponse>> addFilePart(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("chapterId") String chapterId,
+            @RequestParam("partName") String partName,
+            @RequestParam("uploadType") String uploadType,
+            @RequestParam("files") List<MultipartFile> files
+    ) {
+        LectureUploadAcceptedResponse response = partAddCreateService.createFilePart(
+                principal.getUserId(),
+                chapterId,
+                partName,
+                uploadType,
+                files
+        );
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .body(ApiResponse.success(SuccessCode.ACCEPTED, response));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/part/dto/PartResponse.java
+++ b/src/main/java/com/f1/quiket/domain/part/dto/PartResponse.java
@@ -1,0 +1,62 @@
+package com.f1.quiket.domain.part.dto;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.lecture.entity.LectureUpload;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.subject.entity.Subject;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.util.StringUtils;
+
+/**
+ * 파트 상세 응답 DTO
+ *
+ * 파트 공개 식별자와 소속 과목/챕터/업로드 공개 식별자, 본문을 전달
+ */
+@Getter
+@Builder
+public class PartResponse {
+
+    private static final int PREVIEW_LENGTH = 30;
+
+    private final String id;
+    private final String subjectId;
+    private final String chapterId;
+    private final String lectureUploadId;
+    private final String name;
+    private final Integer partNumber;
+    private final String content;
+    private final String contentPreview;
+
+    /**
+     * 엔티티 기반 파트 상세 응답 생성
+     */
+    public static PartResponse of(
+            Part part,
+            Subject subject,
+            Chapter chapter,
+            LectureUpload lectureUpload
+    ) {
+        return PartResponse.builder()
+                .id(part.getPublicId())
+                .subjectId(subject.getPublicId())
+                .chapterId(chapter.getPublicId())
+                .lectureUploadId(lectureUpload == null ? null : lectureUpload.getPublicId())
+                .name(part.getName())
+                .partNumber(part.getPartNumber())
+                .content(part.getContent())
+                .contentPreview(preview(part.getContent()))
+                .build();
+    }
+
+    private static String preview(String content) {
+        if (!StringUtils.hasText(content)) {
+            return null;
+        }
+        String normalized = content.trim();
+        if (normalized.length() <= PREVIEW_LENGTH) {
+            return normalized;
+        }
+        return normalized.substring(0, PREVIEW_LENGTH);
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/part/dto/PartTextAddRequest.java
+++ b/src/main/java/com/f1/quiket/domain/part/dto/PartTextAddRequest.java
@@ -1,0 +1,18 @@
+package com.f1.quiket.domain.part.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 텍스트 직접 입력 파트 추가 요청 DTO
+ *
+ * 추가할 파트명, 업로드 타입, 본문 텍스트 전달
+ */
+@Getter
+@NoArgsConstructor
+public class PartTextAddRequest {
+
+    private String partName;
+    private String uploadType;
+    private String text;
+}

--- a/src/main/java/com/f1/quiket/domain/part/dto/PartUpdateRequest.java
+++ b/src/main/java/com/f1/quiket/domain/part/dto/PartUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.f1.quiket.domain.part.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 파트 수정 요청 DTO
+ *
+ * 변경할 파트명과 본문 전달
+ */
+@Getter
+@NoArgsConstructor
+public class PartUpdateRequest {
+
+    private String name;
+    private String content;
+}

--- a/src/main/java/com/f1/quiket/domain/part/entity/Part.java
+++ b/src/main/java/com/f1/quiket/domain/part/entity/Part.java
@@ -84,4 +84,12 @@ public class Part extends BaseEntity {
         part.contentDeleted = false;
         return part;
     }
+
+    /**
+     * 파트명과 본문 변경
+     */
+    public void updateContent(String name, String content) {
+        this.name = name;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/f1/quiket/domain/part/event/PartAddProcessingRequestedEvent.java
+++ b/src/main/java/com/f1/quiket/domain/part/event/PartAddProcessingRequestedEvent.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.part.event;
+
+import com.f1.quiket.domain.material.dto.StudyMaterialFile;
+import com.f1.quiket.domain.material.dto.StudyMaterialUploadType;
+import java.util.List;
+
+/**
+ * 기존 챕터 파트 추가 비동기 처리 요청 이벤트
+ *
+ * 업로드 접수 커밋 이후 OCR/텍스트 추출과 단일 파트 생성을 시작하기 위한 데이터 전달
+ */
+public record PartAddProcessingRequestedEvent(
+        Long lectureUploadId,
+        Long chapterId,
+        Long subjectId,
+        Long userId,
+        String partName,
+        Integer partNumber,
+        StudyMaterialUploadType uploadType,
+        String text,
+        List<StudyMaterialFile> files
+) {
+}

--- a/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
@@ -3,6 +3,7 @@ package com.f1.quiket.domain.part.repository;
 import com.f1.quiket.domain.part.entity.Part;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,6 +14,11 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public interface PartRepository extends JpaRepository<Part, Long> {
+
+    /**
+     * 공개 식별자 기반 사용자 파트 조회
+     */
+    Optional<Part> findByPublicIdAndUserIdAndContentDeletedFalseAndDeletedAtIsNull(String publicId, Long userId);
 
     /**
      * 사용자 파트 목록 조회
@@ -76,4 +82,15 @@ public interface PartRepository extends JpaRepository<Part, Long> {
             Long lectureUploadId,
             Long userId
     );
+
+    /**
+     * 챕터 내 마지막 파트 번호 조회
+     */
+    @Query("""
+            select coalesce(max(p.partNumber), 0)
+            from Part p
+            where p.chapterId = :chapterId
+              and p.deletedAt is null
+            """)
+    int findMaxPartNumberByChapterId(@Param("chapterId") Long chapterId);
 }

--- a/src/main/java/com/f1/quiket/domain/part/service/PartAddCreateService.java
+++ b/src/main/java/com/f1/quiket/domain/part/service/PartAddCreateService.java
@@ -1,0 +1,294 @@
+package com.f1.quiket.domain.part.service;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.lecture.dto.LectureUploadAcceptedResponse;
+import com.f1.quiket.domain.lecture.dto.PartSplitMethod;
+import com.f1.quiket.domain.lecture.entity.LectureProcessingJob;
+import com.f1.quiket.domain.lecture.entity.LectureUpload;
+import com.f1.quiket.domain.lecture.entity.LectureUploadFile;
+import com.f1.quiket.domain.lecture.repository.LectureProcessingJobRepository;
+import com.f1.quiket.domain.lecture.repository.LectureUploadFileRepository;
+import com.f1.quiket.domain.lecture.repository.LectureUploadRepository;
+import com.f1.quiket.domain.material.dto.StudyMaterialFile;
+import com.f1.quiket.domain.material.dto.StudyMaterialUploadType;
+import com.f1.quiket.domain.part.dto.PartTextAddRequest;
+import com.f1.quiket.domain.part.event.PartAddProcessingRequestedEvent;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 기존 챕터 파트 추가 접수 서비스
+ *
+ * 요청 검증, 챕터/업로드/파일 메타데이터 저장, 단일 파트 추가 처리 이벤트 발행을 담당
+ */
+@Service
+@RequiredArgsConstructor
+public class PartAddCreateService {
+
+    private static final long MAX_UPLOAD_SIZE_BYTES = 50L * 1024L * 1024L;
+    private static final int MIN_TEXT_LENGTH = 100;
+    private static final int MAX_TEXT_LENGTH = 30000;
+    private static final int MAX_PART_NAME_LENGTH = 30;
+    private static final int ESTIMATED_SECONDS = 30;
+
+    private final ChapterRepository chapterRepository;
+    private final SubjectRepository subjectRepository;
+    private final PartRepository partRepository;
+    private final LectureUploadRepository lectureUploadRepository;
+    private final LectureUploadFileRepository lectureUploadFileRepository;
+    private final LectureProcessingJobRepository lectureProcessingJobRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * 텍스트 직접 입력 파트 추가 접수
+     *
+     * @param userId 인증 사용자 내부 식별자
+     * @param chapterPublicId 챕터 공개 식별자
+     * @param request 텍스트 파트 추가 요청
+     * @return 업로드 접수 응답
+     */
+    @Transactional
+    public LectureUploadAcceptedResponse createTextPart(
+            Long userId,
+            String chapterPublicId,
+            PartTextAddRequest request
+    ) {
+        String partName = normalizePartName(request == null ? null : request.getPartName());
+        StudyMaterialUploadType uploadType = parseUploadType(request == null ? null : request.getUploadType());
+        validateTextUpload(uploadType);
+        String text = normalizeText(request == null ? null : request.getText());
+
+        Chapter chapter = getOwnedChapter(userId, chapterPublicId);
+        Subject subject = getOwnedSubject(userId, chapter.getSubjectId());
+        int nextPartNumber = partRepository.findMaxPartNumberByChapterId(chapter.getId()) + 1;
+        LectureUpload upload = saveUpload(chapter, userId, uploadType);
+        upload.storeRawText(text);
+        saveProcessingJob(upload.getId(), userId);
+
+        eventPublisher.publishEvent(new PartAddProcessingRequestedEvent(
+                upload.getId(),
+                chapter.getId(),
+                subject.getId(),
+                userId,
+                partName,
+                nextPartNumber,
+                uploadType,
+                text,
+                List.of()
+        ));
+
+        return LectureUploadAcceptedResponse.of(upload, subject, chapter);
+    }
+
+    /**
+     * PDF 또는 이미지 파일 기반 파트 추가 접수
+     *
+     * @param userId 인증 사용자 내부 식별자
+     * @param chapterPublicId 챕터 공개 식별자
+     * @param partNameValue 파트명
+     * @param uploadTypeValue pdf 또는 image
+     * @param multipartFiles 업로드 파일 목록
+     * @return 업로드 접수 응답
+     */
+    @Transactional
+    public LectureUploadAcceptedResponse createFilePart(
+            Long userId,
+            String chapterPublicId,
+            String partNameValue,
+            String uploadTypeValue,
+            List<MultipartFile> multipartFiles
+    ) {
+        String partName = normalizePartName(partNameValue);
+        StudyMaterialUploadType uploadType = parseUploadType(uploadTypeValue);
+        List<StudyMaterialFile> files = validateAndReadFiles(uploadType, multipartFiles);
+
+        Chapter chapter = getOwnedChapter(userId, chapterPublicId);
+        Subject subject = getOwnedSubject(userId, chapter.getSubjectId());
+        int nextPartNumber = partRepository.findMaxPartNumberByChapterId(chapter.getId()) + 1;
+        LectureUpload upload = saveUpload(chapter, userId, uploadType);
+        saveProcessingJob(upload.getId(), userId);
+        saveUploadFiles(upload, uploadType, files);
+
+        eventPublisher.publishEvent(new PartAddProcessingRequestedEvent(
+                upload.getId(),
+                chapter.getId(),
+                subject.getId(),
+                userId,
+                partName,
+                nextPartNumber,
+                uploadType,
+                null,
+                files
+        ));
+
+        return LectureUploadAcceptedResponse.of(upload, subject, chapter);
+    }
+
+    private Chapter getOwnedChapter(Long userId, String chapterPublicId) {
+        if (!StringUtils.hasText(chapterPublicId)) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "chapterId는 필수입니다.");
+        }
+        // 챕터 소유권 검증
+        return chapterRepository.findForUpdateByPublicIdAndUserIdAndDeletedAtIsNull(chapterPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+    }
+
+    private Subject getOwnedSubject(Long userId, Long subjectId) {
+        return subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subjectId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+    }
+
+    private LectureUpload saveUpload(Chapter chapter, Long userId, StudyMaterialUploadType uploadType) {
+        return lectureUploadRepository.save(
+                LectureUpload.create(chapter.getId(), userId, uploadType, PartSplitMethod.MANUAL)
+        );
+    }
+
+    private StudyMaterialUploadType parseUploadType(String value) {
+        try {
+            return StudyMaterialUploadType.from(value);
+        } catch (IllegalArgumentException e) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "지원하지 않는 업로드 타입입니다.");
+        }
+    }
+
+    private String normalizePartName(String value) {
+        if (!StringUtils.hasText(value)) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "파트명을 입력해주세요");
+        }
+        String normalized = value.trim();
+        if (normalized.length() > MAX_PART_NAME_LENGTH) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "파트명은 30자 이하로 입력해주세요");
+        }
+        return normalized;
+    }
+
+    private String normalizeText(String text) {
+        if (!StringUtils.hasText(text)) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "파트 내용을 입력해주세요");
+        }
+        String normalized = text.trim();
+        if (normalized.length() < MIN_TEXT_LENGTH) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "text는 100자 이상 입력해주세요.");
+        }
+        if (normalized.length() > MAX_TEXT_LENGTH) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "파트 내용은 30,000자 이하로 입력해주세요");
+        }
+        return normalized;
+    }
+
+    private void validateTextUpload(StudyMaterialUploadType uploadType) {
+        if (uploadType != StudyMaterialUploadType.TEXT) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "텍스트 업로드는 uploadType=text만 사용할 수 있습니다.");
+        }
+    }
+
+    private List<StudyMaterialFile> validateAndReadFiles(
+            StudyMaterialUploadType uploadType,
+            List<MultipartFile> multipartFiles
+    ) {
+        if (uploadType == StudyMaterialUploadType.TEXT) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "파일 업로드는 uploadType=pdf 또는 image만 사용할 수 있습니다.");
+        }
+        if (multipartFiles == null || multipartFiles.isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "files는 필수입니다.");
+        }
+        if (uploadType == StudyMaterialUploadType.PDF && multipartFiles.size() != 1) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "PDF 파일은 1개만 업로드할 수 있습니다.");
+        }
+
+        long totalSize = multipartFiles.stream().mapToLong(MultipartFile::getSize).sum();
+        if (totalSize > MAX_UPLOAD_SIZE_BYTES) {
+            throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED, "파일 크기는 50MB 이하만 업로드 가능합니다");
+        }
+
+        List<StudyMaterialFile> files = new ArrayList<>();
+        for (MultipartFile multipartFile : multipartFiles) {
+            validateFileType(uploadType, multipartFile);
+            try {
+                files.add(StudyMaterialFile.builder()
+                        .fileName(resolveFileName(multipartFile))
+                        .contentType(resolveContentType(multipartFile))
+                        .bytes(multipartFile.getBytes())
+                        .build());
+            } catch (IOException e) {
+                throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "업로드에 실패했어요. 다시 시도해주세요", e);
+            }
+        }
+        return files;
+    }
+
+    private void validateFileType(StudyMaterialUploadType uploadType, MultipartFile file) {
+        String filename = resolveFileName(file).toLowerCase(Locale.ROOT);
+        String contentType = resolveContentType(file).toLowerCase(Locale.ROOT);
+        // 파일 형식 검증
+        if (uploadType == StudyMaterialUploadType.PDF
+                && !("application/pdf".equals(contentType) || filename.endsWith(".pdf"))) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "지원하지 않는 파일 형식이에요");
+        }
+        if (uploadType == StudyMaterialUploadType.IMAGE
+                && !(isSupportedImageContentType(contentType) || isSupportedImageFileName(filename))) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "JPG, PNG 형식만 지원해요");
+        }
+    }
+
+    private boolean isSupportedImageContentType(String contentType) {
+        return "image/jpeg".equals(contentType) || "image/png".equals(contentType);
+    }
+
+    private boolean isSupportedImageFileName(String filename) {
+        return filename.endsWith(".jpg") || filename.endsWith(".jpeg") || filename.endsWith(".png");
+    }
+
+    private String resolveFileName(MultipartFile file) {
+        return StringUtils.hasText(file.getOriginalFilename()) ? file.getOriginalFilename() : "upload";
+    }
+
+    private String resolveContentType(MultipartFile file) {
+        return StringUtils.hasText(file.getContentType()) ? file.getContentType() : "application/octet-stream";
+    }
+
+    private void saveUploadFiles(
+            LectureUpload upload,
+            StudyMaterialUploadType uploadType,
+            List<StudyMaterialFile> files
+    ) {
+        List<LectureUploadFile> uploadFiles = new ArrayList<>();
+        for (int i = 0; i < files.size(); i++) {
+            StudyMaterialFile file = files.get(i);
+            uploadFiles.add(LectureUploadFile.create(
+                    upload.getId(),
+                    "memory://lecture-uploads/%s/%d".formatted(upload.getPublicId(), i + 1),
+                    file.getFileName(),
+                    (long) file.getBytes().length,
+                    trimFileType(file.getContentType()),
+                    i + 1,
+                    uploadType == StudyMaterialUploadType.IMAGE ? "pending" : null
+            ));
+        }
+        lectureUploadFileRepository.saveAll(uploadFiles);
+    }
+
+    private String trimFileType(String contentType) {
+        String resolved = StringUtils.hasText(contentType) ? contentType : "application/octet";
+        return resolved.length() <= 20 ? resolved : resolved.substring(0, 20);
+    }
+
+    private void saveProcessingJob(Long lectureUploadId, Long userId) {
+        lectureProcessingJobRepository.save(LectureProcessingJob.create(lectureUploadId, userId, ESTIMATED_SECONDS));
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/part/service/PartAddProcessingService.java
+++ b/src/main/java/com/f1/quiket/domain/part/service/PartAddProcessingService.java
@@ -1,0 +1,181 @@
+package com.f1.quiket.domain.part.service;
+
+import com.f1.quiket.domain.lecture.entity.LectureProcessingJob;
+import com.f1.quiket.domain.lecture.entity.LectureUpload;
+import com.f1.quiket.domain.lecture.entity.LectureUploadFile;
+import com.f1.quiket.domain.lecture.repository.LectureProcessingJobRepository;
+import com.f1.quiket.domain.lecture.repository.LectureUploadFileRepository;
+import com.f1.quiket.domain.lecture.repository.LectureUploadRepository;
+import com.f1.quiket.domain.material.dto.StudyMaterialTextExtractionRequest;
+import com.f1.quiket.domain.material.dto.StudyMaterialTextExtractionResult;
+import com.f1.quiket.domain.material.dto.StudyMaterialUploadType;
+import com.f1.quiket.domain.material.processor.StudyMaterialTextExtractor;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.event.PartAddProcessingRequestedEvent;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.util.StringUtils;
+
+/**
+ * 기존 챕터 파트 추가 비동기 처리 서비스
+ *
+ * 텍스트 직접 입력, PDF 텍스트 추출, 이미지 OCR 결과를 단일 파트로 저장
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PartAddProcessingService {
+
+    private static final int MAX_PART_CONTENT_LENGTH = 30000;
+    private static final int ESTIMATED_SECONDS = 30;
+
+    private final LectureUploadRepository lectureUploadRepository;
+    private final LectureUploadFileRepository lectureUploadFileRepository;
+    private final LectureProcessingJobRepository lectureProcessingJobRepository;
+    private final PartRepository partRepository;
+    private final StudyMaterialTextExtractor studyMaterialTextExtractor;
+    private final PlatformTransactionManager transactionManager;
+
+    /**
+     * 파트 추가 접수 커밋 이후 비동기 처리 시작
+     *
+     * @param event 파트 추가 처리 요청 이벤트
+     */
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(PartAddProcessingRequestedEvent event) {
+        process(event);
+    }
+
+    /**
+     * OCR/텍스트 추출 후 단일 파트 저장
+     *
+     * @param event 파트 추가 처리 요청 이벤트
+     */
+    public void process(PartAddProcessingRequestedEvent event) {
+        try {
+            markProcessing(event.lectureUploadId());
+
+            // PDF 텍스트 추출 또는 Gemini OCR 호출
+            StudyMaterialTextExtractionResult result = studyMaterialTextExtractor.extract(
+                    StudyMaterialTextExtractionRequest.builder()
+                            .uploadType(event.uploadType())
+                            .text(event.text())
+                            .files(event.files())
+                            .build()
+            );
+
+            saveCompleted(event, result);
+        } catch (Exception e) {
+            log.warn("Part add processing failed. lectureUploadId={}", event.lectureUploadId(), e);
+            markFailed(event, failMessage(e));
+        }
+    }
+
+    private void markProcessing(Long lectureUploadId) {
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            LectureUpload upload = getUpload(lectureUploadId);
+            // lecture_uploads.status=processing
+            upload.markProcessing();
+            getOrCreateJob(upload).markInProgress();
+        });
+    }
+
+    private void saveCompleted(PartAddProcessingRequestedEvent event, StudyMaterialTextExtractionResult result) {
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            LectureUpload upload = getUpload(event.lectureUploadId());
+            String content = normalizeExtractedText(result.getExtractedText());
+
+            // parts 저장
+            partRepository.save(Part.createFromLectureUpload(
+                    event.chapterId(),
+                    event.subjectId(),
+                    event.userId(),
+                    upload.getId(),
+                    event.partName(),
+                    event.partNumber(),
+                    content
+            ));
+
+            if (event.uploadType() == StudyMaterialUploadType.IMAGE) {
+                updateImageOcrStatuses(upload, result);
+            }
+
+            // lecture_uploads.status=completed
+            upload.markCompleted(content);
+            getOrCreateJob(upload).markCompleted();
+        });
+    }
+
+    private void updateImageOcrStatuses(LectureUpload upload, StudyMaterialTextExtractionResult result) {
+        Set<Integer> failedDisplayOrders = new HashSet<>(
+                result.getFailedDisplayOrders() == null ? Set.of() : result.getFailedDisplayOrders()
+        );
+        // 이미지 OCR 성공/실패 상태 반영
+        lectureUploadFileRepository.findAllByLectureUploadIdAndDeletedAtIsNullOrderByDisplayOrderAsc(upload.getId())
+                .forEach(file -> {
+                    if (failedDisplayOrders.contains(file.getDisplayOrder())) {
+                        file.markOcrFailed();
+                        return;
+                    }
+                    file.markOcrSuccess();
+                });
+    }
+
+    private String normalizeExtractedText(String extractedText) {
+        if (!StringUtils.hasText(extractedText)) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "이미지를 인식하지 못했어요. 다른 이미지를 시도해주세요");
+        }
+        String normalized = extractedText.trim();
+        if (normalized.length() > MAX_PART_CONTENT_LENGTH) {
+            throw new CustomException(
+                    ErrorCode.UNPROCESSABLE_ENTITY,
+                    "파트 내용은 30,000자 이하로 저장할 수 있어요. 더 작은 범위로 나누어 업로드해주세요"
+            );
+        }
+        return normalized;
+    }
+
+    private void markFailed(PartAddProcessingRequestedEvent event, String failReason) {
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            LectureUpload upload = getUpload(event.lectureUploadId());
+            // OCR 전체 실패/추출 실패 처리
+            upload.markFailed();
+            getOrCreateJob(upload).markFailed("processing_failed", failReason);
+            if (event.uploadType() == StudyMaterialUploadType.IMAGE) {
+                lectureUploadFileRepository.findAllByLectureUploadIdAndDeletedAtIsNullOrderByDisplayOrderAsc(upload.getId())
+                        .forEach(LectureUploadFile::markOcrFailed);
+            }
+        });
+    }
+
+    private LectureUpload getUpload(Long lectureUploadId) {
+        return lectureUploadRepository.findById(lectureUploadId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+    }
+
+    private LectureProcessingJob getOrCreateJob(LectureUpload upload) {
+        return lectureProcessingJobRepository.findByLectureUploadId(upload.getId())
+                .orElseGet(() -> lectureProcessingJobRepository.save(
+                        LectureProcessingJob.create(upload.getId(), upload.getUserId(), ESTIMATED_SECONDS)
+                ));
+    }
+
+    private String failMessage(Exception e) {
+        if (e instanceof CustomException customException && StringUtils.hasText(customException.getMessage())) {
+            return customException.getMessage();
+        }
+        return "업로드에 실패했어요. 다시 시도해주세요";
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/part/service/PartQueryService.java
+++ b/src/main/java/com/f1/quiket/domain/part/service/PartQueryService.java
@@ -1,0 +1,111 @@
+package com.f1.quiket.domain.part.service;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.lecture.entity.LectureUpload;
+import com.f1.quiket.domain.lecture.repository.LectureUploadRepository;
+import com.f1.quiket.domain.part.dto.PartResponse;
+import com.f1.quiket.domain.part.dto.PartUpdateRequest;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * 파트 조회 및 수정 서비스
+ *
+ * 공개 식별자 기반 파트 소유권 검증, 상세 응답 조립, 파트명/본문 변경을 담당
+ */
+@Service
+@RequiredArgsConstructor
+public class PartQueryService {
+
+    private static final int MAX_NAME_LENGTH = 30;
+    private static final int MAX_CONTENT_LENGTH = 30000;
+
+    private final PartRepository partRepository;
+    private final SubjectRepository subjectRepository;
+    private final ChapterRepository chapterRepository;
+    private final LectureUploadRepository lectureUploadRepository;
+
+    /**
+     * 파트 상세 조회
+     *
+     * @param userId 인증 사용자 내부 식별자
+     * @param partPublicId 파트 공개 식별자
+     * @return 파트 상세 응답
+     */
+    @Transactional(readOnly = true)
+    public PartResponse getPart(Long userId, String partPublicId) {
+        Part part = getOwnedPart(userId, partPublicId);
+        return toResponse(userId, part);
+    }
+
+    /**
+     * 파트명 및 본문 수정
+     *
+     * @param userId 인증 사용자 내부 식별자
+     * @param partPublicId 파트 공개 식별자
+     * @param request 수정 요청
+     * @return 수정된 파트 상세 응답
+     */
+    @Transactional
+    public PartResponse updatePart(Long userId, String partPublicId, PartUpdateRequest request) {
+        Part part = getOwnedPart(userId, partPublicId);
+        String name = normalizeName(request == null ? null : request.getName());
+        String content = normalizeContent(request == null ? null : request.getContent());
+        part.updateContent(name, content);
+        return toResponse(userId, part);
+    }
+
+    private Part getOwnedPart(Long userId, String partPublicId) {
+        if (!StringUtils.hasText(partPublicId)) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "partId는 필수입니다.");
+        }
+        // 파트 소유권 검증
+        return partRepository.findByPublicIdAndUserIdAndContentDeletedFalseAndDeletedAtIsNull(partPublicId, userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+    }
+
+    private PartResponse toResponse(Long userId, Part part) {
+        Subject subject = subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(part.getSubjectId(), userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBJECT_NOT_FOUND));
+        Chapter chapter = chapterRepository.findById(part.getChapterId())
+                .filter(found -> found.getDeletedAt() == null && found.getUserId().equals(userId))
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+        LectureUpload lectureUpload = part.getLectureUploadId() == null
+                ? null
+                : lectureUploadRepository.findById(part.getLectureUploadId())
+                        .filter(found -> found.getDeletedAt() == null && found.getUserId().equals(userId))
+                        .orElse(null);
+        return PartResponse.of(part, subject, chapter, lectureUpload);
+    }
+
+    private String normalizeName(String value) {
+        if (!StringUtils.hasText(value)) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "파트명을 입력해주세요");
+        }
+        String normalized = value.trim();
+        if (normalized.length() > MAX_NAME_LENGTH) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "파트명은 30자 이하로 입력해주세요");
+        }
+        return normalized;
+    }
+
+    private String normalizeContent(String value) {
+        if (!StringUtils.hasText(value)) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "파트 내용을 입력해주세요");
+        }
+        String normalized = value.trim();
+        if (normalized.length() > MAX_CONTENT_LENGTH) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "파트 내용은 30,000자 이하로 입력해주세요");
+        }
+        return normalized;
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/subject/controller/SubjectController.java
+++ b/src/main/java/com/f1/quiket/domain/subject/controller/SubjectController.java
@@ -72,7 +72,7 @@ public class SubjectController {
     @GetMapping("/{subjectId}")
     public ResponseEntity<ApiResponse<SubjectDetailResponse>> getSubject(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable String subjectId
+            @PathVariable("subjectId") String subjectId
     ) {
         SubjectDetailResponse response = subjectService.getSubject(principal.getPublicId(), subjectId);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
@@ -84,7 +84,7 @@ public class SubjectController {
     @GetMapping("/{subjectId}/quiz-scope")
     public ResponseEntity<ApiResponse<QuizScopeResponse>> getQuizScope(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable String subjectId
+            @PathVariable("subjectId") String subjectId
     ) {
         QuizScopeResponse response = quizScopeService.getQuizScope(principal.getUserId(), subjectId);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
@@ -96,7 +96,7 @@ public class SubjectController {
     @DeleteMapping("/{subjectId}")
     public ResponseEntity<ApiResponse<Void>> deleteSubject(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable String subjectId
+            @PathVariable("subjectId") String subjectId
     ) {
         subjectService.deleteSubject(principal.getPublicId(), subjectId);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));
@@ -108,7 +108,7 @@ public class SubjectController {
     @PatchMapping("/{subjectId}/name")
     public ResponseEntity<ApiResponse<SubjectResponse>> updateSubjectName(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable String subjectId,
+            @PathVariable("subjectId") String subjectId,
             @Valid @RequestBody SubjectNameUpdateRequest request
     ) {
         SubjectResponse response = subjectService.updateSubjectName(principal.getPublicId(), subjectId, request.getName());
@@ -121,7 +121,7 @@ public class SubjectController {
     @PutMapping("/{subjectId}/details")
     public ResponseEntity<ApiResponse<SubjectDetailResponse>> updateSubjectDetails(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable String subjectId,
+            @PathVariable("subjectId") String subjectId,
             @Valid @RequestBody SubjectDetailUpdateRequest request
     ) {
         SubjectDetailResponse response = subjectService.updateSubjectDetails(principal.getPublicId(), subjectId, request);
@@ -134,7 +134,7 @@ public class SubjectController {
     @PutMapping("/{subjectId}/exam-schedule")
     public ResponseEntity<ApiResponse<SubjectExamScheduleResponse>> upsertSubjectExamSchedule(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable String subjectId,
+            @PathVariable("subjectId") String subjectId,
             @Valid @RequestBody SubjectExamScheduleUpsertRequest request
     ) {
         SubjectExamScheduleResponse response = subjectService.upsertExamSchedule(principal.getPublicId(), subjectId, request);
@@ -147,7 +147,7 @@ public class SubjectController {
     @DeleteMapping("/{subjectId}/exam-schedule")
     public ResponseEntity<ApiResponse<Void>> deleteSubjectExamSchedule(
             @AuthenticationPrincipal UserPrincipal principal,
-            @PathVariable String subjectId
+            @PathVariable("subjectId") String subjectId
     ) {
         subjectService.deleteExamSchedule(principal.getPublicId(), subjectId);
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK));

--- a/src/test/java/com/f1/quiket/domain/material/processor/StudyMaterialTextExtractorTest.java
+++ b/src/test/java/com/f1/quiket/domain/material/processor/StudyMaterialTextExtractorTest.java
@@ -124,4 +124,36 @@ class StudyMaterialTextExtractorTest {
         assertThat(result.getExtractedText()).isEqualTo("이미지 OCR 본문");
         verify(studyMaterialAiGateway).generateFromImages(any(), any(), any());
     }
+
+    @Test
+    void extract_image_keeps_success_text_and_records_failed_display_order() {
+        StudyMaterialFile successImage = StudyMaterialFile.builder()
+                .fileName("slide1.png")
+                .contentType("image/png")
+                .bytes("image1".getBytes())
+                .build();
+        StudyMaterialFile failedImage = StudyMaterialFile.builder()
+                .fileName("slide2.png")
+                .contentType("image/png")
+                .bytes("image2".getBytes())
+                .build();
+        when(studyMaterialAiGateway.generateFromImages(any(), any(), any()))
+                .thenAnswer(invocation -> {
+                    List<StudyMaterialFile> files = invocation.getArgument(2);
+                    if (files.get(0) == failedImage) {
+                        throw new RuntimeException("ocr failed");
+                    }
+                    return "첫 번째 이미지 OCR 본문";
+                });
+
+        StudyMaterialTextExtractionResult result = studyMaterialTextExtractor.extract(
+                StudyMaterialTextExtractionRequest.builder()
+                        .uploadType(StudyMaterialUploadType.IMAGE)
+                        .files(List.of(successImage, failedImage))
+                        .build()
+        );
+
+        assertThat(result.getExtractedText()).isEqualTo("첫 번째 이미지 OCR 본문");
+        assertThat(result.getFailedDisplayOrders()).containsExactly(2);
+    }
 }

--- a/src/test/java/com/f1/quiket/domain/part/service/PartAddCreateServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/part/service/PartAddCreateServiceTest.java
@@ -1,0 +1,143 @@
+package com.f1.quiket.domain.part.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.lecture.dto.LectureUploadAcceptedResponse;
+import com.f1.quiket.domain.lecture.entity.LectureUpload;
+import com.f1.quiket.domain.lecture.repository.LectureProcessingJobRepository;
+import com.f1.quiket.domain.lecture.repository.LectureUploadFileRepository;
+import com.f1.quiket.domain.lecture.repository.LectureUploadRepository;
+import com.f1.quiket.domain.part.dto.PartTextAddRequest;
+import com.f1.quiket.domain.part.event.PartAddProcessingRequestedEvent;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class PartAddCreateServiceTest {
+
+    private ChapterRepository chapterRepository;
+    private SubjectRepository subjectRepository;
+    private PartRepository partRepository;
+    private LectureUploadRepository lectureUploadRepository;
+    private LectureUploadFileRepository lectureUploadFileRepository;
+    private LectureProcessingJobRepository lectureProcessingJobRepository;
+    private ApplicationEventPublisher eventPublisher;
+    private PartAddCreateService service;
+
+    @BeforeEach
+    void setUp() {
+        chapterRepository = mock(ChapterRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        partRepository = mock(PartRepository.class);
+        lectureUploadRepository = mock(LectureUploadRepository.class);
+        lectureUploadFileRepository = mock(LectureUploadFileRepository.class);
+        lectureProcessingJobRepository = mock(LectureProcessingJobRepository.class);
+        eventPublisher = mock(ApplicationEventPublisher.class);
+        service = new PartAddCreateService(
+                chapterRepository,
+                subjectRepository,
+                partRepository,
+                lectureUploadRepository,
+                lectureUploadFileRepository,
+                lectureProcessingJobRepository,
+                eventPublisher
+        );
+    }
+
+    @Test
+    void create_text_part_saves_upload_and_publishes_single_part_event() {
+        Subject subject = subject(10L, "subject-public-id", 1L);
+        Chapter chapter = chapter(20L, "chapter-public-id", subject.getId(), 1L);
+        LectureUpload upload = LectureUpload.create(chapter.getId(), 1L,
+                com.f1.quiket.domain.material.dto.StudyMaterialUploadType.TEXT,
+                com.f1.quiket.domain.lecture.dto.PartSplitMethod.MANUAL);
+        ReflectionTestUtils.setField(upload, "id", 30L);
+        ReflectionTestUtils.setField(upload, "publicId", "upload-public-id");
+
+        when(chapterRepository.findForUpdateByPublicIdAndUserIdAndDeletedAtIsNull(chapter.getPublicId(), 1L))
+                .thenReturn(Optional.of(chapter));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subject.getId(), 1L)).thenReturn(Optional.of(subject));
+        when(partRepository.findMaxPartNumberByChapterId(chapter.getId())).thenReturn(2);
+        when(lectureUploadRepository.save(any())).thenReturn(upload);
+
+        LectureUploadAcceptedResponse response = service.createTextPart(1L, chapter.getPublicId(), textRequest());
+
+        assertThat(response.getLectureUploadId()).isEqualTo("upload-public-id");
+        verify(lectureProcessingJobRepository).save(any());
+        ArgumentCaptor<PartAddProcessingRequestedEvent> eventCaptor =
+                ArgumentCaptor.forClass(PartAddProcessingRequestedEvent.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().partNumber()).isEqualTo(3);
+        assertThat(eventCaptor.getValue().partName()).isEqualTo("새 파트");
+        assertThat(eventCaptor.getValue().text()).hasSizeGreaterThanOrEqualTo(100);
+        assertThat(upload.getRawText()).isEqualTo(eventCaptor.getValue().text());
+    }
+
+    @Test
+    void create_text_part_rejects_short_text() {
+        PartTextAddRequest request = textRequest();
+        ReflectionTestUtils.setField(request, "text", "짧은 텍스트");
+
+        assertThatThrownBy(() -> service.createTextPart(1L, "chapter-public-id", request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("text는 100자 이상 입력해주세요.");
+    }
+
+    @Test
+    void create_file_part_rejects_non_pdf_file_when_upload_type_pdf() {
+        MockMultipartFile file = new MockMultipartFile(
+                "files",
+                "lecture.txt",
+                "text/plain",
+                "content".getBytes()
+        );
+
+        assertThatThrownBy(() -> service.createFilePart(
+                1L,
+                "chapter-public-id",
+                "새 파트",
+                "pdf",
+                List.of(file)
+        ))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("지원하지 않는 파일 형식이에요");
+    }
+
+    private PartTextAddRequest textRequest() {
+        PartTextAddRequest request = new PartTextAddRequest();
+        ReflectionTestUtils.setField(request, "partName", "새 파트");
+        ReflectionTestUtils.setField(request, "uploadType", "text");
+        ReflectionTestUtils.setField(request, "text", "데이터 모델링은 현실 세계의 데이터를 추상화하여 구조화하는 과정입니다. ".repeat(3));
+        return request;
+    }
+
+    private Subject subject(Long id, String publicId, Long userId) {
+        Subject subject = Subject.create(userId, "데이터베이스", "exam");
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        return subject;
+    }
+
+    private Chapter chapter(Long id, String publicId, Long subjectId, Long userId) {
+        Chapter chapter = Chapter.create(subjectId, userId, "1장", 1);
+        ReflectionTestUtils.setField(chapter, "id", id);
+        ReflectionTestUtils.setField(chapter, "publicId", publicId);
+        return chapter;
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/part/service/PartAddProcessingServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/part/service/PartAddProcessingServiceTest.java
@@ -1,0 +1,157 @@
+package com.f1.quiket.domain.part.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.lecture.dto.PartSplitMethod;
+import com.f1.quiket.domain.lecture.entity.LectureProcessingJob;
+import com.f1.quiket.domain.lecture.entity.LectureUpload;
+import com.f1.quiket.domain.lecture.entity.LectureUploadFile;
+import com.f1.quiket.domain.lecture.repository.LectureProcessingJobRepository;
+import com.f1.quiket.domain.lecture.repository.LectureUploadFileRepository;
+import com.f1.quiket.domain.lecture.repository.LectureUploadRepository;
+import com.f1.quiket.domain.material.dto.StudyMaterialTextExtractionResult;
+import com.f1.quiket.domain.material.dto.StudyMaterialUploadType;
+import com.f1.quiket.domain.material.processor.StudyMaterialTextExtractor;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.event.PartAddProcessingRequestedEvent;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+class PartAddProcessingServiceTest {
+
+    private LectureUploadRepository lectureUploadRepository;
+    private LectureUploadFileRepository lectureUploadFileRepository;
+    private LectureProcessingJobRepository lectureProcessingJobRepository;
+    private PartRepository partRepository;
+    private StudyMaterialTextExtractor studyMaterialTextExtractor;
+    private PartAddProcessingService service;
+
+    @BeforeEach
+    void setUp() {
+        lectureUploadRepository = mock(LectureUploadRepository.class);
+        lectureUploadFileRepository = mock(LectureUploadFileRepository.class);
+        lectureProcessingJobRepository = mock(LectureProcessingJobRepository.class);
+        partRepository = mock(PartRepository.class);
+        studyMaterialTextExtractor = mock(StudyMaterialTextExtractor.class);
+        service = new PartAddProcessingService(
+                lectureUploadRepository,
+                lectureUploadFileRepository,
+                lectureProcessingJobRepository,
+                partRepository,
+                studyMaterialTextExtractor,
+                transactionManager()
+        );
+    }
+
+    @Test
+    void process_extracts_text_and_saves_single_part() {
+        LectureUpload upload = LectureUpload.create(20L, 1L, StudyMaterialUploadType.TEXT, PartSplitMethod.MANUAL);
+        ReflectionTestUtils.setField(upload, "id", 30L);
+        LectureProcessingJob processingJob = LectureProcessingJob.create(upload.getId(), 1L, 30);
+        when(lectureUploadRepository.findById(30L)).thenReturn(Optional.of(upload));
+        when(lectureProcessingJobRepository.findByLectureUploadId(upload.getId())).thenReturn(Optional.of(processingJob));
+        when(studyMaterialTextExtractor.extract(any()))
+                .thenReturn(StudyMaterialTextExtractionResult.builder()
+                        .provider("none")
+                        .extractedText(" 추출된 본문 ")
+                        .build());
+
+        service.process(new PartAddProcessingRequestedEvent(
+                30L,
+                20L,
+                10L,
+                1L,
+                "새 파트",
+                4,
+                StudyMaterialUploadType.TEXT,
+                "추출된 본문",
+                List.of()
+        ));
+
+        ArgumentCaptor<Part> partCaptor = ArgumentCaptor.forClass(Part.class);
+        verify(partRepository).save(partCaptor.capture());
+        assertThat(partCaptor.getValue().getPartNumber()).isEqualTo(4);
+        assertThat(partCaptor.getValue().getName()).isEqualTo("새 파트");
+        assertThat(partCaptor.getValue().getContent()).isEqualTo("추출된 본문");
+        assertThat(upload.getStatus()).isEqualTo("completed");
+        assertThat(upload.getRawText()).isEqualTo("추출된 본문");
+        assertThat(processingJob.getStatus()).isEqualTo("completed");
+    }
+
+    @Test
+    void process_marks_partial_image_ocr_failure_on_upload_files() {
+        LectureUpload upload = LectureUpload.create(20L, 1L, StudyMaterialUploadType.IMAGE, PartSplitMethod.MANUAL);
+        ReflectionTestUtils.setField(upload, "id", 30L);
+        LectureProcessingJob processingJob = LectureProcessingJob.create(upload.getId(), 1L, 30);
+        LectureUploadFile successFile = uploadFile(upload.getId(), 1);
+        LectureUploadFile failedFile = uploadFile(upload.getId(), 2);
+        when(lectureUploadRepository.findById(30L)).thenReturn(Optional.of(upload));
+        when(lectureProcessingJobRepository.findByLectureUploadId(upload.getId())).thenReturn(Optional.of(processingJob));
+        when(lectureUploadFileRepository.findAllByLectureUploadIdAndDeletedAtIsNullOrderByDisplayOrderAsc(upload.getId()))
+                .thenReturn(List.of(successFile, failedFile));
+        when(studyMaterialTextExtractor.extract(any()))
+                .thenReturn(StudyMaterialTextExtractionResult.builder()
+                        .provider("gemini")
+                        .extractedText("인식된 본문")
+                        .failedDisplayOrders(List.of(2))
+                        .build());
+
+        service.process(new PartAddProcessingRequestedEvent(
+                30L,
+                20L,
+                10L,
+                1L,
+                "새 파트",
+                4,
+                StudyMaterialUploadType.IMAGE,
+                null,
+                List.of()
+        ));
+
+        assertThat(successFile.getOcrStatus()).isEqualTo("success");
+        assertThat(failedFile.getOcrStatus()).isEqualTo("failed");
+        assertThat(upload.getStatus()).isEqualTo("completed");
+    }
+
+    private LectureUploadFile uploadFile(Long lectureUploadId, int displayOrder) {
+        return LectureUploadFile.create(
+                lectureUploadId,
+                "memory://test/%d".formatted(displayOrder),
+                "slide%d.png".formatted(displayOrder),
+                10L,
+                "image/png",
+                displayOrder,
+                "pending"
+        );
+    }
+
+    private PlatformTransactionManager transactionManager() {
+        return new PlatformTransactionManager() {
+            @Override
+            public TransactionStatus getTransaction(TransactionDefinition definition) {
+                return new SimpleTransactionStatus();
+            }
+
+            @Override
+            public void commit(TransactionStatus status) {
+            }
+
+            @Override
+            public void rollback(TransactionStatus status) {
+            }
+        };
+    }
+}

--- a/src/test/java/com/f1/quiket/domain/part/service/PartQueryServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/part/service/PartQueryServiceTest.java
@@ -1,0 +1,140 @@
+package com.f1.quiket.domain.part.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
+import com.f1.quiket.domain.lecture.entity.LectureUpload;
+import com.f1.quiket.domain.lecture.repository.LectureUploadRepository;
+import com.f1.quiket.domain.material.dto.StudyMaterialUploadType;
+import com.f1.quiket.domain.lecture.dto.PartSplitMethod;
+import com.f1.quiket.domain.part.dto.PartResponse;
+import com.f1.quiket.domain.part.dto.PartUpdateRequest;
+import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.domain.subject.entity.Subject;
+import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.error.CustomException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class PartQueryServiceTest {
+
+    private PartRepository partRepository;
+    private SubjectRepository subjectRepository;
+    private ChapterRepository chapterRepository;
+    private LectureUploadRepository lectureUploadRepository;
+    private PartQueryService service;
+
+    @BeforeEach
+    void setUp() {
+        partRepository = mock(PartRepository.class);
+        subjectRepository = mock(SubjectRepository.class);
+        chapterRepository = mock(ChapterRepository.class);
+        lectureUploadRepository = mock(LectureUploadRepository.class);
+        service = new PartQueryService(partRepository, subjectRepository, chapterRepository, lectureUploadRepository);
+    }
+
+    @Test
+    void get_part_returns_public_ids_and_content_preview() {
+        Subject subject = subject(10L, "subject-public-id", 1L);
+        Chapter chapter = chapter(20L, "chapter-public-id", subject.getId(), 1L);
+        LectureUpload upload = lectureUpload(30L, "upload-public-id", chapter.getId(), 1L);
+        Part part = part(40L, "part-public-id", chapter, subject, upload);
+
+        when(partRepository.findByPublicIdAndUserIdAndContentDeletedFalseAndDeletedAtIsNull(part.getPublicId(), 1L))
+                .thenReturn(Optional.of(part));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subject.getId(), 1L)).thenReturn(Optional.of(subject));
+        when(chapterRepository.findById(chapter.getId())).thenReturn(Optional.of(chapter));
+        when(lectureUploadRepository.findById(upload.getId())).thenReturn(Optional.of(upload));
+
+        PartResponse response = service.getPart(1L, part.getPublicId());
+
+        assertThat(response.getId()).isEqualTo("part-public-id");
+        assertThat(response.getSubjectId()).isEqualTo("subject-public-id");
+        assertThat(response.getChapterId()).isEqualTo("chapter-public-id");
+        assertThat(response.getLectureUploadId()).isEqualTo("upload-public-id");
+        assertThat(response.getContentPreview()).hasSize(30);
+    }
+
+    @Test
+    void update_part_trims_name_and_content_without_changing_part_number() {
+        Subject subject = subject(10L, "subject-public-id", 1L);
+        Chapter chapter = chapter(20L, "chapter-public-id", subject.getId(), 1L);
+        LectureUpload upload = lectureUpload(30L, "upload-public-id", chapter.getId(), 1L);
+        Part part = part(40L, "part-public-id", chapter, subject, upload);
+        PartUpdateRequest request = new PartUpdateRequest();
+        ReflectionTestUtils.setField(request, "name", " 수정 파트 ");
+        ReflectionTestUtils.setField(request, "content", " 수정 본문 ");
+
+        when(partRepository.findByPublicIdAndUserIdAndContentDeletedFalseAndDeletedAtIsNull(part.getPublicId(), 1L))
+                .thenReturn(Optional.of(part));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subject.getId(), 1L)).thenReturn(Optional.of(subject));
+        when(chapterRepository.findById(chapter.getId())).thenReturn(Optional.of(chapter));
+        when(lectureUploadRepository.findById(upload.getId())).thenReturn(Optional.of(upload));
+
+        PartResponse response = service.updatePart(1L, part.getPublicId(), request);
+
+        assertThat(response.getName()).isEqualTo("수정 파트");
+        assertThat(response.getContent()).isEqualTo("수정 본문");
+        assertThat(response.getPartNumber()).isEqualTo(3);
+        assertThat(part.getPartNumber()).isEqualTo(3);
+    }
+
+    @Test
+    void update_part_rejects_blank_content() {
+        PartUpdateRequest request = new PartUpdateRequest();
+        ReflectionTestUtils.setField(request, "name", "파트");
+        ReflectionTestUtils.setField(request, "content", " ");
+        Part part = Part.createFromLectureUpload(20L, 10L, 1L, null, "파트", 1, "본문");
+        ReflectionTestUtils.setField(part, "publicId", "part-public-id");
+
+        when(partRepository.findByPublicIdAndUserIdAndContentDeletedFalseAndDeletedAtIsNull(part.getPublicId(), 1L))
+                .thenReturn(Optional.of(part));
+
+        assertThatThrownBy(() -> service.updatePart(1L, part.getPublicId(), request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage("파트 내용을 입력해주세요");
+    }
+
+    private Subject subject(Long id, String publicId, Long userId) {
+        Subject subject = Subject.create(userId, "데이터베이스", "exam");
+        ReflectionTestUtils.setField(subject, "id", id);
+        ReflectionTestUtils.setField(subject, "publicId", publicId);
+        return subject;
+    }
+
+    private Chapter chapter(Long id, String publicId, Long subjectId, Long userId) {
+        Chapter chapter = Chapter.create(subjectId, userId, "1장", 1);
+        ReflectionTestUtils.setField(chapter, "id", id);
+        ReflectionTestUtils.setField(chapter, "publicId", publicId);
+        return chapter;
+    }
+
+    private LectureUpload lectureUpload(Long id, String publicId, Long chapterId, Long userId) {
+        LectureUpload upload = LectureUpload.create(chapterId, userId, StudyMaterialUploadType.TEXT, PartSplitMethod.MANUAL);
+        ReflectionTestUtils.setField(upload, "id", id);
+        ReflectionTestUtils.setField(upload, "publicId", publicId);
+        return upload;
+    }
+
+    private Part part(Long id, String publicId, Chapter chapter, Subject subject, LectureUpload upload) {
+        Part part = Part.createFromLectureUpload(
+                chapter.getId(),
+                subject.getId(),
+                subject.getUserId(),
+                upload.getId(),
+                "데이터 모델링 개념",
+                3,
+                "데이터 모델링은 현실 세계의 데이터를 추상화하여 구조화하는 과정입니다."
+        );
+        ReflectionTestUtils.setField(part, "id", id);
+        ReflectionTestUtils.setField(part, "publicId", publicId);
+        return part;
+    }
+}


### PR DESCRIPTION
## 🧩 Description

기존 챕터에 파트를 추가하거나 파트 내용을 조회·수정하는 파트 관리 API를 구현합니다.

- `GET /api/v1/parts/{partId}` 파트 상세 조회
- `PATCH /api/v1/parts/{partId}` 파트 수정
- `POST /api/v1/chapters/{chapterId}/parts` 기존 챕터에 파트 추가 (텍스트 / PDF / 이미지)

---

## 🛠️ Changes

- `PartController`: 파트 상세 조회, 수정 엔드포인트 추가
- `PartQueryService`: 파트 상세 조회 및 소유권 검증
- `PartAddCreateService`: 파트 추가 요청 저장 및 비동기 처리 이벤트 발행
- `PartAddProcessingService`: 텍스트 추출 / AI 처리 / Part 저장 비동기 처리
- `ChapterController`: `POST /api/v1/chapters/{chapterId}/parts` 엔드포인트 추가, API prefix 누락 수정
- `PartResponse`, `PartTextAddRequest`, `PartUpdateRequest` DTO 추가
- `PartAddProcessingRequestedEvent` 이벤트 추가
- 파트 추가 관련 단위 테스트 추가 (`PartQueryServiceTest`, `PartAddCreateServiceTest`, `PartAddProcessingServiceTest`, `StudyMaterialTextExtractorTest`)

---

## 🧪 How to Test

1. `POST /api/v1/chapters/{chapterId}/parts` 텍스트 직접 입력으로 파트 추가 후 `GET /api/v1/parts/{partId}` 조회
2. `PATCH /api/v1/parts/{partId}` 파트 수정 후 내용 반영 확인
3. 타인 소유 파트 접근 시 403 응답 확인

---

## 🔗 Related Issue

Closes #114

---

## ⚠️ Notes

- 파트 추가는 AI 처리 비동기 흐름을 따르며, 즉시 완료 상태가 아닌 `processing` 상태로 반환됩니다.
- `part_number`는 챕터 내 마지막 번호 + 1로 자동 부여됩니다.
- 텍스트 입력은 100~30,000자, 파일 합산 50MB 이하로 제한합니다.

---

## 🧑‍💻 Assignee

- @ja2hoon