### PR TITLE
[Fix] 메일 발송 실패가 응답을 5xx로 만드는 문제 수정 (비밀번호 재설정 500)

### DIFF
--- a/src/main/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListener.java
+++ b/src/main/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListener.java
@@ -7,10 +7,21 @@ import com.f1.quiket.infra.mail.dto.MailSendRequest;
 import com.f1.quiket.infra.mail.service.SesMailSender;
 import com.f1.quiket.infra.mail.template.MailTemplateFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+/**
+ * 인증/비밀번호 재설정/이메일 변경 메일 발송 리스너.
+ *
+ * <p>모든 메일 발송은 {@code @TransactionalEventListener(AFTER_COMMIT)}로 처리한다.
+ * AFTER_COMMIT 단계에서 던진 예외는 트랜잭션 동기화 콜백을 통해 호출자(컨트롤러)까지
+ * 전파되어 이미 정상 처리된 요청을 5xx로 만들 수 있다. 메일 발송은 요청 처리의 부가
+ * 작업이므로 실패해도 본 요청(인증 코드 발급 등)은 성공으로 응답해야 한다.
+ * 따라서 발송 예외를 여기서 격리하고 로그로만 남긴다.</p>
+ */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class EmailVerificationMailEventListener {
@@ -24,7 +35,7 @@ public class EmailVerificationMailEventListener {
                 event.email(),
                 event.verificationCode()
         );
-        sesMailSender.sendMail(mailRequest);
+        sendSafely(mailRequest, "sign-up-verification", event.email());
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
@@ -33,7 +44,7 @@ public class EmailVerificationMailEventListener {
                 event.email(),
                 event.verificationCode()
         );
-        sesMailSender.sendMail(mailRequest);
+        sendSafely(mailRequest, "password-reset", event.email());
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
@@ -42,6 +53,18 @@ public class EmailVerificationMailEventListener {
                 event.email(),
                 event.verificationCode()
         );
-        sesMailSender.sendMail(mailRequest);
+        sendSafely(mailRequest, "my-email-change", event.email());
+    }
+
+    /**
+     * 메일 발송 실패를 격리한다. 발송 실패는 본 요청 처리에 영향을 주지 않도록
+     * 예외를 전파하지 않고 로그로만 기록한다 (AFTER_COMMIT 예외의 호출자 전파 차단).
+     */
+    private void sendSafely(MailSendRequest mailRequest, String mailType, String toEmail) {
+        try {
+            sesMailSender.sendMail(mailRequest);
+        } catch (Exception e) {
+            log.error("메일 발송 실패 — 요청 처리는 계속됩니다. mailType={}, toEmail={}", mailType, toEmail, e);
+        }
     }
 }

--- a/src/test/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListenerTest.java
+++ b/src/test/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListenerTest.java
@@ -1,0 +1,81 @@
+package com.f1.quiket.infra.mail.listener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.auth.event.EmailVerificationMailRequestedEvent;
+import com.f1.quiket.domain.auth.event.PasswordResetMailRequestedEvent;
+import com.f1.quiket.domain.mypage.event.MyEmailChangeMailRequestedEvent;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
+import com.f1.quiket.infra.mail.dto.MailSendRequest;
+import com.f1.quiket.infra.mail.service.SesMailSender;
+import com.f1.quiket.infra.mail.template.MailTemplateFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EmailVerificationMailEventListenerTest {
+
+    private MailTemplateFactory mailTemplateFactory;
+    private SesMailSender sesMailSender;
+    private EmailVerificationMailEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        mailTemplateFactory = mock(MailTemplateFactory.class);
+        sesMailSender = mock(SesMailSender.class);
+        listener = new EmailVerificationMailEventListener(mailTemplateFactory, sesMailSender);
+    }
+
+    @Test
+    void sendPasswordResetMail_does_not_propagate_when_send_fails() {
+        // 메일 발송 실패가 AFTER_COMMIT을 통해 호출자(컨트롤러)로 전파되면 정상 요청이 5xx가 된다.
+        // 리스너는 발송 예외를 격리하고 전파하지 않아야 한다.
+        when(mailTemplateFactory.createPasswordResetMail(any(), any())).thenReturn(mock(MailSendRequest.class));
+        doThrow(new CustomException(ErrorCode.MAIL_SEND_FAILED)).when(sesMailSender).sendMail(any());
+
+        assertThatCode(() -> listener.sendPasswordResetMail(
+                new PasswordResetMailRequestedEvent("user@example.com", "123456")
+        )).doesNotThrowAnyException();
+
+        verify(sesMailSender).sendMail(any());
+    }
+
+    @Test
+    void sendEmailVerificationMail_does_not_propagate_when_send_fails() {
+        when(mailTemplateFactory.createSignUpVerificationMail(any(), any())).thenReturn(mock(MailSendRequest.class));
+        doThrow(new CustomException(ErrorCode.MAIL_SEND_FAILED)).when(sesMailSender).sendMail(any());
+
+        assertThatCode(() -> listener.sendEmailVerificationMail(
+                new EmailVerificationMailRequestedEvent("user@example.com", "123456")
+        )).doesNotThrowAnyException();
+
+        verify(sesMailSender).sendMail(any());
+    }
+
+    @Test
+    void sendMyEmailChangeMail_does_not_propagate_when_send_fails() {
+        when(mailTemplateFactory.createEmailChangeMail(any(), any())).thenReturn(mock(MailSendRequest.class));
+        doThrow(new RuntimeException("ses down")).when(sesMailSender).sendMail(any());
+
+        assertThatCode(() -> listener.sendMyEmailChangeMail(
+                new MyEmailChangeMailRequestedEvent("user@example.com", "123456")
+        )).doesNotThrowAnyException();
+
+        verify(sesMailSender).sendMail(any());
+    }
+
+    @Test
+    void sendPasswordResetMail_sends_mail_on_success() {
+        MailSendRequest request = mock(MailSendRequest.class);
+        when(mailTemplateFactory.createPasswordResetMail(any(), any())).thenReturn(request);
+
+        listener.sendPasswordResetMail(new PasswordResetMailRequestedEvent("user@example.com", "123456"));
+
+        verify(sesMailSender).sendMail(request);
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 운영에서 `POST /api/v1/auth/password-reset/requests`가 가입 이메일로 요청 시 **500(C002)** 으로 응답되던 문제 수정
- 근본 원인은 **메일 발송 실패가 API 응답을 5xx로 전파**하는 구조 — 비밀번호 재설정뿐 아니라 모든 메일 발송에 잠재된 결함

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `EmailVerificationMailEventListener`의 세 리스너(회원가입 인증 / 비밀번호 재설정 / 이메일 변경)에서 메일 발송 예외를 **격리**하고 로그로만 기록 → 본 요청은 정상(2xx) 응답
- 메일 발송 실패 시 리스너가 예외를 전파하지 않음을 검증하는 단위 테스트 추가

---

## 🔍 원인 분석
<!-- 리뷰어 이해를 돕기 위한 분석 (Description의 일부) -->

- 메일 발송은 `@TransactionalEventListener(AFTER_COMMIT)`로 처리됨
- AFTER_COMMIT 단계에서 던진 예외는 트랜잭션 동기화 콜백을 통해 **호출자(컨트롤러)까지 전파**됨
- `SesMailSender.sendMail`은 발송 실패 시 `CustomException(MAIL_SEND_FAILED)`을 던지는데, AFTER_COMMIT 전파 과정에서 래핑되어 `CustomException` 핸들러가 아닌 **fallback `Exception` 핸들러로 빠져 500(C002)** 응답 → 운영 증상과 정확히 일치
- 토큰 발급 등 본 요청은 정상 처리됐음에도 메일 실패만으로 5xx가 반환되어 **비밀번호 재설정 자체가 불가능**했음

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.infra.mail.listener.EmailVerificationMailEventListenerTest`
2. `./gradlew check`
3. 운영/스테이징 스모크: 가입 이메일로 `POST /auth/password-reset/requests` → **200**(요청 접수). 메일 발송이 실패해도 응답은 정상

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #138

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 본 PR은 "메일 발송 실패가 응답을 5xx로 만드는 구조"를 수정함. **SES 발송이 실제로 왜 실패하는지(샌드박스 모드/발신·수신 주소 미검증/권한 등)는 운영 로그로 별도 점검 필요** — 다만 그 원인과 무관하게 메일 실패가 API를 깨뜨리면 안 되므로 우선 수정
- 동일 패턴인 `POST /my/email/change-requests`가 운영에서 200이었던 것은 해당 시점 메일 발송 성공 여부 차이로 추정되며, 본 수정으로 세 경로 모두 메일 실패에 견고해짐
- 메일 재발송/모니터링(실패 메일 추적)은 후속 개선 여지

---

## 🧑‍💻 Assignee

- @imclaremont