### PR TITLE
[Chore] 운영 로그 총량 상한(totalSizeCap) 추가

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -19,9 +19,9 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>${LOG_DIR}/%d{yyyy-MM}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>90</maxHistory>
-            <!-- 로그 아카이브 총량 상한. 90일(maxHistory)과 함께 동작하며, 둘 중 먼저
-                 충족되는 조건으로 오래된 아카이브부터 삭제하여 디스크 폭주를 방지한다.
-                 프리티어 EBS 30GB 기준 약 10% (로그 폭주 방어 + 보관 여유). -->
+            <!-- 로그 아카이브 총량 상한 - maxHistory(90일)와 둘 중 먼저 충족되는 조건으로
+                 오래된 아카이브부터 삭제, 디스크 폭주 방어
+                 프리티어 EBS 30GB 기준 약 10% -->
             <totalSizeCap>3GB</totalSizeCap>
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -20,8 +20,9 @@
             <fileNamePattern>${LOG_DIR}/%d{yyyy-MM}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>90</maxHistory>
             <!-- 로그 아카이브 총량 상한. 90일(maxHistory)과 함께 동작하며, 둘 중 먼저
-                 충족되는 조건으로 오래된 아카이브부터 삭제하여 디스크 폭주를 방지한다. -->
-            <totalSizeCap>2GB</totalSizeCap>
+                 충족되는 조건으로 오래된 아카이브부터 삭제하여 디스크 폭주를 방지한다.
+                 프리티어 EBS 30GB 기준 약 10% (로그 폭주 방어 + 보관 여유). -->
+            <totalSizeCap>3GB</totalSizeCap>
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
     </appender>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -19,6 +19,9 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>${LOG_DIR}/%d{yyyy-MM}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>90</maxHistory>
+            <!-- 로그 아카이브 총량 상한. 90일(maxHistory)과 함께 동작하며, 둘 중 먼저
+                 충족되는 조건으로 오래된 아카이브부터 삭제하여 디스크 폭주를 방지한다. -->
+            <totalSizeCap>2GB</totalSizeCap>
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
     </appender>


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- prod 로그(`logback-spring.xml`)가 `maxHistory=90`(시간 기준)만 있고 **용량 기준 상한이 없어**, 트래픽 급증/에러 로그 폭주 시 디스크가 가득 찰 수 있던 위험을 방어
- 로그 아카이브 총량 상한(`totalSizeCap`)을 추가하여 디스크 폭주 방지

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `logback-spring.xml`의 prod `ROLLING_FILE` → `TimeBasedRollingPolicy`에 `<totalSizeCap>3GB</totalSizeCap>` 추가
- `maxHistory`(90일)와 함께 동작 — 둘 중 먼저 충족되는 조건으로 오래된 아카이브부터 삭제

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test` (logback XML 파싱/컨텍스트 로딩 정상 — 통과 확인)
2. 배포 후 로그 아카이브 누적이 3GB 상한 내에서 관리되는지 모니터링
   ```bash
   du -sh <DEPLOY_PATH>/logs
   ```

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #148

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- **값 산정 근거**: 프리티어 EBS는 30GB(gp3). `totalSizeCap`은 디스크 용량이 아니라 **로그 아카이브가 차지할 최대 공간** 상한이며, 디스크 30GB의 약 10%인 **3GB**로 설정 (로그 폭주 방어 + 보관 여유 확보)
- `TimeBasedRollingPolicy`도 `totalSizeCap`을 지원하므로 **정책 클래스 변경 불필요**(`SizeAndTimeBasedRollingPolicy` 전환 없이 한 줄 추가)
- 개별 파일 크기 상한(`maxFileSize`)은 본 PR 범위 아님 (일별 롤링 유지)
- 로그 호스트 영속화(#146/PR #147)와 함께 적용되면, 호스트 `logs/` 디렉토리 총량도 이 상한으로 관리됨
- `logback-spring.xml`만 변경 — 애플리케이션 코드/스키마 영향 없음

---

## 🧑‍💻 Assignee

- @imclaremont