### PR TITLE
[Fix] 퀴즈 결과 문제별 해설 조회 API 구현 (review 404 해소)

### DIFF
--- a/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/controller/QuizResultController.java
@@ -5,6 +5,7 @@ import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitOutcome;
 import com.f1.quiket.domain.quiz.dto.QuizResultSubmitRequest;
 import com.f1.quiket.domain.quiz.dto.QuizRetryRequest;
+import com.f1.quiket.domain.quiz.dto.QuizReviewResponse;
 import com.f1.quiket.domain.quiz.service.QuizResultQueryService;
 import com.f1.quiket.domain.quiz.service.QuizResultRetryAllService;
 import com.f1.quiket.domain.quiz.service.QuizResultRetryWrongService;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -61,6 +63,23 @@ public class QuizResultController {
             @PathVariable("resultId") String resultPublicId
     ) {
         QuizResultResponse response = quizResultQueryService.getQuizResult(principal.getUserId(), resultPublicId);
+        return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
+    }
+
+    /**
+     * 문제별 해설 조회 (RESULT-002, filter: all/correct/wrong)
+     */
+    @GetMapping("/{resultId}/review")
+    public ResponseEntity<ApiResponse<QuizReviewResponse>> getQuizResultReview(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("resultId") String resultPublicId,
+            @RequestParam(value = "filter", required = false, defaultValue = "all") String filter
+    ) {
+        QuizReviewResponse response = quizResultQueryService.getQuizReview(
+                principal.getUserId(),
+                resultPublicId,
+                filter
+        );
         return ResponseEntity.ok(ApiResponse.success(SuccessCode.OK, response));
     }
 

--- a/src/main/java/com/f1/quiket/domain/quiz/dto/QuizReviewResponse.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/dto/QuizReviewResponse.java
@@ -1,0 +1,23 @@
+package com.f1.quiket.domain.quiz.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 문제별 해설(리뷰) 조회 응답 — RESULT-002 해설보기.
+ */
+@Getter
+@Builder
+public class QuizReviewResponse {
+
+    private final String playSessionId;
+    private final List<QuizReviewItemResponse> items;
+
+    public static QuizReviewResponse of(String playSessionId, List<QuizReviewItemResponse> items) {
+        return QuizReviewResponse.builder()
+                .playSessionId(playSessionId)
+                .items(items)
+                .build();
+    }
+}

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultQueryService.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizResultQueryService.java
@@ -1,6 +1,8 @@
 package com.f1.quiket.domain.quiz.service;
 
 import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.dto.QuizReviewItemResponse;
+import com.f1.quiket.domain.quiz.dto.QuizReviewResponse;
 import com.f1.quiket.domain.quiz.entity.Question;
 import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
 import com.f1.quiket.domain.quiz.entity.QuestionOption;
@@ -75,6 +77,31 @@ public class QuizResultQueryService {
                 answersByQuestionId,
                 playAnswers
         );
+    }
+
+    /**
+     * 문제별 해설(리뷰) 조회 — RESULT-002. filter(all/correct/wrong)로 문항을 거른다.
+     * 결과 상세 조립을 재사용하고 해설 화면에 필요한 항목만 추려 응답한다.
+     */
+    public QuizReviewResponse getQuizReview(Long userId, String resultPublicId, String filter) {
+        QuizResultResponse result = getQuizResult(userId, resultPublicId);
+        List<QuizReviewItemResponse> items = filterReviewItems(result.getReviewItems(), filter);
+        return QuizReviewResponse.of(result.getPlaySessionId(), items);
+    }
+
+    private List<QuizReviewItemResponse> filterReviewItems(List<QuizReviewItemResponse> items, String filter) {
+        String normalized = (filter == null || filter.isBlank()) ? "all" : filter.toLowerCase();
+        return switch (normalized) {
+            case "all" -> items;
+            case "correct" -> items.stream()
+                    .filter(item -> Boolean.TRUE.equals(item.getCorrectServer()))
+                    .toList();
+            // 틀린 문제 = 오답 + 미선택(skip). 서버 채점이 정답이 아닌 모든 문항.
+            case "wrong" -> items.stream()
+                    .filter(item -> !Boolean.TRUE.equals(item.getCorrectServer()))
+                    .toList();
+            default -> throw new CustomException(ErrorCode.QUIZ_OPTION_INVALID, "지원하지 않는 해설 필터입니다.");
+        };
     }
 
     private User findUser(Long userId) {

--- a/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultQueryServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/quiz/service/QuizResultQueryServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.f1.quiket.domain.quiz.dto.QuizResultResponse;
+import com.f1.quiket.domain.quiz.dto.QuizReviewResponse;
 import com.f1.quiket.domain.quiz.entity.Question;
 import com.f1.quiket.domain.quiz.entity.QuestionAnswer;
 import com.f1.quiket.domain.quiz.entity.QuestionOption;
@@ -117,6 +118,50 @@ class QuizResultQueryServiceTest {
         assertThat(response.getReviewItems().get(0).getSelectedOptionId()).isEqualTo(String.valueOf(correctOption.getId()));
         assertThat(response.getReviewItems().get(0).getAnswerValue()).isEqualTo("1");
         assertThat(response.getReviewItems().get(0).getCorrectServer()).isTrue();
+    }
+
+    @Test
+    void getQuizReview_filters_items_and_validates_filter() {
+        Long userId = 1L;
+        User user = user(userId, 20, 400, 3);
+        Subject subject = subject(10L, "subject-public-id", userId, "데이터베이스");
+        QuizSession quizSession = quizSession(500L, "quiz-session-public-id", userId, subject.getId());
+        QuizPlaySession playSession = playSession(700L, "client-session-id", quizSession.getId(), userId, subject.getId());
+        Question question = question(900L, "question-public-id", quizSession.getId(), userId, subject.getId(), 1);
+        QuestionOption correctOption = option(1000L, question.getId(), 1, "정답", true);
+        QuestionOption wrongOption = option(1001L, question.getId(), 2, "오답", false);
+        QuestionAnswer answer = answer(2000L, question.getId(), "1");
+        // 정답 1문항만 푼 결과
+        QuizPlayAnswer playAnswer = playAnswer(playSession.getId(), question.getId(), userId, correctOption.getId(), true, false);
+        QuizResult result = result(3000L, "result-public-id", playSession, quizSession, subject, 1, 1, 0, 0, 100);
+
+        when(userRepository.findByIdAndDeletedAtIsNull(userId)).thenReturn(Optional.of(user));
+        when(quizResultRepository.findByPublicIdAndUserId(result.getPublicId(), userId)).thenReturn(Optional.of(result));
+        when(quizPlaySessionRepository.findByIdAndUserId(playSession.getId(), userId)).thenReturn(Optional.of(playSession));
+        when(quizSessionRepository.findByIdAndUserIdAndDeletedAtIsNull(quizSession.getId(), userId)).thenReturn(Optional.of(quizSession));
+        when(subjectRepository.findByIdAndUserIdAndDeletedAtIsNull(subject.getId(), userId)).thenReturn(Optional.of(subject));
+        when(questionRepository.findAllByQuizSessionIdAndUserIdOrderByDisplayOrderAscIdAsc(quizSession.getId(), userId)).thenReturn(List.of(question));
+        when(questionOptionRepository.findAllByQuestionIdInOrderByQuestionIdAscOptionNumberAsc(List.of(question.getId()))).thenReturn(List.of(correctOption, wrongOption));
+        when(questionAnswerRepository.findAllByQuestionIdIn(List.of(question.getId()))).thenReturn(List.of(answer));
+        when(quizPlayAnswerRepository.findAllByPlaySessionId(playSession.getId())).thenReturn(List.of(playAnswer));
+
+        // all: 전체 1문항
+        QuizReviewResponse all = quizResultQueryService.getQuizReview(userId, result.getPublicId(), "all");
+        assertThat(all.getPlaySessionId()).isEqualTo(playSession.getClientSessionId());
+        assertThat(all.getItems()).hasSize(1);
+
+        // correct: 정답 1문항
+        assertThat(quizResultQueryService.getQuizReview(userId, result.getPublicId(), "correct").getItems()).hasSize(1);
+        // wrong: 오답 0문항
+        assertThat(quizResultQueryService.getQuizReview(userId, result.getPublicId(), "wrong").getItems()).isEmpty();
+        // null/blank filter → all 취급
+        assertThat(quizResultQueryService.getQuizReview(userId, result.getPublicId(), null).getItems()).hasSize(1);
+
+        // 잘못된 filter → 400
+        assertThatThrownBy(() -> quizResultQueryService.getQuizReview(userId, result.getPublicId(), "unknown"))
+                .isInstanceOf(CustomException.class)
+                .extracting(exception -> ((CustomException) exception).getErrorCode())
+                .isEqualTo(ErrorCode.QUIZ_OPTION_INVALID);
     }
 
     @Test


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- OpenAPI 명세(RESULT-002)에 정의되어 있으나 컨트롤러에 미구현이라 **404**가 반환되던 `GET /api/v1/quiz-results/{resultId}/review`를 구현
- 단순 중복 엔드포인트가 아니라 **해설 화면 전용 필터(맞은/틀린 문제만 보기)** 를 제공하므로 명세대로 구현

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `GET /quiz-results/{resultId}/review?filter=all|correct|wrong` 추가
- `QuizResultQueryService.getQuizReview` — 결과 상세 조립(`getQuizResult`)을 재사용하고 `reviewItems`를 filter로 추려 `QuizReviewResponse({playSessionId, items})`로 응답
  - `all`: 전체 / `correct`: 서버 채점 정답 / `wrong`: 오답+미선택
  - 잘못된 filter 값은 400(`QUIZ_OPTION_INVALID`)
- `QuizReviewResponse` DTO 신규 (기존 `QuizReviewItemResponse` 재사용)
- 단위 테스트 추가 (filter 동작 + 잘못된 filter)

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.domain.quiz.service.QuizResultQueryServiceTest`
2. `./gradlew check`
3. 스모크: `GET /api/v1/quiz-results/{resultId}/review` → 200(전체), `?filter=wrong` → 오답만, `?filter=correct` → 정답만

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #139

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 리뷰 데이터 자체는 결과 상세(`GET /quiz-results/{id}`)의 `reviewItems`에도 포함되나, 본 엔드포인트는 명세상 filter 기능을 제공하므로 별도 구현이 맞음 (명세 제거가 아닌 구현 방향 선택)
- OpenAPI 명세는 이미 해당 엔드포인트를 정의하고 있어 문서 변경 없음 (구현을 명세에 맞춤)
- `filter`가 String 파라미터라 `@Validated` enum 제약 대신 서비스에서 검증 — 잘못된 값은 400으로 일관 응답

---

## 🧑‍💻 Assignee

- @imclaremont