### PR TITLE
[Refactor] 표준 MVC 예외를 ResponseEntityExceptionHandler로 일원화

### DIFF
--- a/src/main/java/com/f1/quiket/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/f1/quiket/global/error/GlobalExceptionHandler.java
@@ -2,25 +2,39 @@ package com.f1.quiket.global.error;
 
 import com.f1.quiket.global.response.ApiResponse;
 import com.f1.quiket.global.response.ErrorCode;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
-import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
-import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 /**
  * 전역 예외 처리 핸들러
- * 모든 컨트롤러에서 발생하는 예외를 통일된 형식(ApiResponse)으로 처리
+ *
+ * <p>표준 Spring MVC 예외(본문 파싱 실패, 타입 불일치, 필수 파라미터 누락, 메서드 미지원,
+ * 미디어타입 등)는 {@link ResponseEntityExceptionHandler}가 적절한 4xx/5xx로 분류하며,
+ * 본 핸들러는 {@link #handleExceptionInternal}에서 응답 본문만 {@link ApiResponse} 포맷으로
+ * 변환한다. 따라서 예외마다 개별 {@code @ExceptionHandler}를 나열하지 않아도 표준 예외가
+ * 일관된 형식·상태코드로 응답된다.</p>
+ *
+ * <p>RESH가 다루지 않는 도메인 예외({@link CustomException}), Bean Validation 파라미터 검증
+ * 실패({@link ConstraintViolationException}), 전용 응답이 필요한 케이스({@link
+ * MaxUploadSizeExceededException}), 그리고 최종 fallback({@link Exception})만 개별 핸들러로
+ * 둔다.</p>
  */
 @Slf4j
 @ControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     /**
      * 커스텀 예외 처리
@@ -34,69 +48,25 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * @Valid, @Validated 입력값 검증 실패
+     * {@code @Validated} 경로/쿼리 파라미터 검증 실패 (RESH 미커버).
+     * 메서드 파라미터에 직접 붙은 제약(@Email, @NotBlank 등) 위반 시 발생하며,
+     * 클라이언트 입력 오류이므로 400으로 응답한다.
      */
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-
-        String message = Optional.ofNullable(e.getBindingResult().getFieldError())
-                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<?>> handleConstraintViolationException(ConstraintViolationException e) {
+        String message = e.getConstraintViolations().stream()
+                .findFirst()
+                .map(this::formatViolation)
                 .orElse("입력값이 올바르지 않습니다.");
 
-        log.warn("Validation failed: {}", message);
+        log.warn("Constraint violation: {}", message);
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE, message));
     }
 
     /**
-     * 요청 본문 파싱 실패 (깨진 JSON, 타입 불일치, 날짜/enum 역직렬화 실패 등)
-     * 클라이언트 입력 오류이므로 500이 아닌 400으로 응답한다.
-     * 내부 파싱 상세는 민감 정보 노출 방지를 위해 메시지에 포함하지 않는다.
-     */
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ApiResponse<?>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
-        log.warn("Malformed request body: {}", e.getMostSpecificCause().getMessage());
-        return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE, "요청 본문의 형식이 올바르지 않습니다."));
-    }
-
-    /**
-     * HTTP 메서드 미지원
-     */
-    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<ApiResponse<?>> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
-        log.warn("Method not allowed: {}", e.getMethod());
-        return ResponseEntity
-                .status(HttpStatus.METHOD_NOT_ALLOWED)
-                .body(ApiResponse.fail(ErrorCode.METHOD_NOT_ALLOWED));
-    }
-
-    /**
-     * multipart 파일 용량 초과
-     */
-    @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<ApiResponse<?>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
-        log.warn("Multipart upload size exceeded: {}", e.getMessage());
-        return ResponseEntity
-                .status(ErrorCode.FILE_SIZE_EXCEEDED.getStatus())
-                .body(ApiResponse.fail(ErrorCode.FILE_SIZE_EXCEEDED));
-    }
-
-    /**
-     * 404 Not Found
-     */
-    @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<ApiResponse<?>> handleNoHandlerFoundException(NoHandlerFoundException e) {
-        log.warn("Resource not found: {}", e.getRequestURL());
-        return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
-                .body(ApiResponse.fail(ErrorCode.NOT_FOUND));
-    }
-
-    /**
-     * 전역 예외 처리
+     * 전역 fallback — 처리되지 않은 예외는 500
      */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<?>> handleGlobalException(Exception e) {
@@ -104,5 +74,93 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
+    /**
+     * {@code @Valid} 본문 검증 실패 — 위반 필드/메시지를 노출하도록 RESH 기본 동작을 재정의.
+     */
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request
+    ) {
+        String message = Optional.ofNullable(ex.getBindingResult().getFieldError())
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .orElse("입력값이 올바르지 않습니다.");
+
+        log.warn("Validation failed: {}", message);
+        return createResponseEntity(ApiResponse.fail(ErrorCode.INVALID_INPUT_VALUE, message), headers, status, request);
+    }
+
+    /**
+     * RESH가 분류한 표준 MVC 예외의 공통 응답 변환.
+     * 상태코드를 도메인 {@link ErrorCode}로 매핑하고 본문을 {@link ApiResponse}로 통일한다.
+     * 내부 파싱/검증 상세는 응답에 노출하지 않고 원인만 로그로 남긴다.
+     */
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception ex,
+            Object body,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest request
+    ) {
+        // 파일 업로드 용량 초과는 전용 응답(FILE_SIZE_EXCEEDED, 413)을 보존한다.
+        // RESH가 MaxUploadSizeExceededException을 이미 @ExceptionHandler로 매핑하므로
+        // 개별 핸들러를 두면 매핑 충돌이 나, 여기서 타입 분기로 처리한다.
+        if (ex instanceof MaxUploadSizeExceededException) {
+            log.warn("Multipart upload size exceeded: {}", ex.getMessage());
+            HttpStatusCode fileSizeStatus = HttpStatus.valueOf(ErrorCode.FILE_SIZE_EXCEEDED.getStatus());
+            return createResponseEntity(ApiResponse.fail(ErrorCode.FILE_SIZE_EXCEEDED), headers, fileSizeStatus, request);
+        }
+
+        ErrorCode errorCode = resolveErrorCode(statusCode);
+        String message = resolveMessage(ex, errorCode);
+
+        if (statusCode.is5xxServerError()) {
+            log.error("MVC exception ({}): ", statusCode, ex);
+        } else {
+            log.warn("MVC exception ({}): {}", statusCode, ex.getMessage());
+        }
+        return createResponseEntity(ApiResponse.fail(errorCode, message), headers, statusCode, request);
+    }
+
+    private String formatViolation(ConstraintViolation<?> violation) {
+        String path = violation.getPropertyPath() == null ? "" : violation.getPropertyPath().toString();
+        int lastDot = path.lastIndexOf('.');
+        String field = lastDot >= 0 ? path.substring(lastDot + 1) : path;
+        return field.isBlank() ? violation.getMessage() : field + ": " + violation.getMessage();
+    }
+
+    private ErrorCode resolveErrorCode(HttpStatusCode statusCode) {
+        if (statusCode.equals(HttpStatus.METHOD_NOT_ALLOWED)) {
+            return ErrorCode.METHOD_NOT_ALLOWED;
+        }
+        if (statusCode.equals(HttpStatus.NOT_FOUND)) {
+            return ErrorCode.NOT_FOUND;
+        }
+        if (statusCode.equals(HttpStatus.UNSUPPORTED_MEDIA_TYPE)) {
+            return ErrorCode.UNSUPPORTED_MEDIA_TYPE;
+        }
+        if (statusCode.equals(HttpStatus.NOT_ACCEPTABLE)) {
+            return ErrorCode.NOT_ACCEPTABLE;
+        }
+        if (statusCode.equals(HttpStatus.SERVICE_UNAVAILABLE)) {
+            return ErrorCode.SERVICE_UNAVAILABLE;
+        }
+        if (statusCode.is5xxServerError()) {
+            return ErrorCode.INTERNAL_SERVER_ERROR;
+        }
+        // 그 외 4xx(본문 파싱 실패/타입 불일치/필수 파라미터 누락 등)는 잘못된 입력으로 통일
+        return ErrorCode.INVALID_INPUT_VALUE;
+    }
+
+    private String resolveMessage(Exception ex, ErrorCode errorCode) {
+        if (ex instanceof HttpMessageNotReadableException) {
+            return "요청 본문의 형식이 올바르지 않습니다.";
+        }
+        return errorCode.getMessage();
     }
 }

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -17,8 +17,10 @@ public enum ErrorCode {
     FORBIDDEN(403, "C006", "접근 권한이 없습니다."),
     NOT_FOUND(404, "C003", "요청한 리소스를 찾을 수 없습니다."),
     METHOD_NOT_ALLOWED(405, "C004", "허용되지 않은 HTTP 메서드입니다."),
+    NOT_ACCEPTABLE(406, "C013", "응답 가능한 표현 형식이 없습니다."),
     CONFLICT(409, "C007", "이미 존재하는 리소스입니다."),
     FILE_SIZE_EXCEEDED(413, "C011", "파일 크기는 50MB 이하만 업로드 가능합니다"),
+    UNSUPPORTED_MEDIA_TYPE(415, "C012", "지원하지 않는 미디어 타입입니다."),
     UNPROCESSABLE_ENTITY(422, "C008", "처리할 수 없는 엔티티입니다."),
 
     // Auth Errors

--- a/src/test/java/com/f1/quiket/global/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/f1/quiket/global/error/GlobalExceptionHandlerTest.java
@@ -1,47 +1,150 @@
 package com.f1.quiket.global.error;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.f1.quiket.global.response.ApiResponse;
 import com.f1.quiket.global.response.ErrorCode;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.Path;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 class GlobalExceptionHandlerTest {
 
     private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
 
-    @Test
-    void handleMaxUploadSizeExceededException_returns_file_size_exceeded_response() {
-        ResponseEntity<ApiResponse<?>> response = handler.handleMaxUploadSizeExceededException(
-                new MaxUploadSizeExceededException(50 * 1024 * 1024)
-        );
+    private ServletWebRequest webRequest() {
+        return new ServletWebRequest(new MockHttpServletRequest());
+    }
 
-        assertThat(response.getStatusCode().value()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED.getStatus());
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().isSuccess()).isFalse();
-        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED.getCode());
-        assertThat(response.getBody().getMessage()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED.getMessage());
+    private ApiResponse<?> body(ResponseEntity<?> response) {
+        assertThat(response.getBody()).isInstanceOf(ApiResponse.class);
+        return (ApiResponse<?>) response.getBody();
     }
 
     @Test
-    void handleHttpMessageNotReadableException_returns_400_invalid_input() {
-        // 날짜/enum 역직렬화 실패 등 잘못된 요청 본문은 500이 아닌 400으로 응답해야 한다.
-        HttpMessageNotReadableException exception = new HttpMessageNotReadableException(
+    void handleExceptionInternal_preserves_file_size_exceeded_response() {
+        // MaxUploadSizeExceededException은 RESH가 매핑하므로 개별 핸들러를 둘 수 없어
+        // handleExceptionInternal에서 타입 분기로 전용 응답(FILE_SIZE_EXCEEDED, 413)을 보존한다.
+        ResponseEntity<Object> response = handler.handleExceptionInternal(
+                new MaxUploadSizeExceededException(50 * 1024 * 1024),
+                null, new HttpHeaders(), HttpStatus.PAYLOAD_TOO_LARGE, webRequest()
+        );
+
+        assertThat(response.getStatusCode().value()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED.getStatus());
+        assertThat(body(response).isSuccess()).isFalse();
+        assertThat(body(response).getCode()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED.getCode());
+        assertThat(body(response).getMessage()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED.getMessage());
+    }
+
+    @Test
+    void handleExceptionInternal_maps_message_not_readable_to_400_with_fixed_message() {
+        // 날짜/enum 역직렬화 실패 등 잘못된 본문은 400 + 고정 메시지 (PR #133 동작을 RESH 경로에서 보존)
+        HttpMessageNotReadableException ex = new HttpMessageNotReadableException(
                 "JSON parse error: Cannot deserialize value of type `java.time.LocalDate` from String \"2026.06.30\"",
                 new RuntimeException("date parse failed"),
                 null
         );
 
-        ResponseEntity<ApiResponse<?>> response = handler.handleHttpMessageNotReadableException(exception);
+        ResponseEntity<Object> response = handler.handleExceptionInternal(
+                ex, null, new HttpHeaders(), HttpStatus.BAD_REQUEST, webRequest()
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(body(response).isSuccess()).isFalse();
+        assertThat(body(response).getCode()).isEqualTo(ErrorCode.INVALID_INPUT_VALUE.getCode());
+        assertThat(body(response).getMessage()).isEqualTo("요청 본문의 형식이 올바르지 않습니다.");
+    }
+
+    @Test
+    void handleExceptionInternal_maps_status_to_matching_error_code() {
+        assertThat(body(internal(HttpStatus.METHOD_NOT_ALLOWED)).getCode())
+                .isEqualTo(ErrorCode.METHOD_NOT_ALLOWED.getCode());
+        assertThat(body(internal(HttpStatus.NOT_FOUND)).getCode())
+                .isEqualTo(ErrorCode.NOT_FOUND.getCode());
+        assertThat(body(internal(HttpStatus.UNSUPPORTED_MEDIA_TYPE)).getCode())
+                .isEqualTo(ErrorCode.UNSUPPORTED_MEDIA_TYPE.getCode());
+        assertThat(body(internal(HttpStatus.NOT_ACCEPTABLE)).getCode())
+                .isEqualTo(ErrorCode.NOT_ACCEPTABLE.getCode());
+        // 매핑되지 않은 5xx는 내부 서버 오류로 통일
+        assertThat(body(internal(HttpStatus.INTERNAL_SERVER_ERROR)).getCode())
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR.getCode());
+        // 매핑되지 않은 4xx는 잘못된 입력으로 통일
+        assertThat(body(internal(HttpStatus.PAYLOAD_TOO_LARGE)).getCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE.getCode());
+    }
+
+    private ResponseEntity<Object> internal(HttpStatus status) {
+        return handler.handleExceptionInternal(
+                new RuntimeException("boom"), null, new HttpHeaders(), status, webRequest()
+        );
+    }
+
+    @Test
+    void handleConstraintViolationException_returns_400_with_field_message() {
+        // @Validated path/query 파라미터 검증 실패 — 기존에는 500으로 샜던 케이스
+        ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+        Path path = mock(Path.class);
+        when(path.toString()).thenReturn("checkEmail.email");
+        when(violation.getPropertyPath()).thenReturn(path);
+        when(violation.getMessage()).thenReturn("올바른 이메일 형식이 아닙니다");
+
+        ResponseEntity<ApiResponse<?>> response = handler.handleConstraintViolationException(
+                new ConstraintViolationException(Set.of(violation))
+        );
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().isSuccess()).isFalse();
         assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INVALID_INPUT_VALUE.getCode());
-        assertThat(response.getBody().getMessage()).isEqualTo("요청 본문의 형식이 올바르지 않습니다.");
+        assertThat(response.getBody().getMessage()).isEqualTo("email: 올바른 이메일 형식이 아닙니다");
+    }
+
+    @Test
+    void handleConstraintViolationException_falls_back_when_no_violation() {
+        ResponseEntity<ApiResponse<?>> response = handler.handleConstraintViolationException(
+                new ConstraintViolationException(Set.of())
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getMessage()).isEqualTo("입력값이 올바르지 않습니다.");
+    }
+
+    @Test
+    void handleMethodArgumentNotValid_exposes_field_and_message() {
+        MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+        BindingResult bindingResult = mock(BindingResult.class);
+        when(ex.getBindingResult()).thenReturn(bindingResult);
+        when(bindingResult.getFieldError()).thenReturn(new FieldError("request", "examDate", "시험 날짜는 필수입니다"));
+
+        ResponseEntity<Object> response = handler.handleMethodArgumentNotValid(
+                ex, new HttpHeaders(), HttpStatus.BAD_REQUEST, webRequest()
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(body(response).getCode()).isEqualTo(ErrorCode.INVALID_INPUT_VALUE.getCode());
+        assertThat(body(response).getMessage()).isEqualTo("examDate: 시험 날짜는 필수입니다");
+    }
+
+    @Test
+    void handleGlobalException_returns_500() {
+        ResponseEntity<ApiResponse<?>> response = handler.handleGlobalException(new RuntimeException("unexpected"));
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR.getCode());
     }
 }


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- `GlobalExceptionHandler`가 `ResponseEntityExceptionHandler`(RESH)를 상속하지 않아, fallback `@ExceptionHandler(Exception.class)`가 Spring이 원래 4xx로 처리할 표준 MVC 예외까지 가로채 **500**으로 응답하던 구조적 문제를 정리
- RESH 상속 + `handleExceptionInternal` 한 곳에서 응답을 `ApiResponse` 포맷으로 변환 → 예외마다 개별 핸들러를 나열하지 않아도 표준 예외가 일관된 형식·상태코드로 응답
- 특히 `@Validated` 경로/쿼리 파라미터 검증 실패(`ConstraintViolationException`)가 **400**으로 응답되도록 수정 (기존 500)

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `ErrorCode`에 `UNSUPPORTED_MEDIA_TYPE(415, C012)` / `NOT_ACCEPTABLE(406, C013)` 추가 (status→코드 매핑 공백 보완)
- `GlobalExceptionHandler extends ResponseEntityExceptionHandler`
- `handleExceptionInternal` override → 상태코드를 도메인 `ErrorCode`로 매핑 + 본문 `ApiResponse` 통일, 내부 상세는 로그로만 기록
- `handleMethodArgumentNotValid` override → 기존 `field: message` 커스텀 메시지 보존
- `ConstraintViolationException` 핸들러 추가 → 400 (예: `AuthController`의 `@Email @RequestParam`)
- `HttpMessageNotReadable` / `HttpRequestMethodNotSupported` / `NoHandlerFound` 개별 핸들러 제거 → RESH 경로로 흡수 (응답 동작 동일)
- `MaxUploadSizeExceededException`은 RESH가 이미 매핑하므로 개별 `@ExceptionHandler`를 두면 Ambiguous 매핑으로 컨텍스트 로딩이 실패 → `handleExceptionInternal` 타입 분기로 전용 응답(`FILE_SIZE_EXCEEDED`, 413) 보존
- `CustomException` / `Exception` fallback 유지
- 단위 테스트 갱신/추가 (상태코드 매핑, ConstraintViolation 400, MethodArgumentNotValid 메시지, 파일 용량 초과 응답 보존)

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.global.error.GlobalExceptionHandlerTest`
2. `./gradlew check`
3. 스모크
   - `@Validated` 쿼리 파라미터에 잘못된 값(예: 잘못된 이메일 형식) → **400 C001** (기존 500)
   - 잘못된 본문(비-ISO 날짜/깨진 JSON) → **400 C001**
   - 미지원 메서드 → **405 C004**, 50MB 초과 업로드 → **413 C011**

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #134

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- PR #133에서 추가한 `HttpMessageNotReadableException` 개별 핸들러는 본 작업으로 RESH에 흡수되어 제거됨 — 응답 동작(400 + 고정 메시지)은 동일
- `MaxUploadSizeExceededException` 개별 `@ExceptionHandler`는 RESH의 매핑과 충돌(Ambiguous)하여 컨텍스트 로딩을 깨뜨리므로 제거가 필수였음. `handleExceptionInternal` 타입 분기로 전용 응답을 보존해 회귀 없음
- `@PathVariable`이 전 컨트롤러 String이라 `MethodArgumentTypeMismatch`는 실발생 거의 없으나 RESH 상속으로 함께 정합 처리됨
- 내부 파싱/검증 상세(Jackson/제약 위반 원인)는 응답 본문에 노출하지 않고 `warn` 로그로만 기록

---

## 🧑‍💻 Assignee

- @imclaremont