### PR TITLE
[Fix] multipart 업로드 용량 초과 응답 처리

### DIFF
--- a/src/main/java/com/f1/quiket/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/f1/quiket/global/error/GlobalExceptionHandler.java
@@ -2,14 +2,15 @@ package com.f1.quiket.global.error;
 
 import com.f1.quiket.global.response.ApiResponse;
 import com.f1.quiket.global.response.ErrorCode;
-import lombok.extern.slf4j.Slf4j;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 /**
@@ -36,7 +37,7 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        
+
         String message = Optional.ofNullable(e.getBindingResult().getFieldError())
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .orElse("입력값이 올바르지 않습니다.");
@@ -56,6 +57,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.METHOD_NOT_ALLOWED)
                 .body(ApiResponse.fail(ErrorCode.METHOD_NOT_ALLOWED));
+    }
+
+    /**
+     * multipart 파일 용량 초과
+     */
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<?>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        log.warn("Multipart upload size exceeded: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.FILE_SIZE_EXCEEDED.getStatus())
+                .body(ApiResponse.fail(ErrorCode.FILE_SIZE_EXCEEDED));
     }
 
     /**

--- a/src/test/java/com/f1/quiket/global/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/f1/quiket/global/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,27 @@
+package com.f1.quiket.global.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.f1.quiket.global.response.ApiResponse;
+import com.f1.quiket.global.response.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+class GlobalExceptionHandlerTest {
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    void handleMaxUploadSizeExceededException_returns_file_size_exceeded_response() {
+        ResponseEntity<ApiResponse<?>> response = handler.handleMaxUploadSizeExceededException(
+                new MaxUploadSizeExceededException(50 * 1024 * 1024)
+        );
+
+        assertThat(response.getStatusCode().value()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED.getStatus());
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isSuccess()).isFalse();
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED.getCode());
+        assertThat(response.getBody().getMessage()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED.getMessage());
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- multipart 요청이 Spring multipart 파서 제한을 초과할 때 500으로 응답되던 문제 수정
- 서비스 진입 전 발생하는 `MaxUploadSizeExceededException`도 413 응답으로 통일

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `GlobalExceptionHandler`에 `MaxUploadSizeExceededException` 핸들러 추가
- `ErrorCode.FILE_SIZE_EXCEEDED` 기반 413 응답 반환
- 전역 예외 핸들러 단위 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests 'com.f1.quiket.global.error.GlobalExceptionHandlerTest'`
2. `./gradlew test`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #121

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 도메인 서비스의 50MB 합산 검증은 그대로 유지
- multipart 파서 단계와 서비스 검증 단계 모두 동일한 413 응답 체계 사용

---

## 🧑‍💻 Assignee

- @imclaremont
