### PR TITLE
[Refactor] 홈 최근활동 조회 모델 개선

### DIFF
--- a/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
+++ b/src/main/java/com/f1/quiket/domain/chapter/repository/ChapterRepository.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.chapter.repository;
 
 import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.home.repository.SubjectCountProjection;
 import jakarta.persistence.LockModeType;
 import java.util.Collection;
 import java.util.List;
@@ -34,6 +35,23 @@ public interface ChapterRepository extends JpaRepository<Chapter, Long> {
      * 과목별 챕터 목록 조회
      */
     List<Chapter> findAllBySubjectIdInAndDeletedAtIsNull(Collection<Long> subjectIds);
+
+    /**
+     * 과목별 챕터 개수 집계
+     */
+    @Query("""
+            select c.subjectId as subjectId,
+                   count(c) as itemCount
+            from Chapter c
+            where c.userId = :userId
+              and c.deletedAt is null
+              and c.subjectId in :subjectIds
+            group by c.subjectId
+            """)
+    List<SubjectCountProjection> countBySubjectIds(
+            @Param("userId") Long userId,
+            @Param("subjectIds") Collection<Long> subjectIds
+    );
 
     /**
      * 공개 식별자 기반 사용자 챕터 조회

--- a/src/main/java/com/f1/quiket/domain/home/repository/SubjectCountProjection.java
+++ b/src/main/java/com/f1/quiket/domain/home/repository/SubjectCountProjection.java
@@ -1,0 +1,11 @@
+package com.f1.quiket.domain.home.repository;
+
+/**
+ * 과목별 개수 집계 조회
+ */
+public interface SubjectCountProjection {
+
+    Long getSubjectId();
+
+    Long getItemCount();
+}

--- a/src/main/java/com/f1/quiket/domain/home/repository/SubjectLastActivityProjection.java
+++ b/src/main/java/com/f1/quiket/domain/home/repository/SubjectLastActivityProjection.java
@@ -1,0 +1,13 @@
+package com.f1.quiket.domain.home.repository;
+
+import java.time.LocalDateTime;
+
+/**
+ * 과목별 마지막 활동 시각 조회
+ */
+public interface SubjectLastActivityProjection {
+
+    Long getSubjectId();
+
+    LocalDateTime getLastActivityAt();
+}

--- a/src/main/java/com/f1/quiket/domain/home/service/HomeService.java
+++ b/src/main/java/com/f1/quiket/domain/home/service/HomeService.java
@@ -1,6 +1,5 @@
 package com.f1.quiket.domain.home.service;
 
-import com.f1.quiket.domain.chapter.entity.Chapter;
 import com.f1.quiket.domain.chapter.repository.ChapterRepository;
 import com.f1.quiket.domain.home.dto.HomeDataResponse;
 import com.f1.quiket.domain.home.dto.HomeHeroResponse;
@@ -10,7 +9,8 @@ import com.f1.quiket.domain.home.dto.RecentActivityResponse;
 import com.f1.quiket.domain.home.dto.RecentActivityType;
 import com.f1.quiket.domain.home.dto.SubjectExamScheduleResponse;
 import com.f1.quiket.domain.home.dto.SubjectSummaryResponse;
-import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.home.repository.SubjectCountProjection;
+import com.f1.quiket.domain.home.repository.SubjectLastActivityProjection;
 import com.f1.quiket.domain.part.repository.PartRepository;
 import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
 import com.f1.quiket.domain.quiz.entity.QuizResult;
@@ -28,8 +28,10 @@ import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -72,8 +74,9 @@ public class HomeService {
      */
     public HomeDataResponse getHome(String publicId) {
         User user = findUser(publicId);
-        HomeReadModel readModel = loadHomeReadModel(user.getId());
-        List<RecentActivityResponse> allRecentActivities = buildRecentActivities(readModel);
+        HomeSubjectReadModel subjectReadModel = loadHomeSubjectReadModel(user.getId());
+        RecentActivityReadModel activityReadModel = loadRecentActivityReadModel(user.getId(), 0, HOME_RECENT_ACTIVITY_SIZE);
+        List<RecentActivityResponse> allRecentActivities = buildRecentActivities(activityReadModel);
         List<RecentActivityResponse> recentActivities = sliceRecentActivities(
                 allRecentActivities,
                 0,
@@ -83,8 +86,8 @@ public class HomeService {
         return HomeDataResponse.builder()
                 .user(HomeUserSummaryResponse.from(user))
                 .hero(HomeHeroResponse.from(findActiveQuiz(allRecentActivities)))
-                .dDayCards(findDDayScheduleResponses(readModel))
-                .subjects(findSubjectSummaryResponses(readModel))
+                .dDayCards(findDDayScheduleResponses(user.getId()))
+                .subjects(findSubjectSummaryResponses(subjectReadModel))
                 .recentActivities(recentActivities)
                 .build();
     }
@@ -96,11 +99,11 @@ public class HomeService {
         User user = findUser(publicId);
         int normalizedPage = Math.max(page, 0);
         int normalizedSize = normalizeSize(size);
-        HomeReadModel readModel = loadHomeReadModel(user.getId());
+        RecentActivityReadModel readModel = loadRecentActivityReadModel(user.getId(), normalizedPage, normalizedSize);
         List<RecentActivityResponse> activities = buildRecentActivities(readModel);
         List<RecentActivityResponse> content = sliceRecentActivities(activities, normalizedPage, normalizedSize);
 
-        return RecentActivityPageResponse.of(content, normalizedPage, normalizedSize, activities.size());
+        return RecentActivityPageResponse.of(content, normalizedPage, normalizedSize, readModel.totalElements());
     }
 
     /**
@@ -112,18 +115,59 @@ public class HomeService {
     }
 
     /**
-     * 홈 조회 모델 로딩
+     * 홈 과목 조회 모델 로딩
      */
-    private HomeReadModel loadHomeReadModel(Long userId) {
-        List<Subject> subjects = subjectRepository.findAllByUserIdAndDeletedAtIsNull(userId);
-        List<Chapter> chapters = chapterRepository.findAllByUserIdAndDeletedAtIsNull(userId);
-        List<Part> parts = partRepository.findAllByUserIdAndDeletedAtIsNull(userId);
+    private HomeSubjectReadModel loadHomeSubjectReadModel(Long userId) {
+        List<Subject> subjects = subjectRepository.findHomeSummarySubjects(userId, HOME_SUBJECT_SIZE);
+        List<Long> subjectIds = subjects.stream()
+                .map(Subject::getId)
+                .toList();
         List<SubjectExamSchedule> schedules = loadSubjectSchedules(userId, subjects);
-        List<QuizSession> quizSessions = quizSessionRepository.findAllByUserIdAndDeletedAtIsNull(userId);
-        List<QuizPlaySession> playSessions = quizPlaySessionRepository.findAllByUserId(userId);
-        List<QuizResult> quizResults = quizResultRepository.findAllByUserId(userId);
 
-        return new HomeReadModel(userId, subjects, chapters, parts, schedules, quizSessions, playSessions, quizResults);
+        return new HomeSubjectReadModel(
+                userId,
+                subjects,
+                schedules,
+                loadChapterCountMap(userId, subjectIds),
+                loadPartCountMap(userId, subjectIds),
+                loadLastActivityAtMap(userId, subjectIds)
+        );
+    }
+
+    /**
+     * 최근활동 조회 모델 로딩
+     */
+    private RecentActivityReadModel loadRecentActivityReadModel(Long userId, int page, int size) {
+        int fetchSize = calculateActivityFetchSize(page, size);
+        PageRequest activityLimit = PageRequest.of(0, fetchSize);
+
+        List<QuizSession> readyQuizSessions = quizSessionRepository.findReadyActivities(
+                userId,
+                QUIZ_SESSION_COMPLETED,
+                activityLimit
+        );
+        List<QuizPlaySession> inProgressPlaySessions =
+                quizPlaySessionRepository.findByUserIdAndStatusAndDeletedAtIsNullOrderByUpdatedAtDesc(
+                        userId,
+                        PLAY_SESSION_IN_PROGRESS,
+                        activityLimit
+                );
+        List<QuizResult> completedQuizResults =
+                quizResultRepository.findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(userId, activityLimit);
+
+        long totalElements = quizSessionRepository.countReadyActivities(userId, QUIZ_SESSION_COMPLETED)
+                + quizPlaySessionRepository.countByUserIdAndStatusAndDeletedAtIsNull(userId, PLAY_SESSION_IN_PROGRESS)
+                + quizResultRepository.countByUserIdAndDeletedAtIsNull(userId);
+
+        return new RecentActivityReadModel(
+                readyQuizSessions,
+                inProgressPlaySessions,
+                completedQuizResults,
+                loadSubjectMap(userId, readyQuizSessions, inProgressPlaySessions, completedQuizResults),
+                loadQuizSessionMap(userId, readyQuizSessions, inProgressPlaySessions, completedQuizResults),
+                loadPlaySessionMap(userId, inProgressPlaySessions, completedQuizResults),
+                totalElements
+        );
     }
 
     /**
@@ -140,6 +184,139 @@ public class HomeService {
                 // 사용자 소유 일정만 사용
                 .filter(schedule -> userId.equals(schedule.getUserId()))
                 .toList();
+    }
+
+    /**
+     * 최근활동 소스별 조회 크기 산출
+     */
+    private int calculateActivityFetchSize(int page, int size) {
+        long requestedSize = ((long) page + 1) * size;
+        return (int) Math.min(requestedSize, Integer.MAX_VALUE);
+    }
+
+    /**
+     * 과목별 챕터 개수 로딩
+     */
+    private Map<Long, Long> loadChapterCountMap(Long userId, List<Long> subjectIds) {
+        if (subjectIds.isEmpty()) {
+            return Map.of();
+        }
+        return toCountMap(chapterRepository.countBySubjectIds(userId, subjectIds));
+    }
+
+    /**
+     * 과목별 파트 개수 로딩
+     */
+    private Map<Long, Long> loadPartCountMap(Long userId, List<Long> subjectIds) {
+        if (subjectIds.isEmpty()) {
+            return Map.of();
+        }
+        return toCountMap(partRepository.countBySubjectIds(userId, subjectIds));
+    }
+
+    /**
+     * 과목별 개수 맵 변환
+     */
+    private Map<Long, Long> toCountMap(List<SubjectCountProjection> values) {
+        return values.stream()
+                .collect(Collectors.toMap(SubjectCountProjection::getSubjectId, SubjectCountProjection::getItemCount));
+    }
+
+    /**
+     * 과목별 마지막 활동 시각 로딩
+     */
+    private Map<Long, LocalDateTime> loadLastActivityAtMap(Long userId, List<Long> subjectIds) {
+        if (subjectIds.isEmpty()) {
+            return Map.of();
+        }
+        Map<Long, LocalDateTime> lastActivityMap = new HashMap<>();
+        mergeLastActivityAt(lastActivityMap, quizSessionRepository.findLastActivityBySubjectIds(userId, subjectIds));
+        mergeLastActivityAt(lastActivityMap, quizPlaySessionRepository.findLastActivityBySubjectIds(userId, subjectIds));
+        mergeLastActivityAt(lastActivityMap, quizResultRepository.findLastActivityBySubjectIds(userId, subjectIds));
+        return lastActivityMap;
+    }
+
+    /**
+     * 마지막 활동 시각 병합
+     */
+    private void mergeLastActivityAt(
+            Map<Long, LocalDateTime> target,
+            List<SubjectLastActivityProjection> values
+    ) {
+        values.forEach(value -> {
+            LocalDateTime lastActivityAt = value.getLastActivityAt();
+            if (lastActivityAt == null) {
+                return;
+            }
+            target.merge(value.getSubjectId(), lastActivityAt, (previous, current) ->
+                    previous.isAfter(current) ? previous : current
+            );
+        });
+    }
+
+    /**
+     * 최근활동 과목 맵 로딩
+     */
+    private Map<Long, Subject> loadSubjectMap(
+            Long userId,
+            List<QuizSession> readyQuizSessions,
+            List<QuizPlaySession> inProgressPlaySessions,
+            List<QuizResult> completedQuizResults
+    ) {
+        Set<Long> subjectIds = new HashSet<>();
+        readyQuizSessions.forEach(session -> subjectIds.add(session.getSubjectId()));
+        inProgressPlaySessions.forEach(session -> subjectIds.add(session.getSubjectId()));
+        completedQuizResults.forEach(result -> subjectIds.add(result.getSubjectId()));
+
+        if (subjectIds.isEmpty()) {
+            return Map.of();
+        }
+        return subjectRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(subjectIds, userId).stream()
+                .collect(Collectors.toMap(Subject::getId, Function.identity()));
+    }
+
+    /**
+     * 최근활동 퀴즈 세션 맵 로딩
+     */
+    private Map<Long, QuizSession> loadQuizSessionMap(
+            Long userId,
+            List<QuizSession> readyQuizSessions,
+            List<QuizPlaySession> inProgressPlaySessions,
+            List<QuizResult> completedQuizResults
+    ) {
+        Map<Long, QuizSession> quizSessionMap = readyQuizSessions.stream()
+                .collect(Collectors.toMap(QuizSession::getId, Function.identity()));
+        Set<Long> quizSessionIds = new HashSet<>();
+        inProgressPlaySessions.forEach(session -> quizSessionIds.add(session.getQuizSessionId()));
+        completedQuizResults.forEach(result -> quizSessionIds.add(result.getQuizSessionId()));
+        quizSessionIds.removeAll(quizSessionMap.keySet());
+
+        if (quizSessionIds.isEmpty()) {
+            return quizSessionMap;
+        }
+        quizSessionRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(quizSessionIds, userId)
+                .forEach(session -> quizSessionMap.put(session.getId(), session));
+        return quizSessionMap;
+    }
+
+    /**
+     * 최근활동 풀이 세션 맵 로딩
+     */
+    private Map<Long, QuizPlaySession> loadPlaySessionMap(
+            Long userId,
+            List<QuizPlaySession> inProgressPlaySessions,
+            List<QuizResult> completedQuizResults
+    ) {
+        Set<Long> playSessionIds = completedQuizResults.stream()
+                .map(QuizResult::getPlaySessionId)
+                .collect(Collectors.toSet());
+
+        List<QuizPlaySession> playSessions = new ArrayList<>(inProgressPlaySessions);
+        if (!playSessionIds.isEmpty()) {
+            playSessions.addAll(quizPlaySessionRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(playSessionIds, userId));
+        }
+        return playSessions.stream()
+                .collect(Collectors.toMap(QuizPlaySession::getId, Function.identity(), (left, right) -> left));
     }
 
     /**
@@ -165,19 +342,15 @@ public class HomeService {
     /**
      * 최근활동 응답 목록 생성
      */
-    private List<RecentActivityResponse> buildRecentActivities(HomeReadModel readModel) {
-        // V2: 여러 도메인 활동을 정확히 페이징하기 위한 읽기 모델 전환 필요
-        List<RecentActivityResponse> activities = new java.util.ArrayList<>();
+    private List<RecentActivityResponse> buildRecentActivities(RecentActivityReadModel readModel) {
+        List<RecentActivityResponse> activities = new ArrayList<>();
         Map<Long, Subject> subjectMap = readModel.subjectMap();
         Map<Long, QuizSession> quizSessionMap = readModel.quizSessionMap();
         Map<Long, QuizPlaySession> playSessionMap = readModel.playSessionMap();
-        Set<Long> startedQuizSessionIds = readModel.playSessions().stream()
-                .map(QuizPlaySession::getQuizSessionId)
-                .collect(Collectors.toSet());
 
-        activities.addAll(buildReadyQuizActivities(readModel.quizSessions(), startedQuizSessionIds, subjectMap));
-        activities.addAll(buildInProgressQuizActivities(readModel.playSessions(), quizSessionMap, subjectMap));
-        activities.addAll(buildCompletedQuizActivities(readModel.quizResults(), quizSessionMap, playSessionMap, subjectMap));
+        activities.addAll(buildReadyQuizActivities(readModel.readyQuizSessions(), subjectMap));
+        activities.addAll(buildInProgressQuizActivities(readModel.inProgressPlaySessions(), quizSessionMap, subjectMap));
+        activities.addAll(buildCompletedQuizActivities(readModel.completedQuizResults(), quizSessionMap, playSessionMap, subjectMap));
 
         return activities.stream()
                 .sorted(Comparator.comparing(RecentActivityResponse::getCreatedAt, Comparator.nullsLast(Comparator.reverseOrder())))
@@ -189,13 +362,9 @@ public class HomeService {
      */
     private List<RecentActivityResponse> buildReadyQuizActivities(
             List<QuizSession> quizSessions,
-            Set<Long> startedQuizSessionIds,
             Map<Long, Subject> subjectMap
     ) {
         return quizSessions.stream()
-                // 생성 완료 후 아직 풀이를 시작하지 않은 퀴즈
-                .filter(session -> QUIZ_SESSION_COMPLETED.equals(session.getStatus()))
-                .filter(session -> !startedQuizSessionIds.contains(session.getId()))
                 .map(session -> toReadyQuizActivity(session, subjectMap.get(session.getSubjectId())))
                 .flatMap(Optional::stream)
                 .toList();
@@ -244,15 +413,21 @@ public class HomeService {
     /**
      * D-Day 응답 목록 조회
      */
-    private List<SubjectExamScheduleResponse> findDDayScheduleResponses(HomeReadModel readModel) {
-        return subjectExamScheduleRepository
+    private List<SubjectExamScheduleResponse> findDDayScheduleResponses(Long userId) {
+        List<SubjectExamSchedule> schedules = subjectExamScheduleRepository
                 .findByUserIdAndDeletedAtIsNullAndExamDateGreaterThanEqualOrderByExamDateAscCreatedAtDesc(
-                        readModel.userId(),
+                        userId,
                         LocalDate.now(),
                         PageRequest.of(0, HOME_D_DAY_SIZE)
-                )
-                .stream()
-                .map(schedule -> toSubjectExamScheduleResponse(schedule, readModel.subjectMap().get(schedule.getSubjectId())))
+                );
+        Map<Long, Subject> subjectMap = loadSubjectMapByIds(
+                userId,
+                schedules.stream()
+                        .map(SubjectExamSchedule::getSubjectId)
+                        .collect(Collectors.toSet())
+        );
+        return schedules.stream()
+                .map(schedule -> toSubjectExamScheduleResponse(schedule, subjectMap.get(schedule.getSubjectId())))
                 .flatMap(Optional::stream)
                 .toList();
     }
@@ -260,62 +435,29 @@ public class HomeService {
     /**
      * 과목 요약 응답 목록 조회
      */
-    private List<SubjectSummaryResponse> findSubjectSummaryResponses(HomeReadModel readModel) {
-        Map<Long, Long> chapterCountMap = countBySubjectId(readModel.chapters(), Chapter::getSubjectId);
-        Map<Long, Long> partCountMap = countBySubjectId(readModel.parts(), Part::getSubjectId);
+    private List<SubjectSummaryResponse> findSubjectSummaryResponses(HomeSubjectReadModel readModel) {
         Map<Long, SubjectExamSchedule> scheduleMap = readModel.scheduleMap();
 
         return readModel.subjects().stream()
-                .sorted(Comparator
-                        .comparing((Subject subject) -> resolveLastActivityAt(subject.getId(), readModel), Comparator.nullsLast(Comparator.reverseOrder()))
-                        .thenComparing(Subject::getCreatedAt, Comparator.reverseOrder()))
-                .limit(HOME_SUBJECT_SIZE)
                 .map(subject -> toSubjectSummaryResponse(
                         subject,
-                        chapterCountMap.getOrDefault(subject.getId(), 0L),
-                        partCountMap.getOrDefault(subject.getId(), 0L),
-                        resolveLastActivityAt(subject.getId(), readModel),
+                        readModel.chapterCountMap().getOrDefault(subject.getId(), 0L),
+                        readModel.partCountMap().getOrDefault(subject.getId(), 0L),
+                        readModel.lastActivityMap().get(subject.getId()),
                         scheduleMap.get(subject.getId())
                 ))
                 .toList();
     }
 
     /**
-     * 과목별 개수 집계
+     * 과목 맵 로딩
      */
-    private <T> Map<Long, Long> countBySubjectId(Collection<T> values, Function<T, Long> subjectIdExtractor) {
-        return values.stream()
-                .collect(Collectors.groupingBy(subjectIdExtractor, Collectors.counting()));
-    }
-
-    /**
-     * 과목 마지막 활동 시각 산출
-     */
-    private LocalDateTime resolveLastActivityAt(Long subjectId, HomeReadModel readModel) {
-        return java.util.stream.Stream.of(
-                        latest(readModel.quizSessions(), subjectId, QuizSession::getSubjectId, QuizSession::getCreatedAt),
-                        latest(readModel.playSessions(), subjectId, QuizPlaySession::getSubjectId, QuizPlaySession::getUpdatedAt),
-                        latest(readModel.quizResults(), subjectId, QuizResult::getSubjectId, QuizResult::getCreatedAt)
-                )
-                .flatMap(Optional::stream)
-                .max(LocalDateTime::compareTo)
-                .orElse(null);
-    }
-
-    /**
-     * 과목별 최신 시각 조회
-     */
-    private <T> Optional<LocalDateTime> latest(
-            Collection<T> values,
-            Long subjectId,
-            Function<T, Long> subjectIdExtractor,
-            Function<T, LocalDateTime> dateTimeExtractor
-    ) {
-        return values.stream()
-                // 동일 과목 데이터만 집계
-                .filter(value -> subjectId.equals(subjectIdExtractor.apply(value)))
-                .map(dateTimeExtractor)
-                .max(LocalDateTime::compareTo);
+    private Map<Long, Subject> loadSubjectMapByIds(Long userId, Set<Long> subjectIds) {
+        if (subjectIds.isEmpty()) {
+            return Map.of();
+        }
+        return subjectRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(subjectIds, userId).stream()
+                .collect(Collectors.toMap(Subject::getId, Function.identity()));
     }
 
     /**
@@ -473,26 +615,16 @@ public class HomeService {
     }
 
     /**
-     * 홈 조합용 조회 모델
+     * 홈 과목 조합용 조회 모델
      */
-    private record HomeReadModel(
+    private record HomeSubjectReadModel(
             Long userId,
             List<Subject> subjects,
-            List<Chapter> chapters,
-            List<Part> parts,
             List<SubjectExamSchedule> schedules,
-            List<QuizSession> quizSessions,
-            List<QuizPlaySession> playSessions,
-            List<QuizResult> quizResults
+            Map<Long, Long> chapterCountMap,
+            Map<Long, Long> partCountMap,
+            Map<Long, LocalDateTime> lastActivityMap
     ) {
-
-        /**
-         * 과목 맵 생성
-         */
-        private Map<Long, Subject> subjectMap() {
-            return subjects.stream()
-                    .collect(Collectors.toMap(Subject::getId, Function.identity()));
-        }
 
         /**
          * 일정 맵 생성
@@ -501,21 +633,19 @@ public class HomeService {
             return schedules.stream()
                     .collect(Collectors.toMap(SubjectExamSchedule::getSubjectId, Function.identity()));
         }
+    }
 
-        /**
-         * 퀴즈 세션 맵 생성
-         */
-        private Map<Long, QuizSession> quizSessionMap() {
-            return quizSessions.stream()
-                    .collect(Collectors.toMap(QuizSession::getId, Function.identity()));
-        }
-
-        /**
-         * 풀이 세션 맵 생성
-         */
-        private Map<Long, QuizPlaySession> playSessionMap() {
-            return playSessions.stream()
-                    .collect(Collectors.toMap(QuizPlaySession::getId, Function.identity()));
-        }
+    /**
+     * 최근활동 조합용 조회 모델
+     */
+    private record RecentActivityReadModel(
+            List<QuizSession> readyQuizSessions,
+            List<QuizPlaySession> inProgressPlaySessions,
+            List<QuizResult> completedQuizResults,
+            Map<Long, Subject> subjectMap,
+            Map<Long, QuizSession> quizSessionMap,
+            Map<Long, QuizPlaySession> playSessionMap,
+            long totalElements
+    ) {
     }
 }

--- a/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
+++ b/src/main/java/com/f1/quiket/domain/part/repository/PartRepository.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.part.repository;
 
 import com.f1.quiket.domain.part.entity.Part;
+import com.f1.quiket.domain.home.repository.SubjectCountProjection;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -39,6 +40,23 @@ public interface PartRepository extends JpaRepository<Part, Long> {
      * 과목별 파트 목록 조회
      */
     List<Part> findAllBySubjectIdInAndDeletedAtIsNull(Collection<Long> subjectIds);
+
+    /**
+     * 과목별 파트 개수 집계
+     */
+    @Query("""
+            select p.subjectId as subjectId,
+                   count(p) as itemCount
+            from Part p
+            where p.userId = :userId
+              and p.deletedAt is null
+              and p.subjectId in :subjectIds
+            group by p.subjectId
+            """)
+    List<SubjectCountProjection> countBySubjectIds(
+            @Param("userId") Long userId,
+            @Param("subjectIds") Collection<Long> subjectIds
+    );
     List<Part> findAllBySubjectIdAndUserIdAndDeletedAtIsNullOrderByChapterIdAscPartNumberAscCreatedAtAsc(
             Long subjectId,
             Long userId

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizPlaySessionRepository.java
@@ -1,9 +1,14 @@
 package com.f1.quiket.domain.quiz.repository;
 
+import com.f1.quiket.domain.home.repository.SubjectLastActivityProjection;
 import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -18,6 +23,20 @@ public interface QuizPlaySessionRepository extends JpaRepository<QuizPlaySession
     List<QuizPlaySession> findAllByUserId(Long userId);
 
     /**
+     * 사용자 풀이 세션 상태별 최신 목록 조회
+     */
+    List<QuizPlaySession> findByUserIdAndStatusAndDeletedAtIsNullOrderByUpdatedAtDesc(
+            Long userId,
+            String status,
+            Pageable pageable
+    );
+
+    /**
+     * 사용자 풀이 세션 상태별 개수
+     */
+    long countByUserIdAndStatusAndDeletedAtIsNull(Long userId, String status);
+
+    /**
      * 클라이언트 풀이 세션 단건 조회
      */
     Optional<QuizPlaySession> findByClientSessionId(String clientSessionId);
@@ -26,4 +45,26 @@ public interface QuizPlaySessionRepository extends JpaRepository<QuizPlaySession
      * 사용자 풀이 세션 단건 조회
      */
     Optional<QuizPlaySession> findByIdAndUserId(Long id, Long userId);
+
+    /**
+     * 사용자 풀이 세션 목록 조회 (PK 컬렉션 기반)
+     */
+    List<QuizPlaySession> findAllByIdInAndUserIdAndDeletedAtIsNull(Collection<Long> ids, Long userId);
+
+    /**
+     * 과목별 풀이 최신 시각 조회
+     */
+    @Query("""
+            select playSession.subjectId as subjectId,
+                   max(playSession.updatedAt) as lastActivityAt
+            from QuizPlaySession playSession
+            where playSession.userId = :userId
+              and playSession.deletedAt is null
+              and playSession.subjectId in :subjectIds
+            group by playSession.subjectId
+            """)
+    List<SubjectLastActivityProjection> findLastActivityBySubjectIds(
+            @Param("userId") Long userId,
+            @Param("subjectIds") Collection<Long> subjectIds
+    );
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizResultRepository.java
@@ -1,9 +1,14 @@
 package com.f1.quiket.domain.quiz.repository;
 
+import com.f1.quiket.domain.home.repository.SubjectLastActivityProjection;
 import com.f1.quiket.domain.quiz.entity.QuizResult;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -18,6 +23,16 @@ public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
     List<QuizResult> findAllByUserId(Long userId);
 
     /**
+     * 사용자 결과 최신 목록 조회
+     */
+    List<QuizResult> findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    /**
+     * 사용자 결과 개수
+     */
+    long countByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
      * 풀이 세션 결과 단건 조회
      */
     Optional<QuizResult> findByPlaySessionId(Long playSessionId);
@@ -26,4 +41,21 @@ public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
      * 사용자 결과 단건 조회
      */
     Optional<QuizResult> findByPublicIdAndUserId(String publicId, Long userId);
+
+    /**
+     * 과목별 결과 최신 시각 조회
+     */
+    @Query("""
+            select result.subjectId as subjectId,
+                   max(result.createdAt) as lastActivityAt
+            from QuizResult result
+            where result.userId = :userId
+              and result.deletedAt is null
+              and result.subjectId in :subjectIds
+            group by result.subjectId
+            """)
+    List<SubjectLastActivityProjection> findLastActivityBySubjectIds(
+            @Param("userId") Long userId,
+            @Param("subjectIds") Collection<Long> subjectIds
+    );
 }

--- a/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/repository/QuizSessionRepository.java
@@ -1,10 +1,14 @@
 package com.f1.quiket.domain.quiz.repository;
 
+import com.f1.quiket.domain.home.repository.SubjectLastActivityProjection;
 import com.f1.quiket.domain.quiz.entity.QuizSession;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -17,6 +21,49 @@ public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> 
      * 사용자 퀴즈 세션 목록 조회
      */
     List<QuizSession> findAllByUserIdAndDeletedAtIsNull(Long userId);
+
+    /**
+     * 홈 미시작 퀴즈 활동 조회
+     */
+    @Query("""
+            select session
+            from QuizSession session
+            where session.userId = :userId
+              and session.status = :status
+              and session.deletedAt is null
+              and not exists (
+                  select 1
+                  from QuizPlaySession playSession
+                  where playSession.userId = :userId
+                    and playSession.quizSessionId = session.id
+                    and playSession.deletedAt is null
+              )
+            order by session.completedAt desc, session.updatedAt desc
+            """)
+    List<QuizSession> findReadyActivities(
+            @Param("userId") Long userId,
+            @Param("status") String status,
+            Pageable pageable
+    );
+
+    /**
+     * 홈 미시작 퀴즈 활동 개수
+     */
+    @Query("""
+            select count(session)
+            from QuizSession session
+            where session.userId = :userId
+              and session.status = :status
+              and session.deletedAt is null
+              and not exists (
+                  select 1
+                  from QuizPlaySession playSession
+                  where playSession.userId = :userId
+                    and playSession.quizSessionId = session.id
+                    and playSession.deletedAt is null
+              )
+            """)
+    long countReadyActivities(@Param("userId") Long userId, @Param("status") String status);
 
     /**
      * 과목 퀴즈 세션 목록 조회
@@ -37,4 +84,26 @@ public interface QuizSessionRepository extends JpaRepository<QuizSession, Long> 
      * 사용자 퀴즈 세션 단건 조회 (PK 기반)
      */
     Optional<QuizSession> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
+
+    /**
+     * 사용자 퀴즈 세션 목록 조회 (PK 컬렉션 기반)
+     */
+    List<QuizSession> findAllByIdInAndUserIdAndDeletedAtIsNull(Collection<Long> ids, Long userId);
+
+    /**
+     * 과목별 퀴즈 생성 최신 시각 조회
+     */
+    @Query("""
+            select session.subjectId as subjectId,
+                   max(session.createdAt) as lastActivityAt
+            from QuizSession session
+            where session.userId = :userId
+              and session.deletedAt is null
+              and session.subjectId in :subjectIds
+            group by session.subjectId
+            """)
+    List<SubjectLastActivityProjection> findLastActivityBySubjectIds(
+            @Param("userId") Long userId,
+            @Param("subjectIds") Collection<Long> subjectIds
+    );
 }

--- a/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
+++ b/src/main/java/com/f1/quiket/domain/subject/repository/SubjectRepository.java
@@ -1,11 +1,14 @@
 package com.f1.quiket.domain.subject.repository;
 
 import com.f1.quiket.domain.subject.entity.Subject;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /**
@@ -25,6 +28,42 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
     Page<Subject> findByUserIdAndDeletedAtIsNull(Long userId, Pageable pageable);
 
     /**
+     * 홈 과목 요약 대상 조회
+     */
+    @Query(value = """
+            SELECT s.*
+            FROM subjects s
+            WHERE s.user_id = :userId
+              AND s.deleted_at IS NULL
+            ORDER BY GREATEST(
+                COALESCE((
+                    SELECT MAX(qs.created_at)
+                    FROM quiz_sessions qs
+                    WHERE qs.user_id = :userId
+                      AND qs.subject_id = s.id
+                      AND qs.deleted_at IS NULL
+                ), TIMESTAMP('1000-01-01 00:00:00')),
+                COALESCE((
+                    SELECT MAX(qps.updated_at)
+                    FROM quiz_play_sessions qps
+                    WHERE qps.user_id = :userId
+                      AND qps.subject_id = s.id
+                      AND qps.deleted_at IS NULL
+                ), TIMESTAMP('1000-01-01 00:00:00')),
+                COALESCE((
+                    SELECT MAX(qr.created_at)
+                    FROM quiz_results qr
+                    WHERE qr.user_id = :userId
+                      AND qr.subject_id = s.id
+                      AND qr.deleted_at IS NULL
+                ), TIMESTAMP('1000-01-01 00:00:00'))
+            ) DESC,
+            s.created_at DESC
+            LIMIT :limit
+            """, nativeQuery = true)
+    List<Subject> findHomeSummarySubjects(@Param("userId") Long userId, @Param("limit") int limit);
+
+    /**
      * 공개 식별자 기반 사용자 과목 조회
      */
     Optional<Subject> findByPublicIdAndUserIdAndDeletedAtIsNull(String publicId, Long userId);
@@ -33,4 +72,9 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
      * 사용자 과목 단건 조회 (PK 기반)
      */
     Optional<Subject> findByIdAndUserIdAndDeletedAtIsNull(Long id, Long userId);
+
+    /**
+     * 사용자 과목 목록 조회 (PK 컬렉션 기반)
+     */
+    List<Subject> findAllByIdInAndUserIdAndDeletedAtIsNull(Collection<Long> ids, Long userId);
 }

--- a/src/test/java/com/f1/quiket/domain/home/service/HomeServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/home/service/HomeServiceTest.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.home.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -11,6 +12,8 @@ import com.f1.quiket.domain.chapter.repository.ChapterRepository;
 import com.f1.quiket.domain.home.dto.HomeDataResponse;
 import com.f1.quiket.domain.home.dto.RecentActivityPageResponse;
 import com.f1.quiket.domain.home.dto.RecentActivityType;
+import com.f1.quiket.domain.home.repository.SubjectCountProjection;
+import com.f1.quiket.domain.home.repository.SubjectLastActivityProjection;
 import com.f1.quiket.domain.part.entity.Part;
 import com.f1.quiket.domain.part.repository.PartRepository;
 import com.f1.quiket.domain.quiz.entity.QuizPlaySession;
@@ -27,8 +30,11 @@ import com.f1.quiket.domain.user.entity.User;
 import com.f1.quiket.domain.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -141,15 +147,104 @@ class HomeServiceTest {
 
     private void mockCommonHomeData(User user, List<Subject> subjects, List<Chapter> chapters, List<Part> parts, List<SubjectExamSchedule> schedules, List<QuizSession> quizSessions, List<QuizPlaySession> playSessions, List<QuizResult> quizResults) {
         when(userRepository.findByPublicIdAndDeletedAtIsNull(user.getPublicId())).thenReturn(Optional.of(user));
-        when(subjectRepository.findAllByUserIdAndDeletedAtIsNull(user.getId())).thenReturn(subjects);
-        when(chapterRepository.findAllByUserIdAndDeletedAtIsNull(user.getId())).thenReturn(chapters);
-        when(partRepository.findAllByUserIdAndDeletedAtIsNull(user.getId())).thenReturn(parts);
+        when(subjectRepository.findHomeSummarySubjects(eq(user.getId()), anyInt())).thenReturn(subjects);
+        when(subjectRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(any(), eq(user.getId()))).thenReturn(subjects);
+        when(chapterRepository.countBySubjectIds(eq(user.getId()), any())).thenReturn(countProjections(chapters, Chapter::getSubjectId));
+        when(partRepository.countBySubjectIds(eq(user.getId()), any())).thenReturn(countProjections(parts, Part::getSubjectId));
         when(subjectExamScheduleRepository.findAllBySubjectIdInAndDeletedAtIsNull(any())).thenReturn(schedules);
         when(subjectExamScheduleRepository.findByUserIdAndDeletedAtIsNullAndExamDateGreaterThanEqualOrderByExamDateAscCreatedAtDesc(eq(user.getId()), any(LocalDate.class), any()))
                 .thenReturn(List.of());
-        when(quizSessionRepository.findAllByUserIdAndDeletedAtIsNull(user.getId())).thenReturn(quizSessions);
-        when(quizPlaySessionRepository.findAllByUserId(user.getId())).thenReturn(playSessions);
-        when(quizResultRepository.findAllByUserId(user.getId())).thenReturn(quizResults);
+        when(quizSessionRepository.findReadyActivities(eq(user.getId()), eq("completed"), any()))
+                .thenReturn(readyQuizSessions(quizSessions, playSessions));
+        when(quizSessionRepository.countReadyActivities(user.getId(), "completed"))
+                .thenReturn((long) readyQuizSessions(quizSessions, playSessions).size());
+        when(quizSessionRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(any(), eq(user.getId()))).thenReturn(quizSessions);
+        when(quizSessionRepository.findLastActivityBySubjectIds(eq(user.getId()), any()))
+                .thenReturn(lastActivityProjections(quizSessions, QuizSession::getSubjectId, QuizSession::getCreatedAt));
+        when(quizPlaySessionRepository.findByUserIdAndStatusAndDeletedAtIsNullOrderByUpdatedAtDesc(eq(user.getId()), eq("in_progress"), any()))
+                .thenReturn(playSessions.stream()
+                        .filter(playSession -> "in_progress".equals(playSession.getStatus()))
+                        .sorted(Comparator.comparing(QuizPlaySession::getUpdatedAt).reversed())
+                        .toList());
+        when(quizPlaySessionRepository.countByUserIdAndStatusAndDeletedAtIsNull(user.getId(), "in_progress"))
+                .thenReturn(playSessions.stream()
+                        .filter(playSession -> "in_progress".equals(playSession.getStatus()))
+                        .count());
+        when(quizPlaySessionRepository.findAllByIdInAndUserIdAndDeletedAtIsNull(any(), eq(user.getId()))).thenReturn(playSessions);
+        when(quizPlaySessionRepository.findLastActivityBySubjectIds(eq(user.getId()), any()))
+                .thenReturn(lastActivityProjections(playSessions, QuizPlaySession::getSubjectId, QuizPlaySession::getUpdatedAt));
+        when(quizResultRepository.findByUserIdAndDeletedAtIsNullOrderByCreatedAtDesc(eq(user.getId()), any()))
+                .thenReturn(quizResults.stream()
+                        .sorted(Comparator.comparing(QuizResult::getCreatedAt).reversed())
+                        .toList());
+        when(quizResultRepository.countByUserIdAndDeletedAtIsNull(user.getId())).thenReturn((long) quizResults.size());
+        when(quizResultRepository.findLastActivityBySubjectIds(eq(user.getId()), any()))
+                .thenReturn(lastActivityProjections(quizResults, QuizResult::getSubjectId, QuizResult::getCreatedAt));
+    }
+
+    private List<QuizSession> readyQuizSessions(List<QuizSession> quizSessions, List<QuizPlaySession> playSessions) {
+        List<Long> startedQuizSessionIds = playSessions.stream()
+                .map(QuizPlaySession::getQuizSessionId)
+                .toList();
+        return quizSessions.stream()
+                .filter(session -> "completed".equals(session.getStatus()))
+                .filter(session -> !startedQuizSessionIds.contains(session.getId()))
+                .sorted(Comparator.comparing(QuizSession::getCompletedAt).reversed())
+                .toList();
+    }
+
+    private <T> List<SubjectCountProjection> countProjections(List<T> values, Function<T, Long> subjectIdExtractor) {
+        return values.stream()
+                .collect(Collectors.groupingBy(subjectIdExtractor, Collectors.counting()))
+                .entrySet()
+                .stream()
+                .map(entry -> subjectCountProjection(entry.getKey(), entry.getValue()))
+                .toList();
+    }
+
+    private SubjectCountProjection subjectCountProjection(Long subjectId, Long itemCount) {
+        return new SubjectCountProjection() {
+            @Override
+            public Long getSubjectId() {
+                return subjectId;
+            }
+
+            @Override
+            public Long getItemCount() {
+                return itemCount;
+            }
+        };
+    }
+
+    private <T> List<SubjectLastActivityProjection> lastActivityProjections(
+            List<T> values,
+            Function<T, Long> subjectIdExtractor,
+            Function<T, LocalDateTime> lastActivityAtExtractor
+    ) {
+        return values.stream()
+                .collect(Collectors.groupingBy(
+                        subjectIdExtractor,
+                        Collectors.mapping(lastActivityAtExtractor, Collectors.maxBy(LocalDateTime::compareTo))
+                ))
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().isPresent())
+                .map(entry -> subjectLastActivityProjection(entry.getKey(), entry.getValue().get()))
+                .toList();
+    }
+
+    private SubjectLastActivityProjection subjectLastActivityProjection(Long subjectId, LocalDateTime lastActivityAt) {
+        return new SubjectLastActivityProjection() {
+            @Override
+            public Long getSubjectId() {
+                return subjectId;
+            }
+
+            @Override
+            public LocalDateTime getLastActivityAt() {
+                return lastActivityAt;
+            }
+        };
     }
 
     private User user() {


### PR DESCRIPTION
## 작업 내용
- 홈 최근활동을 전체 적재 후 슬라이싱하는 구조에서 소스별 제한 조회 후 병합하는 구조로 변경
- 최근활동 totalElements 산출을 DB count 기반으로 변경
- 홈 과목 요약 대상 조회, 챕터/파트 개수, 마지막 활동 시각 집계 쿼리 분리
- D-Day 카드 과목 매핑을 필요한 과목만 조회하도록 변경

## 테스트
- ./gradlew test --tests 'com.f1.quiket.domain.home.service.HomeServiceTest'
- ./gradlew test 


Closes #124