### PR TITLE
[Chore] 운영 환경 에러 로그 파일 분리 설정

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <property name="LOG_DIR" value="/var/log/quicket"/>
-    <property name="LOG_FILE" value="application.log"/>
     <property name="LOG_PATTERN"
               value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
 
@@ -12,16 +11,34 @@
     </appender>
 
     <appender name="ROLLING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${LOG_DIR}/${LOG_FILE}</file>
+        <file>${LOG_DIR}/application.log</file>
         <encoder>
             <pattern>${LOG_PATTERN}</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_DIR}/%d{yyyy-MM}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${LOG_DIR}/%d{yyyy-MM, aux}/application.%d{yyyy-MM-dd_HH-mm}.log</fileNamePattern>
             <maxHistory>90</maxHistory>
             <!-- 로그 아카이브 총량 상한 - maxHistory(90일)와 둘 중 먼저 충족되는 조건으로
                  오래된 아카이브부터 삭제, 디스크 폭주 방어
                  프리티어 EBS 30GB 기준 약 10% -->
+            <totalSizeCap>3GB</totalSizeCap>
+            <cleanHistoryOnStart>true</cleanHistoryOnStart>
+        </rollingPolicy>
+    </appender>
+
+    <appender name="ROLLING_FILE_ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/error.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/%d{yyyy-MM}/error.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>90</maxHistory>
             <totalSizeCap>3GB</totalSizeCap>
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>
@@ -36,6 +53,7 @@
     <springProfile name="prod">
         <root level="INFO">
             <appender-ref ref="ROLLING_FILE"/>
+            <appender-ref ref="ROLLING_FILE_ERROR"/>
         </root>
     </springProfile>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -16,7 +16,7 @@
             <pattern>${LOG_PATTERN}</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_DIR}/%d{yyyy-MM, aux}/application.%d{yyyy-MM-dd_HH-mm}.log</fileNamePattern>
+            <fileNamePattern>${LOG_DIR}/%d{yyyy-MM, aux}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>90</maxHistory>
             <!-- 로그 아카이브 총량 상한 - maxHistory(90일)와 둘 중 먼저 충족되는 조건으로
                  오래된 아카이브부터 삭제, 디스크 폭주 방어
@@ -37,8 +37,11 @@
             <pattern>${LOG_PATTERN}</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_DIR}/%d{yyyy-MM}/error.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <fileNamePattern>${LOG_DIR}/%d{yyyy-MM, aux}/error.%d{yyyy-MM-dd}.log</fileNamePattern>
             <maxHistory>90</maxHistory>
+            <!-- 로그 아카이브 총량 상한 - maxHistory(90일)와 둘 중 먼저 충족되는 조건으로
+                 오래된 아카이브부터 삭제, 디스크 폭주 방어
+                 프리티어 EBS 30GB 기준 약 10% -->
             <totalSizeCap>3GB</totalSizeCap>
             <cleanHistoryOnStart>true</cleanHistoryOnStart>
         </rollingPolicy>


### PR DESCRIPTION
## 🧩 Description

- 운영 환경 로그 레벨 `INFO` 이상 출력 유지
- `ERROR` 레벨 로그를 별도 파일로 분리 저장
- 로그 파일 월별 폴더 경로 하위 롤링 적용
- 로그 파일 최대 90일 보관 정책 적용

---

## 🛠️ Changes

- `ROLLING_FILE_ERROR` appender 추가 — `LevelFilter`로 ERROR 레벨만 수집
- 에러 로그 파일 경로: 
    - 컨테이너 내부 `/var/log/quicket/error.log` 
    - EC2 호스트 `{배포경로}/logs/error.log`
- 에러 로그 롤링 경로: 
    - 컨테이너 내부 `/var/log/quicket/{yyyy-MM}/error.{yyyy-MM-dd}.log`
    - EC2 호스트 `{배포경로}/logs/{yyyy-MM}/error.{yyyy-MM-dd}.log`
- 에러 로그 보관 정책: 90일 / 총 3GB cap
- 불필요한 `LOG_FILE` 프로퍼티 제거 후 파일 경로 인라인 처리

---

## 🧪 How to Test

1. `prod` 프로파일로 애플리케이션 실행
2. INFO 로그 발생 확인 → `application.log`에 기록되는지 확인
3. ERROR 로그 발생 확인 → `error.log`에만 기록되는지, `application.log`에도 기록되는지 확인
4. 날짜 변경 후 월별 폴더(`yyyy-MM/`)에 롤링 파일 생성 확인

---

## 🔗 Related Issue

Closes #154

---

## ⚠️ Notes

- 일반 로그(`application.log`)와 에러 로그(`error.log`)는 동일한 롤링/보관 정책 적용
- `local` 프로파일 동작은 변경 없음

---

## 🧑‍💻 Assignee

- @ja2hoon