### PR TITLE
[Fix] 잘못된 요청 본문을 400으로 응답

### DIFF
--- a/src/main/java/com/f1/quiket/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/f1/quiket/global/error/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -46,6 +47,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE, message));
+    }
+
+    /**
+     * 요청 본문 파싱 실패 (깨진 JSON, 타입 불일치, 날짜/enum 역직렬화 실패 등)
+     * 클라이언트 입력 오류이므로 500이 아닌 400으로 응답한다.
+     * 내부 파싱 상세는 민감 정보 노출 방지를 위해 메시지에 포함하지 않는다.
+     */
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        log.warn("Malformed request body: {}", e.getMostSpecificCause().getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE, "요청 본문의 형식이 올바르지 않습니다."));
     }
 
     /**

--- a/src/test/java/com/f1/quiket/global/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/f1/quiket/global/error/GlobalExceptionHandlerTest.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.f1.quiket.global.response.ApiResponse;
 import com.f1.quiket.global.response.ErrorCode;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 class GlobalExceptionHandlerTest {
@@ -23,5 +25,23 @@ class GlobalExceptionHandlerTest {
         assertThat(response.getBody().isSuccess()).isFalse();
         assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED.getCode());
         assertThat(response.getBody().getMessage()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED.getMessage());
+    }
+
+    @Test
+    void handleHttpMessageNotReadableException_returns_400_invalid_input() {
+        // 날짜/enum 역직렬화 실패 등 잘못된 요청 본문은 500이 아닌 400으로 응답해야 한다.
+        HttpMessageNotReadableException exception = new HttpMessageNotReadableException(
+                "JSON parse error: Cannot deserialize value of type `java.time.LocalDate` from String \"2026.06.30\"",
+                new RuntimeException("date parse failed"),
+                null
+        );
+
+        ResponseEntity<ApiResponse<?>> response = handler.handleHttpMessageNotReadableException(exception);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().isSuccess()).isFalse();
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INVALID_INPUT_VALUE.getCode());
+        assertThat(response.getBody().getMessage()).isEqualTo("요청 본문의 형식이 올바르지 않습니다.");
     }
 }


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 잘못된 요청 본문(역직렬화 실패)이 클라이언트 입력 오류임에도 **500(C002)** 으로 응답되던 문제를 **400(C001)** 으로 수정
- 재현: `PUT /api/v1/subjects/{id}/exam-schedule`에 `examDate: "2026.06.30"`(비-ISO) 전송 시 500
- 원인: `examDate`(`LocalDate`) 파싱 실패로 `HttpMessageNotReadableException` 발생 → `GlobalExceptionHandler`에 핸들러가 없어 fallback `@ExceptionHandler(Exception.class)`로 500 반환
- 이 케이스뿐 아니라 모든 잘못된 본문(깨진 JSON / 타입 불일치 / enum 역직렬화 실패)이 일괄 500으로 나가던 전역 문제

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `GlobalExceptionHandler`에 `HttpMessageNotReadableException` 핸들러 추가 → `400 INVALID_INPUT_VALUE(C001)`
- 내부 파싱 상세(Jackson 메시지)는 응답 본문에 노출하지 않고 고정 메시지(`"요청 본문의 형식이 올바르지 않습니다."`)만 반환, 원인은 `warn` 로그로만 기록
- `GlobalExceptionHandlerTest`에 날짜 역직렬화 실패 → 400 단위 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.global.error.GlobalExceptionHandlerTest`
2. `./gradlew check`
3. 스모크: `PUT /api/v1/subjects/{id}/exam-schedule`에 `examDate: "2026.06.30"`(비-ISO) 전송 → **400 C001** 응답 확인 (기존 500 → 400)

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #132

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 클라이언트도 `examDate`는 ISO(`2026-06-30`)로 전송해야 정상 처리됨. 본 PR은 **잘못된 입력에 대한 응답 코드 정합성(500→400)** 만 다룸
- enum 대소문자(`EXAM` vs `exam`) 문제는 명세(소문자) 준수로 클라이언트 측 처리 — 본 PR 범위 아님
- `MethodArgumentTypeMismatchException`(PathVariable/RequestParam 타입 불일치) 등 다른 요청 파싱 계열도 400으로 정리 가능하나, 본 PR은 제보된 본문 역직렬화 케이스로 스코프 한정

---

## 🧑‍💻 Assignee

- @imclaremont