### PR TITLE
[Feat] lecture-uploads chapterName 선택 입력 및 AI 자동 생성 구현 (#155)

### DIFF
--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Quiket MVP API
-  version: 1.0.1
+  version: 1.0.2
   description: |
     Quiket MVP API 명세
 
@@ -1103,13 +1103,22 @@ paths:
               $ref: '#/components/schemas/LectureTextUploadRequest'
             examples:
               textAuto:
+                summary: 챕터명 직접 입력
                 value:
                   subjectId: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
                   chapterName: 1장 데이터 모델링
                   uploadType: text
                   partSplitMethod: auto
                   text: 데이터 모델링은 현실 세계의 데이터를 추상화하여 구조화하는 과정입니다...
+              textAutoWithoutChapterName:
+                summary: 챕터명 미입력 (AI 자동 생성)
+                value:
+                  subjectId: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
+                  uploadType: text
+                  partSplitMethod: auto
+                  text: 데이터 모델링은 현실 세계의 데이터를 추상화하여 구조화하는 과정입니다...
               textManual:
+                summary: 챕터명 직접 입력 + 수동 분할
                 value:
                   subjectId: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
                   chapterName: 1장 데이터 모델링
@@ -3281,7 +3290,6 @@ components:
       type: object
       required:
         - subjectId
-        - chapterName
         - uploadType
         - partSplitMethod
         - text
@@ -3292,8 +3300,10 @@ components:
           example: 018f8c2e-5f73-7b6a-b9f0-3f55e7f7c901
         chapterName:
           type: string
+          nullable: true
           minLength: 1
           maxLength: 30
+          description: 챕터명 (선택). 미입력 시 AI가 업로드 내용을 분석하여 자동 생성
           example: 1장 데이터 모델링
         uploadType:
           type: string
@@ -3317,7 +3327,6 @@ components:
       type: object
       required:
         - subjectId
-        - chapterName
         - uploadType
         - partSplitMethod
         - files
@@ -3327,8 +3336,10 @@ components:
           format: uuid
         chapterName:
           type: string
+          nullable: true
           minLength: 1
           maxLength: 30
+          description: 챕터명 (선택). 미입력 시 AI가 업로드 내용을 분석하여 자동 생성
         uploadType:
           type: string
           enum:
@@ -3446,6 +3457,10 @@ components:
         - $ref: '#/components/schemas/LectureUploadAcceptedData'
         - type: object
           properties:
+            chapterName:
+              type: string
+              description: 챕터명. AI 처리 완료 전에는 임시명("새 챕터"), 완료 후에는 AI 생성 또는 사용자 입력 챕터명
+              example: 1장 데이터 모델링
             progressPct:
               type: integer
               minimum: 0

--- a/src/main/java/com/f1/quiket/domain/lecture/controller/LectureUploadController.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/controller/LectureUploadController.java
@@ -62,7 +62,7 @@ public class LectureUploadController {
      *
      * @param principal 인증 사용자
      * @param subjectId 과목 공개 식별자
-     * @param chapterName 생성할 챕터명
+     * @param chapterName 생성할 챕터명 (선택 - null이면 AI 자동 생성)
      * @param uploadType pdf 또는 image
      * @param partSplitMethod auto 또는 manual
      * @param files 업로드 파일 목록
@@ -73,7 +73,7 @@ public class LectureUploadController {
     public ResponseEntity<ApiResponse<LectureUploadAcceptedResponse>> createFileUpload(
             @AuthenticationPrincipal UserPrincipal principal,
             @RequestParam("subjectId") String subjectId,
-            @RequestParam("chapterName") String chapterName,
+            @RequestParam(value = "chapterName", required = false) String chapterName,
             @RequestParam("uploadType") String uploadType,
             @RequestParam("partSplitMethod") String partSplitMethod,
             @RequestParam("files") List<MultipartFile> files,

--- a/src/main/java/com/f1/quiket/domain/lecture/dto/LectureMaterialAiProcessResult.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/dto/LectureMaterialAiProcessResult.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 /**
  * 강의 자료 AI 처리 결과 DTO
  *
- * AI 제공자, 추출 텍스트, 파트 초안 목록 전달
+ * AI 제공자, 추출 텍스트, 파트 초안 목록, AI 생성 챕터명 전달
  */
 @Getter
 @Builder
@@ -15,5 +15,10 @@ public class LectureMaterialAiProcessResult {
     private final String provider;
     private final String extractedText;
     private final List<LecturePartDraft> parts;
+    /**
+     * AI가 생성한 챕터명
+     * 요청 시 chapterName이 null인 경우에만 값이 존재하며, 그 외엔 null
+     */
+    private final String generatedChapterName;
 }
 

--- a/src/main/java/com/f1/quiket/domain/lecture/dto/LectureTextUploadRequest.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/dto/LectureTextUploadRequest.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
  * 텍스트 직접 입력 강의 업로드 요청 DTO
  *
  * 과목, 챕터, 파트 분류 방식, 입력 텍스트를 전달
+ * chapterName 미입력 시 AI가 업로드 내용 기반으로 자동 생성
  */
 @Getter
 @NoArgsConstructor
@@ -20,7 +21,11 @@ public class LectureTextUploadRequest {
     @NotBlank(message = "subjectId는 필수입니다.")
     private String subjectId;
 
-    @NotBlank(message = "chapterName은 필수입니다.")
+    /**
+     * 챕터명 (선택)
+     * null이면 AI가 업로드 내용 기반으로 챕터명 자동 생성
+     * 제공 시 1~30자 제약 적용
+     */
     @Size(min = 1, max = 30, message = "chapterName은 1~30자로 입력해주세요.")
     private String chapterName;
 

--- a/src/main/java/com/f1/quiket/domain/lecture/dto/LectureUploadAcceptedResponse.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/dto/LectureUploadAcceptedResponse.java
@@ -10,6 +10,7 @@ import lombok.Getter;
  * 강의 업로드 접수 응답 DTO
  *
  * 외부 공개 식별자와 최초 처리 상태 전달
+ * 챕터명은 AI 처리 완료 후 status API(/lecture-uploads/{id}/status)에서 확인
  */
 @Getter
 @Builder

--- a/src/main/java/com/f1/quiket/domain/lecture/dto/LectureUploadStatusResponse.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/dto/LectureUploadStatusResponse.java
@@ -13,7 +13,8 @@ import lombok.Getter;
 /**
  * 강의 업로드 상태 조회 응답 DTO
  *
- * 처리 상태, 진행률, 생성 파트 목록, 실패 사유 전달
+ * 처리 상태, 진행률, 챕터명, 생성 파트 목록, 실패 사유 전달
+ * chapterName은 AI 처리 완료 후 갱신된 최종값을 반환 (처리 중에는 임시명 "새 챕터")
  */
 @Getter
 @Builder
@@ -21,6 +22,11 @@ public class LectureUploadStatusResponse {
     private final String lectureUploadId;
     private final String subjectId;
     private final String chapterId;
+    /**
+     * 챕터명
+     * AI 처리 완료 전: 임시명("새 챕터"), 완료 후: AI 생성 또는 사용자 입력 챕터명
+     */
+    private final String chapterName;
     private final String status;
     private final Integer estimatedSeconds;
     private final Integer progressPct;
@@ -41,6 +47,7 @@ public class LectureUploadStatusResponse {
                 .lectureUploadId(upload.getPublicId())
                 .subjectId(subject.getPublicId())
                 .chapterId(chapter.getPublicId())
+                .chapterName(chapter.getName())
                 .status(upload.getStatus())
                 .estimatedSeconds(30)
                 .progressPct(progressPct(upload))

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
@@ -56,6 +56,7 @@ public class LectureMaterialAiProcessor {
 
     /**
      * 이미지 OCR 및 파트 분류 처리
+     * chapterName 미지정 시 AI 응답에서 생성된 챕터명 추출
      */
     private LectureMaterialAiProcessResult processImage(LectureMaterialAiProcessRequest request) {
         StudyMaterialAiPrompt prompt = promptBuilder.buildGeminiPrompt(request, null);
@@ -65,16 +66,18 @@ public class LectureMaterialAiProcessor {
                 prompt.userMessage(),
                 request.getFiles()
         );
-        List<LecturePartDraft> parts = parseParts(aiResponse);
+        LecturePartsPayload payload = parsePayload(aiResponse);
         return LectureMaterialAiProcessResult.builder()
                 .provider("gemini")
                 .extractedText(null)
-                .parts(parts)
+                .parts(parseParts(payload))
+                .generatedChapterName(resolveGeneratedChapterName(request, payload))
                 .build();
     }
 
     /**
      * PDF 텍스트 레이어 판별 후 AI 처리
+     * chapterName 미지정 시 AI 응답에서 생성된 챕터명 추출
      */
     private LectureMaterialAiProcessResult processPdf(LectureMaterialAiProcessRequest request) {
         StudyMaterialFile pdfFile = request.getFiles().get(0);
@@ -88,10 +91,12 @@ public class LectureMaterialAiProcessor {
                     prompt.systemMessage(),
                     prompt.userMessage()
             );
+            LecturePartsPayload payload = parsePayload(aiResponse);
             return LectureMaterialAiProcessResult.builder()
                     .provider("groq")
                     .extractedText(text)
-                    .parts(parseGroqParts(aiResponse, text))
+                    .parts(parseGroqParts(payload, text))
+                    .generatedChapterName(resolveGeneratedChapterName(request, payload))
                     .build();
         }
 
@@ -102,15 +107,18 @@ public class LectureMaterialAiProcessor {
                 prompt.userMessage(),
                 pdfFile
         );
+        LecturePartsPayload payload = parsePayload(aiResponse);
         return LectureMaterialAiProcessResult.builder()
                 .provider("gemini")
                 .extractedText(extractionResult.getExtractedText())
-                .parts(parseParts(aiResponse))
+                .parts(parseParts(payload))
+                .generatedChapterName(resolveGeneratedChapterName(request, payload))
                 .build();
     }
 
     /**
      * 직접 입력 텍스트 기반 파트 분류 처리
+     * chapterName 미지정 시 AI 응답에서 생성된 챕터명 추출
      */
     private LectureMaterialAiProcessResult processText(LectureMaterialAiProcessRequest request) {
         StudyMaterialAiPrompt prompt = promptBuilder.buildGroqPrompt(request, request.getText());
@@ -119,11 +127,33 @@ public class LectureMaterialAiProcessor {
                 prompt.systemMessage(),
                 prompt.userMessage()
         );
+        LecturePartsPayload payload = parsePayload(aiResponse);
         return LectureMaterialAiProcessResult.builder()
                 .provider("groq")
                 .extractedText(request.getText())
-                .parts(parseGroqParts(aiResponse, request.getText()))
+                .parts(parseGroqParts(payload, request.getText()))
+                .generatedChapterName(resolveGeneratedChapterName(request, payload))
                 .build();
+    }
+
+    /**
+     * chapterName 미지정 요청에서 AI가 생성한 챕터명 추출
+     *
+     * 사용자가 이미 챕터명을 제공했거나 AI 응답에 챕터명이 없으면 null 반환
+     * 유효하지 않은 챕터명(31자 이상)도 null로 처리하여 폴백("새 챕터") 유지
+     */
+    private String resolveGeneratedChapterName(LectureMaterialAiProcessRequest request, LecturePartsPayload payload) {
+        // 사용자가 챕터명을 직접 제공한 경우 AI 생성 불필요
+        if (StringUtils.hasText(request.getChapterName())) {
+            return null;
+        }
+        String generatedName = payload.getChapterName();
+        // 30자 초과 응답은 유효하지 않으므로 null 처리 (폴백 "새 챕터" 유지)
+        if (!StringUtils.hasText(generatedName) || generatedName.trim().length() > 30) {
+            log.warn("AI 챕터명 생성 실패 또는 유효하지 않은 챕터명. 폴백 유지. generatedName={}", generatedName);
+            return null;
+        }
+        return generatedName.trim();
     }
 
     /**
@@ -143,44 +173,52 @@ public class LectureMaterialAiProcessor {
     }
 
     /**
-     * AI 파트 분류 응답 파싱
+     * AI 응답 JSON 역직렬화
+     *
+     * normalizeJson 후 LecturePartsPayload로 변환
+     * 이후 parseParts 또는 parseGroqParts에서 파트 목록으로 추출
      */
-    private List<LecturePartDraft> parseParts(String aiResponse) {
+    private LecturePartsPayload parsePayload(String aiResponse) {
         try {
             String normalized = normalizeJson(aiResponse);
-            LecturePartsPayload payload = objectMapper.readValue(normalized, LecturePartsPayload.class);
-            if (payload.getParts() == null || payload.getParts().isEmpty()) {
-                throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답에 파트 정보가 없습니다.");
-            }
-
-            List<LecturePartDraft> parts = new ArrayList<>();
-            for (LecturePartPayload part : payload.getParts()) {
-                // name/partName 호환 응답 처리
-                String resolvedName = StringUtils.hasText(part.getName()) ? part.getName() : part.getPartName();
-                if (part.getPartNumber() == null || !StringUtils.hasText(resolvedName)) {
-                    throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답 파트 형식이 올바르지 않습니다.");
-                }
-                parts.add(LecturePartDraft.builder()
-                        .partNumber(part.getPartNumber())
-                        .name(resolvedName.trim())
-                        .content(valueOrDefault(part.getContent(), "").trim())
-                        .build());
-            }
-            return parts;
+            return objectMapper.readValue(normalized, LecturePartsPayload.class);
         } catch (JsonProcessingException e) {
             throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답 파싱에 실패했습니다.", e);
         }
     }
 
     /**
-     * Groq 라인 범위 응답 파싱 및 원문 분리
+     * Gemini 파트 분류 응답 파싱 (content 포함)
      */
-    private List<LecturePartDraft> parseGroqParts(String aiResponse, String sourceText) {
-        try {
-            String normalized = normalizeJson(aiResponse);
-            LecturePartsPayload payload = objectMapper.readValue(normalized, LecturePartsPayload.class);
-            List<LineSpan> lineSpans = lineSpans(sourceText);
-            if (payload.getParts() == null || payload.getParts().isEmpty()) {
+    private List<LecturePartDraft> parseParts(LecturePartsPayload payload) {
+        if (payload.getParts() == null || payload.getParts().isEmpty()) {
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답에 파트 정보가 없습니다.");
+        }
+
+        List<LecturePartDraft> parts = new ArrayList<>();
+        for (LecturePartPayload part : payload.getParts()) {
+            // name/partName 호환 응답 처리
+            String resolvedName = StringUtils.hasText(part.getName()) ? part.getName() : part.getPartName();
+            if (part.getPartNumber() == null || !StringUtils.hasText(resolvedName)) {
+                throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답 파트 형식이 올바르지 않습니다.");
+            }
+            parts.add(LecturePartDraft.builder()
+                    .partNumber(part.getPartNumber())
+                    .name(resolvedName.trim())
+                    .content(valueOrDefault(part.getContent(), "").trim())
+                    .build());
+        }
+        return parts;
+    }
+
+    /**
+     * Groq 라인 범위 응답 파싱 및 원문 분리
+     *
+     * JSON 파싱은 parsePayload에서 완료된 상태로 진입
+     */
+    private List<LecturePartDraft> parseGroqParts(LecturePartsPayload payload, String sourceText) {
+        List<LineSpan> lineSpans = lineSpans(sourceText);
+        if (payload.getParts() == null || payload.getParts().isEmpty()) {
                 log.warn("Groq 파트 범위 응답 없음, 전체 원문 미분류 처리 totalLineCount={}", lineSpans.size());
                 return List.of(unclassifiedPart(1, sourceText, lineSpans, 1, lineSpans.size()));
             }
@@ -267,9 +305,6 @@ public class LectureMaterialAiProcessor {
                 addUnclassifiedPart(parts, nextPartNumber, sourceText, lineSpans, nextSourceLine, lineSpans.size());
             }
             return parts;
-        } catch (JsonProcessingException e) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답 파싱에 실패했습니다.", e);
-        }
     }
 
     private boolean isValidGroqPartPayload(LecturePartPayload part) {
@@ -387,6 +422,8 @@ public class LectureMaterialAiProcessor {
     @Getter
     @Setter
     private static class LecturePartsPayload {
+        /** chapterName 미지정 시 AI가 강의 내용 기반으로 생성한 챕터명 */
+        private String chapterName;
         private List<LecturePartPayload> parts;
     }
 

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiPromptBuilder.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiPromptBuilder.java
@@ -13,34 +13,62 @@ import org.springframework.util.StringUtils;
  * 강의 자료 AI 프롬프트 생성기
  *
  * OCR 및 파트 분류용 시스템 메시지와 사용자 메시지 생성
+ * chapterName이 null이면 AI에게 챕터명 자동 생성을 함께 요청
  */
 @Component
 public class LectureMaterialAiPromptBuilder {
 
     /**
      * Groq 텍스트 분류 프롬프트 생성
+     *
+     * @param request chapterName이 null이면 챕터명 생성 지시 포함
      */
     public StudyMaterialAiPrompt buildGroqPrompt(LectureMaterialAiProcessRequest request, String sourceText) {
-        return new StudyMaterialAiPrompt(systemMessage(), groqUserMessage(request, sourceText));
+        return new StudyMaterialAiPrompt(systemMessage(needsChapterName(request)), groqUserMessage(request, sourceText));
     }
 
     /**
      * Gemini OCR 및 분류 프롬프트 생성
+     *
+     * @param request chapterName이 null이면 챕터명 생성 지시 포함
      */
     public StudyMaterialAiPrompt buildGeminiPrompt(LectureMaterialAiProcessRequest request, String sourceText) {
-        return new StudyMaterialAiPrompt(systemMessage(), geminiUserMessage(request, sourceText));
+        return new StudyMaterialAiPrompt(systemMessage(needsChapterName(request)), geminiUserMessage(request, sourceText));
     }
 
-    private String systemMessage() {
-        return """
+    /**
+     * chapterName이 null이면 AI 챕터명 생성이 필요한 요청으로 판단
+     */
+    private boolean needsChapterName(LectureMaterialAiProcessRequest request) {
+        return !StringUtils.hasText(request.getChapterName());
+    }
+
+    /**
+     * @param generateChapterName true이면 챕터명 생성 지시 추가
+     */
+    private String systemMessage(boolean generateChapterName) {
+        String base = """
                 너는 Quiket 강의 자료 파트 분류 엔진이다.
                 역할은 입력 자료를 파트 단위로 나누는 것이며 요약 엔진이 아니다.
                 반드시 JSON만 반환한다.
                 코드블록, 마크다운, 설명 문장은 절대 포함하지 않는다.
                 """;
+        if (generateChapterName) {
+            // chapterName 미지정 시 강의 내용 기반 챕터명 자동 생성 지시
+            return base + "챕터명이 미지정된 경우 강의 내용을 대표하는 챕터명을 JSON 최상위 chapterName 필드에 반드시 포함한다. chapterName은 1자 이상 30자 이하의 한국어 또는 영어 명사형으로 작성한다.\n";
+        }
+        return base;
     }
 
     private String groqUserMessage(LectureMaterialAiProcessRequest request, String sourceText) {
+        // chapterName 미지정 시 반환 형식에 chapterName 필드 포함 요구
+        String returnFormat = needsChapterName(request)
+                ? """
+                - 반환 형식: {"chapterName":"...","parts":[{"partNumber":1,"name":"...","startLine":1,"endLine":10}]}
+                - chapterName은 강의 내용을 대표하는 1~30자 명사형 챕터명"""
+                : """
+                - 반환 형식: {"parts":[{"partNumber":1,"name":"...","startLine":1,"endLine":10}]}""";
+
         return """
                 [입력]
                 - 챕터명: %s
@@ -53,7 +81,7 @@ public class LectureMaterialAiPromptBuilder {
                 %s
 
                 [반환 규칙]
-                - 반환 형식: {"parts":[{"partNumber":1,"name":"...","startLine":1,"endLine":10}]}
+                %s
                 - partNumber는 1부터 시작하는 오름차순 정수
                 - name은 1자 이상 30자 이하
                 - startLine과 endLine은 해당 파트에 속한 원문 줄 번호 범위
@@ -71,11 +99,20 @@ public class LectureMaterialAiPromptBuilder {
                 valueOrDefault(request.getChapterName(), "미지정"),
                 request.getPartSplitMethod().getValue(),
                 partSplitPlanContext(request.getPartSplitPlans()),
-                lineNumberedText(sourceText)
+                lineNumberedText(sourceText),
+                returnFormat
         );
     }
 
     private String geminiUserMessage(LectureMaterialAiProcessRequest request, String sourceText) {
+        // chapterName 미지정 시 반환 형식에 chapterName 필드 포함 요구
+        String returnFormat = needsChapterName(request)
+                ? """
+                - 반환 형식: {"chapterName":"...","parts":[{"partNumber":1,"name":"...","content":"..."}]}
+                - chapterName은 강의 내용을 대표하는 1~30자 명사형 챕터명"""
+                : """
+                - 반환 형식: {"parts":[{"partNumber":1,"name":"...","content":"..."}]}""";
+
         return """
                 [작업]
                 업로드 파일에서 텍스트를 추출(OCR 포함)한 뒤 파트를 분류한다.
@@ -91,7 +128,7 @@ public class LectureMaterialAiPromptBuilder {
                 %s
 
                 [반환 규칙]
-                - 반환 형식: {"parts":[{"partNumber":1,"name":"...","content":"..."}]}
+                %s
                 - partNumber는 1부터 시작하는 오름차순 정수
                 - name은 1자 이상 30자 이하
                 - content는 해당 파트에 속한 OCR 추출 원문 전체
@@ -106,7 +143,8 @@ public class LectureMaterialAiPromptBuilder {
                 valueOrDefault(request.getChapterName(), "미지정"),
                 request.getPartSplitMethod().getValue(),
                 partSplitPlanContext(request.getPartSplitPlans()),
-                valueOrDefault(sourceText, "")
+                valueOrDefault(sourceText, ""),
+                returnFormat
         );
     }
 

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadCreateService.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadCreateService.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,6 +46,7 @@ import org.springframework.web.multipart.MultipartFile;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class LectureUploadCreateService {
 
     private static final long MAX_UPLOAD_SIZE_BYTES = 50L * 1024L * 1024L;
@@ -63,6 +65,8 @@ public class LectureUploadCreateService {
 
     /**
      * 텍스트 직접 입력 업로드 접수
+     *
+     * chapterName이 null이면 임시명("새 챕터")으로 챕터 생성 후 AI 처리 완료 시 자동 업데이트
      *
      * @param userId 인증 사용자 내부 식별자
      * @param request 텍스트 업로드 요청
@@ -88,7 +92,8 @@ public class LectureUploadCreateService {
                 chapter.getId(),
                 subject.getId(),
                 userId,
-                chapter.getName(),
+                // chapterName이 null이면 AI가 처리 중 자동 생성 (event에 null 전달)
+                request.getChapterName(),
                 uploadType,
                 partSplitMethod,
                 request.getText(),
@@ -102,9 +107,11 @@ public class LectureUploadCreateService {
     /**
      * PDF 또는 이미지 파일 업로드 접수
      *
+     * chapterName이 null이면 임시명("새 챕터")으로 챕터 생성 후 AI 처리 완료 시 자동 업데이트
+     *
      * @param userId 인증 사용자 내부 식별자
      * @param subjectPublicId 과목 공개 식별자
-     * @param chapterName 생성할 챕터명
+     * @param chapterName 생성할 챕터명 (null이면 AI 자동 생성)
      * @param uploadTypeValue 업로드 타입 문자열
      * @param partSplitMethodValue 파트 분류 방식 문자열
      * @param multipartFiles 업로드 파일 목록
@@ -123,7 +130,6 @@ public class LectureUploadCreateService {
     ) {
         StudyMaterialUploadType uploadType = parseUploadType(uploadTypeValue);
         PartSplitMethod partSplitMethod = parsePartSplitMethod(partSplitMethodValue);
-        validateChapterName(chapterName);
         List<StudyMaterialFile> files = validateAndReadFiles(uploadType, multipartFiles);
         List<LecturePartSplitPlan> plans = validateAndConvertPlans(partSplitMethod, parsePlansJson(partSplitPlansJson));
 
@@ -141,7 +147,8 @@ public class LectureUploadCreateService {
                 chapter.getId(),
                 subject.getId(),
                 userId,
-                chapter.getName(),
+                // chapterName이 null이면 AI가 처리 중 자동 생성 (event에 null 전달)
+                chapterName,
                 uploadType,
                 partSplitMethod,
                 null,
@@ -162,9 +169,14 @@ public class LectureUploadCreateService {
     }
 
     private Chapter createChapter(Subject subject, Long userId, String chapterName) {
-        validateChapterName(chapterName);
+        // 제공된 챕터명 유효성 검증 (null이면 AI 생성 예정이므로 통과)
+        if (chapterName != null && (chapterName.isBlank() || chapterName.length() > 30)) {
+            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "chapterName은 1~30자로 입력해주세요.");
+        }
+        // chapterName 미제공 시 임시 챕터명으로 생성 → AI 처리 완료 후 업데이트
+        String name = StringUtils.hasText(chapterName) ? chapterName.trim() : "새 챕터";
         int nextDisplayOrder = chapterRepository.findMaxDisplayOrderBySubjectId(subject.getId()) + 1;
-        return chapterRepository.save(Chapter.create(subject.getId(), userId, chapterName.trim(), nextDisplayOrder));
+        return chapterRepository.save(Chapter.create(subject.getId(), userId, name, nextDisplayOrder));
     }
 
     private StudyMaterialUploadType parseUploadType(String value) {
@@ -192,12 +204,6 @@ public class LectureUploadCreateService {
         }
         if (text.length() > MAX_TEXT_LENGTH) {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "text는 30,000자 이하로 입력해주세요.");
-        }
-    }
-
-    private void validateChapterName(String chapterName) {
-        if (!StringUtils.hasText(chapterName) || chapterName.trim().length() > 30) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "chapterName은 1~30자로 입력해주세요.");
         }
     }
 
@@ -242,12 +248,27 @@ public class LectureUploadCreateService {
         // 파일 형식 검증
         if (uploadType == StudyMaterialUploadType.PDF
                 && !("application/pdf".equals(contentType) || filename.endsWith(".pdf"))) {
+            logUnsupportedFileType(uploadType, filename, contentType);
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "지원하지 않는 파일 형식이에요");
         }
         if (uploadType == StudyMaterialUploadType.IMAGE
                 && !(isSupportedImageContentType(contentType) || isSupportedImageFileName(filename))) {
+            logUnsupportedFileType(uploadType, filename, contentType);
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "JPG, PNG 형식만 지원해요");
         }
+    }
+
+    private void logUnsupportedFileType(
+            StudyMaterialUploadType uploadType,
+            String filename,
+            String contentType
+    ) {
+        log.warn(
+                "Unsupported lecture upload file type. requestedUploadType={}, fileName={}, contentType={}",
+                uploadType,
+                filename,
+                contentType
+        );
     }
 
     private boolean isSupportedImageContentType(String contentType) {

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
@@ -7,6 +7,8 @@ import com.f1.quiket.domain.lecture.entity.LectureProcessingJob;
 import com.f1.quiket.domain.lecture.entity.LectureUpload;
 import com.f1.quiket.domain.lecture.entity.LectureUploadFile;
 import com.f1.quiket.domain.lecture.event.LectureUploadProcessingRequestedEvent;
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
 import com.f1.quiket.domain.lecture.repository.LectureProcessingJobRepository;
 import com.f1.quiket.domain.lecture.repository.LectureUploadFileRepository;
 import com.f1.quiket.domain.lecture.repository.LectureUploadRepository;
@@ -43,6 +45,7 @@ public class LectureUploadProcessingService {
     private final LectureUploadFileRepository lectureUploadFileRepository;
     private final LectureProcessingJobRepository lectureProcessingJobRepository;
     private final PartRepository partRepository;
+    private final ChapterRepository chapterRepository;
     private final LectureMaterialAiProcessor lectureMaterialAiProcessor;
     private final PlatformTransactionManager transactionManager;
 
@@ -101,6 +104,9 @@ public class LectureUploadProcessingService {
             List<Part> parts = createParts(event, upload, result.getParts());
             partRepository.saveAll(parts);
 
+            // chapterName 미지정 요청에서 AI가 챕터명을 생성한 경우 chapter 엔티티 업데이트
+            updateChapterNameIfGenerated(event, result);
+
             if (event.uploadType() == StudyMaterialUploadType.IMAGE) {
                 // 이미지 OCR 성공 상태 반영
                 lectureUploadFileRepository.findAllByLectureUploadIdAndDeletedAtIsNullOrderByDisplayOrderAsc(upload.getId())
@@ -111,6 +117,33 @@ public class LectureUploadProcessingService {
             upload.markCompleted(rawText);
             getOrCreateJob(upload).markCompleted();
         });
+    }
+
+    /**
+     * chapterName 미지정 요청에서 AI 생성 챕터명으로 chapter.name 갱신
+     *
+     * 사용자가 챕터명을 제공했거나 AI가 챕터명을 생성하지 못한 경우 임시명("새 챕터") 유지
+     *
+     * @param event AI 처리 요청 이벤트 (chapterName이 null이면 AI 생성 대상)
+     * @param result AI 처리 결과 (generatedChapterName이 null이면 폴백 유지)
+     */
+    private void updateChapterNameIfGenerated(
+            LectureUploadProcessingRequestedEvent event,
+            LectureMaterialAiProcessResult result
+    ) {
+        if (StringUtils.hasText(event.chapterName())) {
+            // 사용자가 챕터명을 직접 입력한 경우 업데이트 불필요
+            return;
+        }
+        if (!StringUtils.hasText(result.getGeneratedChapterName())) {
+            // AI 챕터명 생성 실패 시 임시명("새 챕터") 유지
+            log.warn("AI 챕터명 미생성, 임시 챕터명 유지. chapterId={}", event.chapterId());
+            return;
+        }
+        Chapter chapter = chapterRepository.findById(event.chapterId())
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+        chapter.updateName(result.getGeneratedChapterName());
+        log.info("AI 챕터명 업데이트 완료. chapterId={}, generatedName={}", event.chapterId(), result.getGeneratedChapterName());
     }
 
     private List<Part> createParts(

--- a/src/main/java/com/f1/quiket/domain/part/service/PartAddCreateService.java
+++ b/src/main/java/com/f1/quiket/domain/part/service/PartAddCreateService.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,6 +38,7 @@ import org.springframework.web.multipart.MultipartFile;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class PartAddCreateService {
 
     private static final long MAX_UPLOAD_SIZE_BYTES = 50L * 1024L * 1024L;
@@ -238,12 +240,27 @@ public class PartAddCreateService {
         // 파일 형식 검증
         if (uploadType == StudyMaterialUploadType.PDF
                 && !("application/pdf".equals(contentType) || filename.endsWith(".pdf"))) {
+            logUnsupportedFileType(uploadType, filename, contentType);
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "지원하지 않는 파일 형식이에요");
         }
         if (uploadType == StudyMaterialUploadType.IMAGE
                 && !(isSupportedImageContentType(contentType) || isSupportedImageFileName(filename))) {
+            logUnsupportedFileType(uploadType, filename, contentType);
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE, "JPG, PNG 형식만 지원해요");
         }
+    }
+
+    private void logUnsupportedFileType(
+            StudyMaterialUploadType uploadType,
+            String filename,
+            String contentType
+    ) {
+        log.warn(
+                "Unsupported part upload file type. requestedUploadType={}, fileName={}, contentType={}",
+                uploadType,
+                filename,
+                contentType
+        );
     }
 
     private boolean isSupportedImageContentType(String contentType) {

--- a/src/test/java/com/f1/quiket/domain/lecture/service/LectureUploadCreateServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/lecture/service/LectureUploadCreateServiceTest.java
@@ -7,6 +7,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.f1.quiket.domain.chapter.entity.Chapter;
 import com.f1.quiket.domain.chapter.repository.ChapterRepository;
 import com.f1.quiket.domain.lecture.dto.LectureTextUploadRequest;
@@ -27,6 +31,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -105,6 +110,10 @@ class LectureUploadCreateServiceTest {
 
     @Test
     void create_file_upload_rejects_non_pdf_file_when_upload_type_pdf() {
+        Logger logger = (Logger) LoggerFactory.getLogger(LectureUploadCreateService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
         MockMultipartFile file = new MockMultipartFile(
                 "files",
                 "lecture.txt",
@@ -123,6 +132,18 @@ class LectureUploadCreateServiceTest {
         ))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("지원하지 않는 파일 형식이에요");
+
+        assertThat(appender.list)
+                .anySatisfy(event -> {
+                    assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                    assertThat(event.getFormattedMessage())
+                            .contains(
+                                    "requestedUploadType=PDF",
+                                    "fileName=lecture.txt",
+                                    "contentType=text/plain"
+                            );
+                });
+        logger.detachAppender(appender);
     }
 
     private LectureTextUploadRequest textRequest() {

--- a/src/test/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingServiceTest.java
@@ -3,9 +3,12 @@ package com.f1.quiket.domain.lecture.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.f1.quiket.domain.chapter.entity.Chapter;
+import com.f1.quiket.domain.chapter.repository.ChapterRepository;
 import com.f1.quiket.domain.lecture.dto.LectureMaterialAiProcessResult;
 import com.f1.quiket.domain.lecture.dto.LecturePartDraft;
 import com.f1.quiket.domain.lecture.dto.PartSplitMethod;
@@ -35,6 +38,7 @@ class LectureUploadProcessingServiceTest {
     private LectureUploadFileRepository lectureUploadFileRepository;
     private LectureProcessingJobRepository lectureProcessingJobRepository;
     private PartRepository partRepository;
+    private ChapterRepository chapterRepository;
     private LectureMaterialAiProcessor lectureMaterialAiProcessor;
     private LectureUploadProcessingService service;
 
@@ -44,17 +48,23 @@ class LectureUploadProcessingServiceTest {
         lectureUploadFileRepository = mock(LectureUploadFileRepository.class);
         lectureProcessingJobRepository = mock(LectureProcessingJobRepository.class);
         partRepository = mock(PartRepository.class);
+        chapterRepository = mock(ChapterRepository.class);
         lectureMaterialAiProcessor = mock(LectureMaterialAiProcessor.class);
         service = new LectureUploadProcessingService(
                 lectureUploadRepository,
                 lectureUploadFileRepository,
                 lectureProcessingJobRepository,
                 partRepository,
+                chapterRepository,
                 lectureMaterialAiProcessor,
                 transactionManager()
         );
     }
 
+    /**
+     * 기본 처리 흐름: 파트 저장 및 업로드 상태 completed 전환 검증
+     * chapterName을 직접 입력한 경우 챕터명 업데이트가 발생하지 않음을 함께 검증
+     */
     @Test
     void process_saves_parts_and_marks_upload_completed() {
         LectureUpload upload = LectureUpload.create(20L, 1L, StudyMaterialUploadType.TEXT, PartSplitMethod.AUTO);
@@ -73,6 +83,7 @@ class LectureUploadProcessingServiceTest {
                                 .build()))
                         .build());
 
+        // chapterName을 직접 입력한 이벤트
         service.process(new LectureUploadProcessingRequestedEvent(
                 30L,
                 20L,
@@ -92,6 +103,99 @@ class LectureUploadProcessingServiceTest {
         assertThat(upload.getStatus()).isEqualTo("completed");
         assertThat(upload.getRawText()).isEqualTo("원문 텍스트");
         assertThat(processingJob.getStatus()).isEqualTo("completed");
+        // 사용자가 챕터명을 직접 입력한 경우 chapterRepository 호출 없음
+        verify(chapterRepository, never()).findById(any());
+    }
+
+    /**
+     * chapterName 미지정 시 AI 생성 챕터명으로 chapter.name 업데이트 검증
+     */
+    @Test
+    void process_updates_chapter_name_when_chapterName_is_null_and_ai_generates_it() {
+        LectureUpload upload = LectureUpload.create(20L, 1L, StudyMaterialUploadType.TEXT, PartSplitMethod.AUTO);
+        ReflectionTestUtils.setField(upload, "id", 30L);
+        LectureProcessingJob processingJob = LectureProcessingJob.create(upload.getId(), 1L, 30);
+
+        Chapter chapter = Chapter.create(10L, 1L, "새 챕터", 1);
+        ReflectionTestUtils.setField(chapter, "id", 20L);
+
+        when(lectureUploadRepository.findById(30L)).thenReturn(Optional.of(upload));
+        when(lectureProcessingJobRepository.findByLectureUploadId(upload.getId())).thenReturn(Optional.of(processingJob));
+        when(chapterRepository.findById(20L)).thenReturn(Optional.of(chapter));
+        when(lectureMaterialAiProcessor.process(any()))
+                .thenReturn(LectureMaterialAiProcessResult.builder()
+                        .provider("groq")
+                        .extractedText("원문 텍스트")
+                        .parts(List.of(LecturePartDraft.builder()
+                                .partNumber(1)
+                                .name("개념")
+                                .content("원문 텍스트")
+                                .build()))
+                        // AI가 생성한 챕터명
+                        .generatedChapterName("데이터베이스 모델링")
+                        .build());
+
+        // chapterName이 null인 이벤트 (미지정)
+        service.process(new LectureUploadProcessingRequestedEvent(
+                30L,
+                20L,
+                10L,
+                1L,
+                null,
+                StudyMaterialUploadType.TEXT,
+                PartSplitMethod.AUTO,
+                "원문 텍스트",
+                List.of(),
+                List.of()
+        ));
+
+        // AI 생성 챕터명으로 chapter.name이 업데이트됨
+        assertThat(chapter.getName()).isEqualTo("데이터베이스 모델링");
+        assertThat(upload.getStatus()).isEqualTo("completed");
+        assertThat(processingJob.getStatus()).isEqualTo("completed");
+    }
+
+    /**
+     * chapterName 미지정이지만 AI가 챕터명을 생성하지 못한 경우
+     * 임시명("새 챕터") 유지 및 chapter 업데이트 미발생 검증
+     */
+    @Test
+    void process_keeps_placeholder_chapter_name_when_ai_fails_to_generate() {
+        LectureUpload upload = LectureUpload.create(20L, 1L, StudyMaterialUploadType.TEXT, PartSplitMethod.AUTO);
+        ReflectionTestUtils.setField(upload, "id", 30L);
+        LectureProcessingJob processingJob = LectureProcessingJob.create(upload.getId(), 1L, 30);
+
+        when(lectureUploadRepository.findById(30L)).thenReturn(Optional.of(upload));
+        when(lectureProcessingJobRepository.findByLectureUploadId(upload.getId())).thenReturn(Optional.of(processingJob));
+        when(lectureMaterialAiProcessor.process(any()))
+                .thenReturn(LectureMaterialAiProcessResult.builder()
+                        .provider("groq")
+                        .extractedText("원문 텍스트")
+                        .parts(List.of(LecturePartDraft.builder()
+                                .partNumber(1)
+                                .name("개념")
+                                .content("원문 텍스트")
+                                .build()))
+                        // AI 챕터명 생성 실패 (null)
+                        .generatedChapterName(null)
+                        .build());
+
+        service.process(new LectureUploadProcessingRequestedEvent(
+                30L,
+                20L,
+                10L,
+                1L,
+                null,
+                StudyMaterialUploadType.TEXT,
+                PartSplitMethod.AUTO,
+                "원문 텍스트",
+                List.of(),
+                List.of()
+        ));
+
+        assertThat(upload.getStatus()).isEqualTo("completed");
+        // AI 챕터명 미생성 시 chapterRepository 조회 없음 (임시명 유지)
+        verify(chapterRepository, never()).findById(any());
     }
 
     private PlatformTransactionManager transactionManager() {

--- a/src/test/java/com/f1/quiket/domain/part/service/PartAddCreateServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/part/service/PartAddCreateServiceTest.java
@@ -7,6 +7,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.f1.quiket.domain.chapter.entity.Chapter;
 import com.f1.quiket.domain.chapter.repository.ChapterRepository;
 import com.f1.quiket.domain.lecture.dto.LectureUploadAcceptedResponse;
@@ -25,6 +29,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -101,6 +106,10 @@ class PartAddCreateServiceTest {
 
     @Test
     void create_file_part_rejects_non_pdf_file_when_upload_type_pdf() {
+        Logger logger = (Logger) LoggerFactory.getLogger(PartAddCreateService.class);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
         MockMultipartFile file = new MockMultipartFile(
                 "files",
                 "lecture.txt",
@@ -117,6 +126,18 @@ class PartAddCreateServiceTest {
         ))
                 .isInstanceOf(CustomException.class)
                 .hasMessage("지원하지 않는 파일 형식이에요");
+
+        assertThat(appender.list)
+                .anySatisfy(event -> {
+                    assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                    assertThat(event.getFormattedMessage())
+                            .contains(
+                                    "requestedUploadType=PDF",
+                                    "fileName=lecture.txt",
+                                    "contentType=text/plain"
+                            );
+                });
+        logger.detachAppender(appender);
     }
 
     private PartTextAddRequest textRequest() {


### PR DESCRIPTION
## 🧩 Description
/api/v1/lecture-uploads API에서 chapterName을 필수 입력에서 선택 입력으로 변경합니다.
chapterName 미입력 시 AI가 업로드 내용을 분석하여 챕터명을 자동 생성하고 DB에 저장합니다.

---

## 🛠️ Changes

- `chapterName` 필드를 필수(`@NotBlank`)에서 선택(`@Size`만 유지)으로 변경
- `chapterName` 미입력 시 임시명("새 챕터")으로 챕터 생성 후, AI 처리 완료 시 업데이트
- AI 프롬프트를 `chapterName` 제공 여부에 따라 동적으로 구성 (미입력 시 chapterName 필드 JSON 반환 추가)
- `LectureMaterialAiProcessor`에서 AI 생성 챕터명 파싱 및 유효성 검증 처리 (30자 초과 시 임시명 유지)
- `LectureUploadProcessingService`에 `ChapterRepository` 주입 및 `updateChapterNameIfGenerated()` 추가
- `GET /lecture-uploads/{id}/status` 응답에 `chapterName` 필드 추가 (AI 처리 완료 후 최종값 반환)
- OpenAPI 명세 `v1.0.2` 반영: `chapterName` optional 처리, status 응답 스키마 업데이트

---

## 🧪 How to Test

1. `POST /api/v1/lecture-uploads` 요청 시 `chapterName` 없이 업로드 접수 → 202 응답 확인
2. `GET /api/v1/lecture-uploads/{id}/status` 폴링 → `status: completed` 전환 후 `chapterName`에 AI 생성 챕터명 반환 확인
3. `chapterName`을 직접 입력한 경우 기존과 동일하게 동작하는지 확인 (하위 호환 검증)
4. AI 챕터명 생성 실패 케이스 (AI 미응답 / 30자 초과) → 임시명 `"새 챕터"` 유지 확인

---

## 🔗 Related Issue

Closes #155 

---

## ⚠️ Notes

- AI 처리 완료 전 status API의 `chapterName`은 "새 챕터" (임시명)로 반환됨
- 202 Accepted 응답에는 `chapterName` 미포함 (AI 실행 전이므로 의미 없음)
- AI가 챕터명 생성 실패 시 warn 로그 출력 후 임시명 유지 (예외 미발생)

---

## 🧑‍💻 Assignee

- @ja2hoon
