### PR TITLE
[Chore] 토큰 만료 정리 스케줄러 로깅 추가

### DIFF
--- a/src/main/java/com/f1/quiket/support/auth/EmailVerificationCleanupScheduler.java
+++ b/src/main/java/com/f1/quiket/support/auth/EmailVerificationCleanupScheduler.java
@@ -2,9 +2,17 @@ package com.f1.quiket.support.auth;
 
 import com.f1.quiket.domain.auth.service.LocalAuthService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+/**
+ * 만료(expires_at 경과)된 pending 이메일 인증 토큰을 expired 상태로 정리하는 스케줄러.
+ *
+ * <p>정리 건수가 있을 때만 INFO로 기록하고(0건은 미기록 — 노이즈 방지), 정리 실패는
+ * ERROR로 노출하면서 예외를 격리해 다음 주기 실행이 멈추지 않도록 한다.</p>
+ */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class EmailVerificationCleanupScheduler {
@@ -13,6 +21,13 @@ public class EmailVerificationCleanupScheduler {
 
     @Scheduled(fixedDelayString = "${quiket.auth.email-verification-cleanup-fixed-delay-ms:600000}")
     public void expirePendingEmailVerifications() {
-        localAuthService.expirePendingEmailVerifications();
+        try {
+            int expired = localAuthService.expirePendingEmailVerifications();
+            if (expired > 0) {
+                log.info("만료된 이메일 인증 {}건을 정리했습니다.", expired);
+            }
+        } catch (Exception e) {
+            log.error("이메일 인증 만료 정리에 실패했습니다.", e);
+        }
     }
 }

--- a/src/main/java/com/f1/quiket/support/auth/EmailVerificationCleanupScheduler.java
+++ b/src/main/java/com/f1/quiket/support/auth/EmailVerificationCleanupScheduler.java
@@ -7,10 +7,10 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * 만료(expires_at 경과)된 pending 이메일 인증 토큰을 expired 상태로 정리하는 스케줄러.
+ * 만료(expires_at 경과)된 pending 이메일 인증 토큰의 expired 상태 정리 스케줄러
  *
- * <p>정리 건수가 있을 때만 INFO로 기록하고(0건은 미기록 — 노이즈 방지), 정리 실패는
- * ERROR로 노출하면서 예외를 격리해 다음 주기 실행이 멈추지 않도록 한다.</p>
+ * <p>정리 건수 0 초과 시에만 INFO 기록(노이즈 방지), 실패 시 ERROR 노출 + 예외 격리로
+ * 다음 주기 실행 보장</p>
  */
 @Slf4j
 @Component

--- a/src/main/java/com/f1/quiket/support/auth/EmailVerificationCleanupScheduler.java
+++ b/src/main/java/com/f1/quiket/support/auth/EmailVerificationCleanupScheduler.java
@@ -24,10 +24,10 @@ public class EmailVerificationCleanupScheduler {
         try {
             int expired = localAuthService.expirePendingEmailVerifications();
             if (expired > 0) {
-                log.info("만료된 이메일 인증 {}건을 정리했습니다.", expired);
+                log.info("Expired email verifications cleaned up: count={}", expired);
             }
         } catch (Exception e) {
-            log.error("이메일 인증 만료 정리에 실패했습니다.", e);
+            log.error("Failed to clean up expired email verifications", e);
         }
     }
 }

--- a/src/main/java/com/f1/quiket/support/auth/PasswordResetTokenCleanupScheduler.java
+++ b/src/main/java/com/f1/quiket/support/auth/PasswordResetTokenCleanupScheduler.java
@@ -7,10 +7,10 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * 만료(expires_at 경과)된 pending 비밀번호 재설정 토큰을 expired 상태로 정리하는 스케줄러.
+ * 만료(expires_at 경과)된 pending 비밀번호 재설정 토큰의 expired 상태 정리 스케줄러
  *
- * <p>정리 건수가 있을 때만 INFO로 기록하고(0건은 미기록 — 노이즈 방지), 정리 실패는
- * ERROR로 노출하면서 예외를 격리해 다음 주기 실행이 멈추지 않도록 한다.</p>
+ * <p>정리 건수 0 초과 시에만 INFO 기록(노이즈 방지), 실패 시 ERROR 노출 + 예외 격리로
+ * 다음 주기 실행 보장</p>
  */
 @Slf4j
 @Component

--- a/src/main/java/com/f1/quiket/support/auth/PasswordResetTokenCleanupScheduler.java
+++ b/src/main/java/com/f1/quiket/support/auth/PasswordResetTokenCleanupScheduler.java
@@ -2,9 +2,17 @@ package com.f1.quiket.support.auth;
 
 import com.f1.quiket.domain.auth.service.PasswordResetService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+/**
+ * 만료(expires_at 경과)된 pending 비밀번호 재설정 토큰을 expired 상태로 정리하는 스케줄러.
+ *
+ * <p>정리 건수가 있을 때만 INFO로 기록하고(0건은 미기록 — 노이즈 방지), 정리 실패는
+ * ERROR로 노출하면서 예외를 격리해 다음 주기 실행이 멈추지 않도록 한다.</p>
+ */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PasswordResetTokenCleanupScheduler {
@@ -13,6 +21,13 @@ public class PasswordResetTokenCleanupScheduler {
 
     @Scheduled(fixedDelayString = "${quiket.auth.password-reset-cleanup-fixed-delay-ms:600000}")
     public void expirePendingPasswordResetTokens() {
-        passwordResetService.expirePendingPasswordResetTokens();
+        try {
+            int expired = passwordResetService.expirePendingPasswordResetTokens();
+            if (expired > 0) {
+                log.info("만료된 비밀번호 재설정 토큰 {}건을 정리했습니다.", expired);
+            }
+        } catch (Exception e) {
+            log.error("비밀번호 재설정 토큰 만료 정리에 실패했습니다.", e);
+        }
     }
 }

--- a/src/main/java/com/f1/quiket/support/auth/PasswordResetTokenCleanupScheduler.java
+++ b/src/main/java/com/f1/quiket/support/auth/PasswordResetTokenCleanupScheduler.java
@@ -24,10 +24,10 @@ public class PasswordResetTokenCleanupScheduler {
         try {
             int expired = passwordResetService.expirePendingPasswordResetTokens();
             if (expired > 0) {
-                log.info("만료된 비밀번호 재설정 토큰 {}건을 정리했습니다.", expired);
+                log.info("Expired password reset tokens cleaned up: count={}", expired);
             }
         } catch (Exception e) {
-            log.error("비밀번호 재설정 토큰 만료 정리에 실패했습니다.", e);
+            log.error("Failed to clean up expired password reset tokens", e);
         }
     }
 }

--- a/src/test/java/com/f1/quiket/support/auth/EmailVerificationCleanupSchedulerTest.java
+++ b/src/test/java/com/f1/quiket/support/auth/EmailVerificationCleanupSchedulerTest.java
@@ -1,0 +1,48 @@
+package com.f1.quiket.support.auth;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.auth.service.LocalAuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EmailVerificationCleanupSchedulerTest {
+
+    private LocalAuthService localAuthService;
+    private EmailVerificationCleanupScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        localAuthService = mock(LocalAuthService.class);
+        scheduler = new EmailVerificationCleanupScheduler(localAuthService);
+    }
+
+    @Test
+    void expirePendingEmailVerifications_delegates_to_service() {
+        when(localAuthService.expirePendingEmailVerifications()).thenReturn(3);
+
+        scheduler.expirePendingEmailVerifications();
+
+        verify(localAuthService).expirePendingEmailVerifications();
+    }
+
+    @Test
+    void expirePendingEmailVerifications_runs_when_nothing_to_clean() {
+        when(localAuthService.expirePendingEmailVerifications()).thenReturn(0);
+
+        assertThatCode(() -> scheduler.expirePendingEmailVerifications()).doesNotThrowAnyException();
+        verify(localAuthService).expirePendingEmailVerifications();
+    }
+
+    @Test
+    void expirePendingEmailVerifications_isolates_exception() {
+        // 정리 실패가 스케줄러를 멈추지 않도록 예외를 격리한다(ERROR 로그만).
+        when(localAuthService.expirePendingEmailVerifications()).thenThrow(new RuntimeException("db down"));
+
+        assertThatCode(() -> scheduler.expirePendingEmailVerifications()).doesNotThrowAnyException();
+        verify(localAuthService).expirePendingEmailVerifications();
+    }
+}

--- a/src/test/java/com/f1/quiket/support/auth/EmailVerificationCleanupSchedulerTest.java
+++ b/src/test/java/com/f1/quiket/support/auth/EmailVerificationCleanupSchedulerTest.java
@@ -39,7 +39,7 @@ class EmailVerificationCleanupSchedulerTest {
 
     @Test
     void expirePendingEmailVerifications_isolates_exception() {
-        // 정리 실패가 스케줄러를 멈추지 않도록 예외를 격리한다(ERROR 로그만).
+        // 정리 실패 시 예외 격리로 스케줄러 중단 방지(ERROR 로그만)
         when(localAuthService.expirePendingEmailVerifications()).thenThrow(new RuntimeException("db down"));
 
         assertThatCode(() -> scheduler.expirePendingEmailVerifications()).doesNotThrowAnyException();

--- a/src/test/java/com/f1/quiket/support/auth/PasswordResetTokenCleanupSchedulerTest.java
+++ b/src/test/java/com/f1/quiket/support/auth/PasswordResetTokenCleanupSchedulerTest.java
@@ -1,0 +1,48 @@
+package com.f1.quiket.support.auth;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.f1.quiket.domain.auth.service.PasswordResetService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PasswordResetTokenCleanupSchedulerTest {
+
+    private PasswordResetService passwordResetService;
+    private PasswordResetTokenCleanupScheduler scheduler;
+
+    @BeforeEach
+    void setUp() {
+        passwordResetService = mock(PasswordResetService.class);
+        scheduler = new PasswordResetTokenCleanupScheduler(passwordResetService);
+    }
+
+    @Test
+    void expirePendingPasswordResetTokens_delegates_to_service() {
+        when(passwordResetService.expirePendingPasswordResetTokens()).thenReturn(2);
+
+        scheduler.expirePendingPasswordResetTokens();
+
+        verify(passwordResetService).expirePendingPasswordResetTokens();
+    }
+
+    @Test
+    void expirePendingPasswordResetTokens_runs_when_nothing_to_clean() {
+        when(passwordResetService.expirePendingPasswordResetTokens()).thenReturn(0);
+
+        assertThatCode(() -> scheduler.expirePendingPasswordResetTokens()).doesNotThrowAnyException();
+        verify(passwordResetService).expirePendingPasswordResetTokens();
+    }
+
+    @Test
+    void expirePendingPasswordResetTokens_isolates_exception() {
+        // 정리 실패가 스케줄러를 멈추지 않도록 예외를 격리한다(ERROR 로그만).
+        when(passwordResetService.expirePendingPasswordResetTokens()).thenThrow(new RuntimeException("db down"));
+
+        assertThatCode(() -> scheduler.expirePendingPasswordResetTokens()).doesNotThrowAnyException();
+        verify(passwordResetService).expirePendingPasswordResetTokens();
+    }
+}

--- a/src/test/java/com/f1/quiket/support/auth/PasswordResetTokenCleanupSchedulerTest.java
+++ b/src/test/java/com/f1/quiket/support/auth/PasswordResetTokenCleanupSchedulerTest.java
@@ -39,7 +39,7 @@ class PasswordResetTokenCleanupSchedulerTest {
 
     @Test
     void expirePendingPasswordResetTokens_isolates_exception() {
-        // 정리 실패가 스케줄러를 멈추지 않도록 예외를 격리한다(ERROR 로그만).
+        // 정리 실패 시 예외 격리로 스케줄러 중단 방지(ERROR 로그만)
         when(passwordResetService.expirePendingPasswordResetTokens()).thenThrow(new RuntimeException("db down"));
 
         assertThatCode(() -> scheduler.expirePendingPasswordResetTokens()).doesNotThrowAnyException();


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 이메일 인증 / 비밀번호 재설정 토큰 만료 정리 스케줄러가 **로그 없이** 동작해, 정리 수행 여부·건수·실패를 운영에서 알 수 없던 문제 개선
- 두 스케줄러는 10분 주기로 만료(`expires_at` 경과)된 `pending` 토큰을 `expired`로 정리하는 데이터 위생 작업 — 정리 건수(`int`)를 반환하나 기존엔 버려짐

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `EmailVerificationCleanupScheduler` / `PasswordResetTokenCleanupScheduler`에 `@Slf4j` 추가
- **정리 건수 > 0일 때만 `INFO`** 로그 (0건은 미기록 — 10분 주기 노이즈/볼륨 방지)
- 정리 중 예외 발생 시 **`ERROR` 로그로 노출 + 예외 격리** → 한 번의 실패가 스케줄러를 멈추지 않도록 (기존엔 실패가 조용히 삼켜짐)
- 두 스케줄러 단위 테스트 추가 (서비스 위임 / 0건 정상 / 예외 격리)

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests "com.f1.quiket.support.auth.*CleanupSchedulerTest"`
2. `./gradlew check`
3. (운영) 만료 토큰이 정리되는 시점에 `만료된 ... N건을 정리했습니다.` INFO 로그 확인, DB 오류 주입 시 ERROR 로그 확인

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #150

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 10분 주기(하루 144회)라 "0건까지 매번 INFO"는 노이즈 → **건수 > 0일 때만** 기록하여 로그 볼륨 영향 미미 (앞서 추가한 `totalSizeCap`에 사실상 무영향)
- 가시성 개선 작업이며 인증·재설정 **동작 자체는 변경 없음** (만료 토큰 거부는 confirm 시점 `isExpired()` 검증이 1차 방어)
- 예외 격리는 정리 1회 실패가 스케줄러를 멈추지 않게 하기 위함 (다음 주기 정상 재시도)

---

## 🧑‍💻 Assignee

- @imclaremont