### PR TITLE
[Fix] 풀이 세션 ID 길이 제한 확대

### DIFF
--- a/docs/db/quiket-ddl-mvp.sql
+++ b/docs/db/quiket-ddl-mvp.sql
@@ -645,7 +645,7 @@ CREATE TABLE quiz_generation_jobs (
 -- → 중복 제출 차단은 client_session_id로, 조인은 id로
 CREATE TABLE quiz_play_sessions (
     id                      BIGINT          NOT NULL AUTO_INCREMENT          COMMENT 'PK: 서버 풀이 세션 식별자',
-    client_session_id       VARCHAR(36)     NOT NULL                         COMMENT '클라이언트 발급 풀이 세션 ID (중복 제출 차단 키)',
+    client_session_id       VARCHAR(128)    NOT NULL                         COMMENT '클라이언트 발급 풀이 세션 ID (중복 제출 차단 키)',
     quiz_session_id         BIGINT          NOT NULL                         COMMENT '퀴즈 세션(설정+문항) ID',
     user_id                 BIGINT          NOT NULL                         COMMENT '사용자 ID (역정규화)',
     subject_id              BIGINT          NOT NULL                         COMMENT '과목 ID (역정규화)',

--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -1960,6 +1960,7 @@ components:
       description: 풀이 세션 ID. 서버 publicId 또는 클라이언트 발급 clientSessionId
       schema:
         type: string
+        maxLength: 128
         example: android-play-session-uuid
 
   responses:
@@ -3873,12 +3874,13 @@ components:
       properties:
         clientSessionId:
           type: string
-          maxLength: 36
+          maxLength: 128
           example: android-play-session-uuid
         playType:
           $ref: '#/components/schemas/QuizPlayType'
         parentPlaySessionId:
           type: string
+          maxLength: 128
           nullable: true
           example: parent-play-session-uuid
         questionShuffled:
@@ -3913,9 +3915,11 @@ components:
       properties:
         playSessionId:
           type: string
+          maxLength: 128
           example: android-play-session-uuid
         clientSessionId:
           type: string
+          maxLength: 128
           example: android-play-session-uuid
         quizSessionId:
           type: string
@@ -3943,7 +3947,7 @@ components:
       properties:
         clientSessionId:
           type: string
-          maxLength: 36
+          maxLength: 128
           example: android-play-session-uuid
         quizSessionId:
           type: string
@@ -3953,6 +3957,7 @@ components:
           $ref: '#/components/schemas/QuizPlayType'
         parentPlaySessionId:
           type: string
+          maxLength: 128
           nullable: true
           example: parent-play-session-uuid
         elapsedMs:
@@ -4041,6 +4046,7 @@ components:
           example: 018f8c2e-9999-7b11-b2d1-774f4c1c2222
         playSessionId:
           type: string
+          maxLength: 128
           example: android-play-session-uuid
         quizSessionId:
           type: string
@@ -4103,6 +4109,7 @@ components:
               properties:
                 playSessionId:
                   type: string
+                  maxLength: 128
                   example: android-play-session-uuid
                 items:
                   type: array
@@ -4171,7 +4178,7 @@ components:
       properties:
         clientSessionId:
           type: string
-          maxLength: 36
+          maxLength: 128
           example: android-retry-session-uuid
         questionShuffled:
           type: boolean

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlayStartRequest.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizPlayStartRequest.java
@@ -11,14 +11,14 @@ import lombok.NoArgsConstructor;
 public class QuizPlayStartRequest {
 
     @NotBlank(message = "풀이 세션 ID는 필수입니다")
-    @Size(max = 36, message = "풀이 세션 ID는 36자 이하여야 합니다")
+    @Size(max = 128, message = "풀이 세션 ID는 128자 이하여야 합니다")
     private String clientSessionId;
 
     @NotBlank(message = "풀이 유형은 필수입니다")
     @Pattern(regexp = "first|retry_all|retry_wrong", message = "풀이 유형이 올바르지 않습니다")
     private String playType;
 
-    @Size(max = 36, message = "부모 풀이 세션 ID는 36자 이하여야 합니다")
+    @Size(max = 128, message = "부모 풀이 세션 ID는 128자 이하여야 합니다")
     private String parentPlaySessionId;
 
     private Boolean questionShuffled;

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultSubmitRequest.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizResultSubmitRequest.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 public class QuizResultSubmitRequest {
 
     @NotBlank(message = "풀이 세션 ID는 필수입니다")
-    @Size(max = 36, message = "풀이 세션 ID는 36자 이하여야 합니다")
+    @Size(max = 128, message = "풀이 세션 ID는 128자 이하여야 합니다")
     private String clientSessionId;
 
     @NotBlank(message = "퀴즈 세션 ID는 필수입니다")
@@ -27,7 +27,7 @@ public class QuizResultSubmitRequest {
     @Pattern(regexp = "first|retry_all|retry_wrong", message = "풀이 유형이 올바르지 않습니다")
     private String playType;
 
-    @Size(max = 36, message = "부모 풀이 세션 ID는 36자 이하여야 합니다")
+    @Size(max = 128, message = "부모 풀이 세션 ID는 128자 이하여야 합니다")
     private String parentPlaySessionId;
 
     @NotNull(message = "풀이 시간은 필수입니다")

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRetryRequest.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizRetryRequest.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 public class QuizRetryRequest {
 
     @NotBlank(message = "풀이 세션 ID는 필수입니다")
-    @Size(max = 36, message = "풀이 세션 ID는 36자 이하여야 합니다")
+    @Size(max = 128, message = "풀이 세션 ID는 128자 이하여야 합니다")
     private String clientSessionId;
 
     private Boolean questionShuffled;

--- a/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/entity/QuizPlaySession.java
@@ -52,7 +52,7 @@ public class QuizPlaySession {
     @Column(name = "id")
     Long id;
 
-    @Column(name = "client_session_id", length = 36, nullable = false)
+    @Column(name = "client_session_id", length = 128, nullable = false)
     String clientSessionId;
 
     @Column(name = "quiz_session_id", nullable = false)

--- a/src/main/resources/db/migration/V15__increase_quiz_play_client_session_id_length.sql
+++ b/src/main/resources/db/migration/V15__increase_quiz_play_client_session_id_length.sql
@@ -1,0 +1,2 @@
+ALTER TABLE quiz_play_sessions
+    MODIFY COLUMN client_session_id VARCHAR(128) NOT NULL COMMENT '클라이언트 발급 풀이 세션 ID';

--- a/src/test/java/com/f1/quiket/domain/quiz/dto/QuizClientSessionIdValidationTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/dto/QuizClientSessionIdValidationTest.java
@@ -1,0 +1,99 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuizClientSessionIdValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    void playStart_accepts_128_length_client_session_id() {
+        QuizPlayStartRequest request = new QuizPlayStartRequest();
+        ReflectionTestUtils.setField(request, "clientSessionId", repeated("a", 128));
+        ReflectionTestUtils.setField(request, "playType", "first");
+
+        Set<ConstraintViolation<QuizPlayStartRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void playStart_rejects_over_128_length_client_session_id() {
+        QuizPlayStartRequest request = new QuizPlayStartRequest();
+        ReflectionTestUtils.setField(request, "clientSessionId", repeated("a", 129));
+        ReflectionTestUtils.setField(request, "playType", "first");
+
+        Set<ConstraintViolation<QuizPlayStartRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .contains("clientSessionId");
+    }
+
+    @Test
+    void retry_accepts_128_length_client_session_id() {
+        QuizRetryRequest request = new QuizRetryRequest();
+        ReflectionTestUtils.setField(request, "clientSessionId", repeated("a", 128));
+
+        Set<ConstraintViolation<QuizRetryRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void resultSubmit_accepts_128_length_client_session_id() {
+        QuizResultSubmitRequest request = new QuizResultSubmitRequest();
+        ReflectionTestUtils.setField(request, "clientSessionId", repeated("a", 128));
+        ReflectionTestUtils.setField(request, "quizSessionId", "019e7210-e009-7439-9691-34407bb643b3");
+        ReflectionTestUtils.setField(request, "playType", "first");
+        ReflectionTestUtils.setField(request, "elapsedMs", 1000);
+        ReflectionTestUtils.setField(request, "answers", List.of(answerItem()));
+
+        Set<ConstraintViolation<QuizResultSubmitRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void resultSubmit_rejects_over_128_length_parent_play_session_id() {
+        QuizResultSubmitRequest request = new QuizResultSubmitRequest();
+        ReflectionTestUtils.setField(request, "clientSessionId", repeated("a", 128));
+        ReflectionTestUtils.setField(request, "quizSessionId", "019e7210-e009-7439-9691-34407bb643b3");
+        ReflectionTestUtils.setField(request, "playType", "retry_wrong");
+        ReflectionTestUtils.setField(request, "parentPlaySessionId", repeated("b", 129));
+        ReflectionTestUtils.setField(request, "elapsedMs", 1000);
+        ReflectionTestUtils.setField(request, "answers", List.of(answerItem()));
+
+        Set<ConstraintViolation<QuizResultSubmitRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(violation -> violation.getPropertyPath().toString())
+                .contains("parentPlaySessionId");
+    }
+
+    private QuizAnswerSubmitItem answerItem() {
+        QuizAnswerSubmitItem item = new QuizAnswerSubmitItem();
+        ReflectionTestUtils.setField(item, "questionId", "019e7210-e009-7439-9691-34407bb643b4");
+        ReflectionTestUtils.setField(item, "selectedValue", "O");
+        ReflectionTestUtils.setField(item, "skipped", false);
+        return item;
+    }
+
+    private String repeated(String value, int count) {
+        return value.repeat(count);
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 풀이 세션 시작 API에서 클라이언트 발급 `clientSessionId`가 36자를 초과하면 400이 발생하던 문제 수정
- 서버 검증, 엔티티 컬럼 길이, DB 마이그레이션, OpenAPI/DDL 문서 기준을 128자로 일괄 정렬

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `QuizPlayStartRequest`, `QuizRetryRequest`, `QuizResultSubmitRequest`의 `clientSessionId` 검증 길이 128자로 확대
- 동일 성격의 `parentPlaySessionId` 검증 길이 128자로 확대
- `quiz_play_sessions.client_session_id` 컬럼 길이 확대 마이그레이션 추가
- OpenAPI 명세와 MVP DDL 문서 반영
- 128자/129자 경계값 검증 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `ruby -ryaml -e 'YAML.load_file("docs/openapi/quiket-mvp-api.yaml"); puts "openapi yaml ok"'`
2. `./gradlew test --tests 'com.f1.quiket.domain.quiz.dto.QuizClientSessionIdValidationTest'`
3. `./gradlew test`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #125

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- `quizSessionId`는 서버 publicId라 36자 제한 유지
- `clientSessionId`는 클라이언트 발급 식별자라 128자로 확대
- `client_session_id` UNIQUE 인덱스는 128자 기준에서도 MySQL utf8mb4 인덱스 길이 한계 내 안전

---

## 🧑‍💻 Assignee

- @imclaremont
