### PR TITLE
[Chore] 운영 datasource 주석 정정

### DIFF
--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -2,7 +2,7 @@ server:
   port: 8080
 
 spring:
-  # MySQL - AWS RDS
+  # MySQL - DB 호스트 QUIKET_DB_HOST 주입
   datasource:
     url: jdbc:mysql://${QUIKET_DB_HOST}:3306/quiket?useSSL=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${QUIKET_DB_USERNAME}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 운영 datasource 주석을 실제 인프라 구성에 맞게 정정

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `application-prod.yaml` datasource 주석 `# MySQL - AWS RDS` → `# MySQL - DB 호스트 QUIKET_DB_HOST 주입`

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `src/main/resources/application-prod.yaml` 5번째 줄 주석 확인
2. 실제 DB 연결은 `QUIKET_DB_HOST` 환경변수로 주입됨을 확인 (현재 EC2 로컬 MySQL)

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #166

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 실제 운영은 RDS가 아닌 EC2 로컬 MySQL(`QUIKET_DB_HOST` 주입)에 연결되어 기존 주석과 불일치했음
- 향후 RDS 분리(#165) 진행 시 주석 재정정 가능
- 단순 주석 정정으로 동작 변경 없음

---

## 🧑‍💻 Assignee

- @imclaremont
