### PR TITLE
[Chore] 운영 로그 영속화 — 로그 디렉토리 호스트 볼륨 마운트

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -8,7 +8,7 @@ services:
     env_file:
       - .env
     volumes:
-      # 로그 영속화: 컨테이너 내부 로그 디렉토리를 호스트에 bind mount.
-      # 재배포(컨테이너 재생성) 후에도 호스트 ./logs 에서 이전 로그를 조회할 수 있다.
-      # (logback prod 프로파일의 LOG_DIR=/var/log/quicket 와 일치)
+      # 로그 영속화 - 컨테이너 내부 로그 디렉토리 호스트 bind mount
+      # 재배포 후에도 호스트 ./logs 에서 이전 로그 조회 가능
+      # logback prod LOG_DIR(/var/log/quicket)과 동일 경로
       - ./logs:/var/log/quicket

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -7,3 +7,8 @@ services:
       - "8080:8080"
     env_file:
       - .env
+    volumes:
+      # 로그 영속화: 컨테이너 내부 로그 디렉토리를 호스트에 bind mount.
+      # 재배포(컨테이너 재생성) 후에도 호스트 ./logs 에서 이전 로그를 조회할 수 있다.
+      # (logback prod 프로파일의 LOG_DIR=/var/log/quicket 와 일치)
+      - ./logs:/var/log/quicket


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- prod 로그가 컨테이너 내부 `/var/log/quicket/`에만 쌓이고 볼륨 마운트가 없어, 재배포(`docker compose up -d`로 컨테이너 재생성) 시 이전 로그가 유실되던 문제 해소
- 로그 디렉토리를 EC2 호스트에 bind mount하여 재배포와 무관하게 로그를 영속

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `docker-compose-prod.yml`에 bind mount 추가
  ```yaml
  volumes:
    - ./logs:/var/log/quicket
  ```
- 컨테이너 내부 로그 디렉토리(logback prod `LOG_DIR=/var/log/quicket`)를 호스트 `<DEPLOY_PATH>/logs`에 영속화

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. 머지/배포 후 EC2 호스트에서 `<DEPLOY_PATH>/logs/application.log` 생성 확인
   ```bash
   tail -n 200 <DEPLOY_PATH>/logs/application.log
   ```
2. 재배포 1회 후 이전 로그 파일이 유지되는지 확인
3. 일별 롤링 디렉토리 `logs/yyyy-MM/application.yyyy-MM-dd.log` 생성 확인

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #146

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 컨테이너가 root로 실행(Dockerfile에 `USER` 미지정)되어 bind mount 호스트 디렉토리 쓰기 권한 문제 없음. 호스트 `./logs`는 docker가 자동 생성
- 상대 경로 `./logs`는 compose 실행 위치(`EC2_DEPLOY_PATH`) 기준 → `<DEPLOY_PATH>/logs/`
- logback `maxHistory=90`이라 90일치 롤링 로그가 호스트에 누적됨 → **디스크 사용량 모니터링 권장**(프리티어 EBS). 필요 시 후속으로 `totalSizeCap` 추가
- `docker logs` 가시화(prod CONSOLE appender 추가) + json-file 로테이션은 별도 후속 이슈로 분리
- 본 변경은 `docker-compose-prod.yml`만 수정 — 애플리케이션 코드/스키마 영향 없음

---

## 🧑‍💻 Assignee

- @imclaremont