### PR TITLE
[Feat] 카카오 로그인 이메일 선택값 처리

### DIFF
--- a/docs/db/quiket-ddl-mvp.sql
+++ b/docs/db/quiket-ddl-mvp.sql
@@ -6,7 +6,7 @@
 CREATE TABLE users (
     id BIGINT NOT NULL AUTO_INCREMENT COMMENT 'PK: 내부 사용자 식별자',
     public_id CHAR(36) NOT NULL COMMENT '외부 노출용 UUID v7',
-    email VARCHAR(255) NOT NULL COMMENT '사용자 이메일',
+    email VARCHAR(255) NULL COMMENT '사용자 이메일, 소셜 전용 계정은 NULL',
     nickname VARCHAR(36) NOT NULL COMMENT '사용자 닉네임',
     status VARCHAR(20) NOT NULL DEFAULT 'active' COMMENT '계정 상태',
     is_email_verified TINYINT(1) NOT NULL DEFAULT 0 COMMENT '이메일 인증 여부',

--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -2071,6 +2071,8 @@ components:
         email:
           type: string
           format: email
+          nullable: true
+          description: 사용자 이메일, 이메일 미제공 소셜 전용 계정은 null
           example: user@example.com
 
     EmailVerificationConfirmRequest:

--- a/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthService.java
@@ -52,7 +52,6 @@ public class KakaoOAuthService {
             return loginWithExistingKakaoIdentity(kakaoIdentity, context);
         }
 
-        validateUsableKakaoEmail(kakaoUserInfo);
         return loginWithNewKakaoIdentity(kakaoUserInfo, request.getAgreedToTerms(), context);
     }
 
@@ -119,7 +118,7 @@ public class KakaoOAuthService {
         ).isPresent()) {
             throw new CustomException(ErrorCode.AUTH_OAUTH_PROVIDER_ALREADY_LINKED);
         }
-        if (userRepository.existsByEmail(payload.email())) {
+        if (StringUtils.hasText(payload.email()) && userRepository.existsByEmail(payload.email())) {
             throw new CustomException(ErrorCode.AUTH_EMAIL_ALREADY_EXISTS);
         }
 
@@ -148,16 +147,19 @@ public class KakaoOAuthService {
             Boolean agreedToTerms,
             AuthTokenRequestContext context
     ) {
-        User existingUser = userRepository.findByEmailAndDeletedAtIsNull(kakaoUserInfo.email())
-                .orElse(null);
-        if (existingUser != null) {
-            String linkToken = temporaryTokenStore.saveLink(
-                    new KakaoOAuthLinkTokenPayload(kakaoUserInfo.providerSubject(), kakaoUserInfo.email()),
-                    KAKAO_TEMP_TOKEN_TTL_SECONDS
-            );
-            return KakaoOAuthLoginResult.accountLinkRequired(
-                    KakaoAccountLinkRequiredResponse.of(kakaoUserInfo.email(), linkToken, KAKAO_TEMP_TOKEN_TTL_SECONDS)
-            );
+        String email = resolveUsableEmail(kakaoUserInfo);
+
+        if (email != null) {
+            User existingUser = userRepository.findByEmailAndDeletedAtIsNull(email).orElse(null);
+            if (existingUser != null) {
+                String linkToken = temporaryTokenStore.saveLink(
+                        new KakaoOAuthLinkTokenPayload(kakaoUserInfo.providerSubject(), email),
+                        KAKAO_TEMP_TOKEN_TTL_SECONDS
+                );
+                return KakaoOAuthLoginResult.accountLinkRequired(
+                        KakaoAccountLinkRequiredResponse.of(email, linkToken, KAKAO_TEMP_TOKEN_TTL_SECONDS)
+                );
+            }
         }
 
         validateTermsAgreed(agreedToTerms);
@@ -166,7 +168,7 @@ public class KakaoOAuthService {
             String signupToken = temporaryTokenStore.saveSignup(
                     new KakaoOAuthSignupTokenPayload(
                             kakaoUserInfo.providerSubject(),
-                            kakaoUserInfo.email(),
+                            email,
                             suggestedNickname
                     ),
                     KAKAO_TEMP_TOKEN_TTL_SECONDS
@@ -178,7 +180,7 @@ public class KakaoOAuthService {
 
         return KakaoOAuthLoginResult.signupLogin(createKakaoUserAndIssueTokens(
                 kakaoUserInfo.providerSubject(),
-                kakaoUserInfo.email(),
+                email,
                 kakaoUserInfo.nickname(),
                 context
         ));
@@ -191,7 +193,9 @@ public class KakaoOAuthService {
             AuthTokenRequestContext context
     ) {
         User user = User.create(UuidV7Generator.generate(), email, nickname);
-        user.verifyEmail();
+        if (StringUtils.hasText(email)) {
+            user.verifyEmail();
+        }
         User savedUser = userRepository.save(user);
 
         UserAuthIdentity kakaoIdentity = UserAuthIdentity.createOAuth(
@@ -206,10 +210,9 @@ public class KakaoOAuthService {
         return authTokenService.issueTokens(savedUser, context);
     }
 
-    private void validateUsableKakaoEmail(KakaoUserInfo kakaoUserInfo) {
-        if (!kakaoUserInfo.hasUsableEmail()) {
-            throw new CustomException(ErrorCode.AUTH_OAUTH_EMAIL_REQUIRED);
-        }
+    private String resolveUsableEmail(KakaoUserInfo kakaoUserInfo) {
+        // 제공 동의된 검증 이메일만 저장·연동 대상, 그 외 소셜 전용 계정 처리 위해 null 반환
+        return kakaoUserInfo.hasUsableEmail() ? kakaoUserInfo.email() : null;
     }
 
     private void validateTermsAgreed(Boolean agreedToTerms) {

--- a/src/main/java/com/f1/quiket/domain/user/entity/User.java
+++ b/src/main/java/com/f1/quiket/domain/user/entity/User.java
@@ -37,7 +37,7 @@ public class User extends BaseEntity {
     @Column(name = "public_id", length = 36, nullable = false)
     String publicId;
 
-    @Column(name = "email", length = 255, nullable = false)
+    @Column(name = "email", length = 255)
     String email;
 
     @Column(length = 36, nullable = false)

--- a/src/main/resources/db/migration/V17__make_users_email_nullable.sql
+++ b/src/main/resources/db/migration/V17__make_users_email_nullable.sql
@@ -1,0 +1,4 @@
+-- users.email 선택값 전환
+-- 소셜(kakao) 전용 계정의 이메일 미보유 허용, uq_users_email은 다중 NULL 허용으로 유지
+ALTER TABLE users
+    MODIFY email VARCHAR(255) NULL COMMENT '사용자 이메일, 소셜 전용 계정은 NULL';

--- a/src/test/java/com/f1/quiket/domain/auth/service/KakaoOAuthServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/auth/service/KakaoOAuthServiceTest.java
@@ -3,8 +3,10 @@ package com.f1.quiket.domain.auth.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -143,31 +145,50 @@ class KakaoOAuthServiceTest {
     }
 
     @Test
-    void login_fails_when_kakao_email_is_missing() {
-        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token");
+    void login_creates_email_less_user_when_kakao_email_is_missing() {
+        KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token", true);
         when(kakaoApiClient.getUserInfo("kakao-access-token"))
                 .thenReturn(new KakaoUserInfo("123456789", null, null, null, "카카오"));
         when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
                 .thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(userAuthIdentityRepository.save(any(UserAuthIdentity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(authTokenService.issueTokens(any(User.class), any(AuthTokenRequestContext.class)))
+                .thenAnswer(invocation -> tokenResponse(invocation.getArgument(0), List.of()));
 
-        assertThatThrownBy(() -> kakaoOAuthService.login(request, tokenRequestContext()))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.AUTH_OAUTH_EMAIL_REQUIRED);
+        KakaoOAuthLoginResult result = kakaoOAuthService.login(request, tokenRequestContext());
+
+        assertThat(result.getStatus()).isEqualTo(KakaoOAuthLoginStatus.SIGNUP_LOGIN);
+        assertThat(result.getTokenResponse().getUser().getEmail()).isNull();
+        assertThat(result.getTokenResponse().getUser().isEmailVerified()).isFalse();
+        // 이메일 미보유 시 계정 연동 조회 미수행
+        verify(userRepository, never()).findByEmailAndDeletedAtIsNull(anyString());
+
+        ArgumentCaptor<UserAuthIdentity> identityCaptor = ArgumentCaptor.forClass(UserAuthIdentity.class);
+        verify(userAuthIdentityRepository).save(identityCaptor.capture());
+        assertThat(identityCaptor.getValue().getProviderSubject()).isEqualTo("123456789");
     }
 
     @Test
-    void login_fails_when_kakao_email_flags_are_missing() {
+    void login_creates_email_less_user_when_kakao_email_is_not_verified() {
         KakaoLoginRequest request = kakaoLoginRequest("kakao-access-token", true);
         when(kakaoApiClient.getUserInfo("kakao-access-token"))
                 .thenReturn(new KakaoUserInfo("123456789", "user@example.com", null, null, "카카오"));
         when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
                 .thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(userAuthIdentityRepository.save(any(UserAuthIdentity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(authTokenService.issueTokens(any(User.class), any(AuthTokenRequestContext.class)))
+                .thenAnswer(invocation -> tokenResponse(invocation.getArgument(0), List.of()));
 
-        assertThatThrownBy(() -> kakaoOAuthService.login(request, tokenRequestContext()))
-                .isInstanceOf(CustomException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.AUTH_OAUTH_EMAIL_REQUIRED);
+        KakaoOAuthLoginResult result = kakaoOAuthService.login(request, tokenRequestContext());
+
+        assertThat(result.getStatus()).isEqualTo(KakaoOAuthLoginStatus.SIGNUP_LOGIN);
+        // 미검증 카카오 이메일은 저장·연동 대상 제외
+        assertThat(result.getTokenResponse().getUser().getEmail()).isNull();
+        verify(userRepository, never()).findByEmailAndDeletedAtIsNull(anyString());
     }
 
     @Test
@@ -241,6 +262,28 @@ class KakaoOAuthServiceTest {
 
         assertThat(response.getUser().getEmail()).isEqualTo("new@example.com");
         assertThat(response.getUser().getNickname()).isEqualTo("도토리");
+        verify(temporaryTokenStore).deleteSignup("signup-token");
+    }
+
+    @Test
+    void completeNickname_creates_email_less_user_from_signup_token() {
+        KakaoNicknameRequest request = kakaoNicknameRequest("signup-token", "도토리");
+        when(temporaryTokenStore.findSignup("signup-token"))
+                .thenReturn(Optional.of(new KakaoOAuthSignupTokenPayload("123456789", null, null)));
+        when(userAuthIdentityRepository.findByProviderAndProviderSubjectAndDeletedAtIsNull("kakao", "123456789"))
+                .thenReturn(Optional.empty());
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(userAuthIdentityRepository.save(any(UserAuthIdentity.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(authTokenService.issueTokens(any(User.class), any(AuthTokenRequestContext.class)))
+                .thenAnswer(invocation -> tokenResponse(invocation.getArgument(0), List.of()));
+
+        AuthTokenResponse response = kakaoOAuthService.completeNickname(request, tokenRequestContext());
+
+        assertThat(response.getUser().getEmail()).isNull();
+        assertThat(response.getUser().isEmailVerified()).isFalse();
+        assertThat(response.getUser().getNickname()).isEqualTo("도토리");
+        verify(userRepository, never()).existsByEmail(anyString());
         verify(temporaryTokenStore).deleteSignup("signup-token");
     }
 


### PR DESCRIPTION
## 🧩 Description

- 카카오 `account_email` 미제공 상태에서도 `provider_subject` 기준으로 신규 가입 및 로그인을 처리합니다
- 검증된 카카오 이메일이 있을 때만 기존 local 계정 연동 분기를 유지합니다
- 소셜 전용 사용자를 위해 `users.email`을 선택값으로 전환합니다

---

## 🛠️ Changes

- `users.email` nullable 전환 Flyway V17 마이그레이션 추가
- `User` 엔티티 이메일 nullable 매핑 반영
- 카카오 이메일 검증 실패 시 이메일을 저장하지 않고 신규 가입 처리
- 이메일 보유 시에만 local 계정 이메일 조회 및 연동 토큰 발급
- 이메일 없는 닉네임 보완 가입 경로 지원
- DDL 및 OpenAPI 이메일 nullable 계약 반영
- 신규/기존 카카오 로그인 및 이메일 없는 가입 테스트 보완

---

## 🧪 How to Test

1. `./gradlew test --tests com.f1.quiket.domain.auth.service.KakaoOAuthServiceTest --tests com.f1.quiket.infra.kakao.client.KakaoApiClientTest`
2. `./gradlew test`
3. `git diff --check origin/develop...HEAD`

---

## 🔗 Related Issue

Closes #159

---

## ⚠️ Notes

- 운영 배포 시 V17 마이그레이션으로 `users.email`의 `NOT NULL` 제약이 해제됩니다
- 이메일 미제공 카카오 사용자는 동일 이메일의 기존 local 계정을 자동 탐지할 수 없습니다
- `(provider, provider_subject)` 유니크 제약으로 카카오 계정 식별 중복을 방지합니다

---

## 🧑‍💻 Assignee

- @imclaremont
