### PR TITLE
[Fix] 과목 시험 일정 soft delete 조회 정리

### DIFF
--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamScheduleRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectExamScheduleRepository.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -37,5 +39,6 @@ public interface SubjectExamScheduleRepository extends JpaRepository<SubjectExam
     /**
      * 과목 일정 전체 조회
      */
-    Optional<SubjectExamSchedule> findBySubjectId(Long subjectId);
+    @Query("SELECT schedule FROM SubjectExamSchedule schedule WHERE schedule.subjectId = :subjectId")
+    Optional<SubjectExamSchedule> findBySubjectIdIncludingDeleted(@Param("subjectId") Long subjectId);
 }

--- a/src/main/java/com/f1/quiket/domain/subject/service/SubjectService.java
+++ b/src/main/java/com/f1/quiket/domain/subject/service/SubjectService.java
@@ -185,7 +185,7 @@ public class SubjectService {
     public SubjectExamScheduleResponse upsertExamSchedule(String userPublicId, String subjectPublicId, SubjectExamScheduleUpsertRequest request) {
         User user = findUser(userPublicId);
         Subject subject = findSubject(subjectPublicId, user.getId());
-        SubjectExamSchedule schedule = subjectExamScheduleRepository.findBySubjectId(subject.getId())
+        SubjectExamSchedule schedule = subjectExamScheduleRepository.findBySubjectIdIncludingDeleted(subject.getId())
                 .map(existingSchedule -> {
                     existingSchedule.update(normalizeBlank(request.getExamName()), request.getExamDate());
                     return existingSchedule;

--- a/src/test/java/com/f1/quiket/domain/subject/service/SubjectServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/subject/service/SubjectServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -105,7 +106,7 @@ class SubjectServiceTest {
 
         when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
         when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), user.getId())).thenReturn(Optional.of(subject));
-        when(subjectExamScheduleRepository.findBySubjectId(subject.getId())).thenReturn(Optional.empty());
+        when(subjectExamScheduleRepository.findBySubjectIdIncludingDeleted(subject.getId())).thenReturn(Optional.empty());
         when(subjectExamScheduleRepository.save(any(SubjectExamSchedule.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -119,6 +120,30 @@ class SubjectServiceTest {
         assertThat(response.getSubjectId()).isEqualTo(subject.getPublicId());
         assertThat(response.getExamName()).isEqualTo(subject.getName());
         assertThat(response.getExamDate()).isEqualTo(request.getExamDate());
+    }
+
+    @Test
+    void upsertExamSchedule_restores_deleted_schedule_without_new_insert() {
+        User user = user(1L, "user-public-id");
+        Subject subject = subject(10L, "subject-public-id", user.getId(), "데이터베이스");
+        SubjectExamSchedule schedule = schedule(100L, "schedule-public-id", subject.getId(), user.getId(), "중간고사", LocalDate.now().plusDays(1));
+        schedule.delete();
+
+        SubjectExamScheduleUpsertRequest request = new SubjectExamScheduleUpsertRequest();
+        ReflectionTestUtils.setField(request, "examName", "기말고사");
+        ReflectionTestUtils.setField(request, "examDate", LocalDate.now().plusDays(7));
+
+        when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
+        when(subjectRepository.findByPublicIdAndUserIdAndDeletedAtIsNull(subject.getPublicId(), user.getId())).thenReturn(Optional.of(subject));
+        when(subjectExamScheduleRepository.findBySubjectIdIncludingDeleted(subject.getId())).thenReturn(Optional.of(schedule));
+
+        SubjectExamScheduleResponse response = subjectService.upsertExamSchedule(user.getPublicId(), subject.getPublicId(), request);
+
+        verify(subjectExamScheduleRepository, never()).save(any(SubjectExamSchedule.class));
+        assertThat(schedule.getDeletedAt()).isNull();
+        assertThat(schedule.getExamName()).isEqualTo("기말고사");
+        assertThat(schedule.getExamDate()).isEqualTo(request.getExamDate());
+        assertThat(response.getId()).isEqualTo(schedule.getPublicId());
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
- 시험 일정 재등록 시 soft delete 된 기존 일정을 명시적으로 조회
- 기존 일정 복구 후 갱신 처리로 subject_id unique 충돌 방지
- 삭제된 시험 일정 재등록 회귀 테스트 추가

## 테스트
- ./gradlew test --tests 'com.f1.quiket.domain.subject.service.SubjectServiceTest'
- ./gradlew test

Closes #123