### PR TITLE
[Fix] 강의 업로드 실패 응답 failCode / failMessage / failReason 상세화 (#164)

### DIFF
--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -1170,6 +1170,66 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LectureUploadStatusResponse'
+              examples:
+                processing:
+                  summary: 처리 중
+                  value:
+                    success: true
+                    code: S001
+                    message: 요청이 성공했습니다.
+                    data:
+                      lectureUploadId: 019ed89b-d7a4-7e4f-ab01-5c4ea81b78a0
+                      subjectId: 019ec53a-d489-7727-9320-ddfb25222efd
+                      chapterId: 019ed89b-d78d-7649-9993-acbc5aa76ddd
+                      chapterName: 새 챕터
+                      status: processing
+                      progressPct: 40
+                      estimatedSeconds: 30
+                      parts: []
+                      failCode: null
+                      failMessage: null
+                      failReason: null
+                completed:
+                  summary: 처리 완료
+                  value:
+                    success: true
+                    code: S001
+                    message: 요청이 성공했습니다.
+                    data:
+                      lectureUploadId: 019ed89b-d7a4-7e4f-ab01-5c4ea81b78a0
+                      subjectId: 019ec53a-d489-7727-9320-ddfb25222efd
+                      chapterId: 019ed89b-d78d-7649-9993-acbc5aa76ddd
+                      chapterName: 1장 데이터 모델링
+                      status: completed
+                      progressPct: 100
+                      estimatedSeconds: null
+                      parts:
+                        - id: 018f8c2e-7001-7d4e-9404-4440c3f4ad21
+                          chapterId: 019ed89b-d78d-7649-9993-acbc5aa76ddd
+                          name: 데이터 모델링 개념
+                          partNumber: 1
+                          contentPreview: 데이터 모델링은 현실 세계의 데이터를...
+                      failCode: null
+                      failMessage: null
+                      failReason: null
+                failed:
+                  summary: 처리 실패
+                  value:
+                    success: true
+                    code: S001
+                    message: 요청이 성공했습니다.
+                    data:
+                      lectureUploadId: 019ed89b-d7a4-7e4f-ab01-5c4ea81b78a0
+                      subjectId: 019ec53a-d489-7727-9320-ddfb25222efd
+                      chapterId: 019ed89b-d78d-7649-9993-acbc5aa76ddd
+                      chapterName: 새 챕터
+                      status: failed
+                      progressPct: 100
+                      estimatedSeconds: 30
+                      parts: []
+                      failCode: LECTURE_CONTENT_ERROR
+                      failMessage: "파일을 확인해 주세요. (손상·암호화 PDF, 내용이 너무 많은 파일은 처리할 수 없어요)"
+                      failReason: 파일 내용이 너무 많음
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -3472,10 +3532,56 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/PartSummary'
+            failCode:
+              $ref: '#/components/schemas/LectureUploadFailCode'
+            failMessage:
+              type: string
+              nullable: true
+              description: 사용자에게 표시할 실패 안내 메시지. status가 failed일 때만 존재
+              example: "파일을 확인해 주세요. (손상·암호화 PDF, 내용이 너무 많은 파일은 처리할 수 없어요)"
             failReason:
               type: string
               nullable: true
-              example: OCR 처리 실패
+              description: |
+                시스템 내부 실패 원인. status가 failed일 때만 존재. 클라이언트에 노출하지 않음.
+
+                | failCode | failReason |
+                |---|---|
+                | LECTURE_CONTENT_ERROR | 손상·암호화 PDF |
+                | LECTURE_CONTENT_ERROR | 파일 내용이 너무 많음 |
+                | LECTURE_CONTENT_ERROR | AI가 텍스트 판독 불가 판단 |
+                | LECTURE_AI_ERROR | Groq content 필드 없음 |
+                | LECTURE_AI_ERROR | Gemini content 필드 없음 |
+                | LECTURE_AI_ERROR | AI 응답 자체가 빈 문자열 |
+                | LECTURE_AI_ERROR | AI가 유효한 JSON을 반환하지 않음 |
+                | LECTURE_AI_ERROR | AI가 parts 배열 미반환 |
+                | LECTURE_AI_ERROR | parts 아이템에 필수 필드 누락 |
+                | LECTURE_INFRA_ERROR | Groq 서버 장애·네트워크 단절 |
+                | LECTURE_INFRA_ERROR | Gemini 서버 장애 (재시도 소진 후) |
+                | LECTURE_INFRA_ERROR | 재시도 중 스레드 인터럽트 |
+                | LECTURE_INFRA_ERROR | 명시된 에러 외 예외 fallback |
+                | LECTURE_CONFIG_ERROR | GROQ_API_KEY 미설정 |
+                | LECTURE_CONFIG_ERROR | GEMINI_API_KEY 미설정 |
+              example: 파일 내용이 너무 많음
+
+    LectureUploadFailCode:
+      type: string
+      nullable: true
+      description: |
+        실패 분류 코드. status가 failed일 때만 존재.
+
+        | failCode | failMessage (클라이언트 노출용) |
+        |---|---|
+        | LECTURE_CONTENT_ERROR | 파일을 확인해 주세요. (손상·암호화 PDF, 내용이 너무 많은 파일은 처리할 수 없어요) |
+        | LECTURE_AI_ERROR | 처리에 실패했어요. 잠시 후 다시 시도해 주세요. |
+        | LECTURE_INFRA_ERROR | 일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요. |
+        | LECTURE_CONFIG_ERROR | 서비스 오류가 발생했어요. 고객센터에 문의해 주세요. |
+      enum:
+        - LECTURE_CONTENT_ERROR
+        - LECTURE_AI_ERROR
+        - LECTURE_INFRA_ERROR
+        - LECTURE_CONFIG_ERROR
+      example: LECTURE_CONTENT_ERROR
 
     LectureUploadStatus:
       type: string

--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Quiket MVP API
-  version: 1.0.2
+  version: 1.0.3
   description: |
     Quiket MVP API 명세
 

--- a/docs/openapi/quiket-mvp-api.yaml
+++ b/docs/openapi/quiket-mvp-api.yaml
@@ -3533,7 +3533,9 @@ components:
               items:
                 $ref: '#/components/schemas/PartSummary'
             failCode:
-              $ref: '#/components/schemas/LectureUploadFailCode'
+              nullable: true
+              allOf:
+                - $ref: '#/components/schemas/LectureUploadFailCode'
             failMessage:
               type: string
               nullable: true

--- a/src/main/java/com/f1/quiket/domain/lecture/dto/LectureUploadStatusResponse.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/dto/LectureUploadStatusResponse.java
@@ -32,8 +32,9 @@ public class LectureUploadStatusResponse {
     private final Integer estimatedSeconds;
     private final Integer progressPct;
     private final List<PartSummary> parts;
-    private final String failCode;
-    private final String failMessage;
+    private final String failCode;  // ErrorCode enum name
+    private final String failMessage;   // ErrorCode에 매핑되는 사용자 노출용 메시지
+    private final String failReason;    // AI 또는 시스템에서 반환하는 상세 실패 사유 (DB저장용, 사용자 노출 X)
 
     /**
      * 업로드 상태 응답 생성
@@ -58,6 +59,7 @@ public class LectureUploadStatusResponse {
                         .toList())
                 .failCode(processingJob == null ? null : processingJob.getFailCode())
                 .failMessage(resolveFailMessage(processingJob))
+                .failReason(processingJob == null ? null : processingJob.getFailReason())
                 .build();
     }
 
@@ -68,7 +70,7 @@ public class LectureUploadStatusResponse {
         try {
             return ErrorCode.valueOf(processingJob.getFailCode()).getMessage();
         } catch (IllegalArgumentException e) {
-            return null;
+            return ErrorCode.LECTURE_INFRA_ERROR.getMessage();
         }
     }
 

--- a/src/main/java/com/f1/quiket/domain/lecture/dto/LectureUploadStatusResponse.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/dto/LectureUploadStatusResponse.java
@@ -2,6 +2,7 @@ package com.f1.quiket.domain.lecture.dto;
 
 import com.f1.quiket.domain.chapter.entity.Chapter;
 import com.f1.quiket.domain.lecture.entity.LectureProcessingJob;
+import com.f1.quiket.global.response.ErrorCode;
 import com.f1.quiket.domain.lecture.entity.LectureUpload;
 import com.f1.quiket.domain.lecture.entity.LectureUploadStatus;
 import com.f1.quiket.domain.part.entity.Part;
@@ -31,7 +32,8 @@ public class LectureUploadStatusResponse {
     private final Integer estimatedSeconds;
     private final Integer progressPct;
     private final List<PartSummary> parts;
-    private final String failReason;
+    private final String failCode;
+    private final String failMessage;
 
     /**
      * 업로드 상태 응답 생성
@@ -54,8 +56,20 @@ public class LectureUploadStatusResponse {
                 .parts(parts.stream()
                         .map(part -> PartSummary.of(part, chapter))
                         .toList())
-                .failReason(processingJob == null ? null : processingJob.getFailReason())
+                .failCode(processingJob == null ? null : processingJob.getFailCode())
+                .failMessage(resolveFailMessage(processingJob))
                 .build();
+    }
+
+    private static String resolveFailMessage(LectureProcessingJob processingJob) {
+        if (processingJob == null || processingJob.getFailCode() == null) {
+            return null;
+        }
+        try {
+            return ErrorCode.valueOf(processingJob.getFailCode()).getMessage();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private static int progressPct(LectureUpload upload) {

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
@@ -183,7 +183,8 @@ public class LectureMaterialAiProcessor {
             String normalized = normalizeJson(aiResponse);
             return objectMapper.readValue(normalized, LecturePartsPayload.class);
         } catch (JsonProcessingException e) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답 파싱에 실패했습니다.", e);
+            log.warn("AI response JSON parsing failed. response={}", aiResponse, e);
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, e);
         }
     }
 
@@ -191,8 +192,13 @@ public class LectureMaterialAiProcessor {
      * Gemini 파트 분류 응답 파싱 (content 포함)
      */
     private List<LecturePartDraft> parseParts(LecturePartsPayload payload) {
+        if (Boolean.TRUE.equals(payload.getUnreadable())) {
+            log.warn("AI reported file content is unreadable");
+            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR);
+        }
         if (payload.getParts() == null || payload.getParts().isEmpty()) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답에 파트 정보가 없습니다.");
+            log.warn("AI response returned no parts");
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
         }
 
         List<LecturePartDraft> parts = new ArrayList<>();
@@ -200,7 +206,8 @@ public class LectureMaterialAiProcessor {
             // name/partName 호환 응답 처리
             String resolvedName = StringUtils.hasText(part.getName()) ? part.getName() : part.getPartName();
             if (part.getPartNumber() == null || !StringUtils.hasText(resolvedName)) {
-                throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답 파트 형식이 올바르지 않습니다.");
+                log.warn("AI response part format invalid. partNumber={}", part.getPartNumber());
+                throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
             }
             parts.add(LecturePartDraft.builder()
                     .partNumber(part.getPartNumber())
@@ -351,7 +358,7 @@ public class LectureMaterialAiProcessor {
 
     private int addPart(List<LecturePartDraft> parts, int partNumber, String name, String content) {
         if (!StringUtils.hasText(content)) {
-            log.warn("Groq 공백 파트 범위 무시 partNumber={}, name={}", partNumber, name);
+            log.warn("Groq part range is empty. Skipping range handling. partNumber={}, name={}", partNumber, name);
             return partNumber;
         }
         parts.add(LecturePartDraft.builder()
@@ -398,7 +405,8 @@ public class LectureMaterialAiProcessor {
      */
     private String normalizeJson(String aiResponse) {
         if (!StringUtils.hasText(aiResponse)) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답이 비어 있습니다.");
+            log.warn("AI response is empty");
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
         }
         String trimmed = aiResponse.trim();
         // 마크다운 코드블록 응답 제거
@@ -425,6 +433,8 @@ public class LectureMaterialAiProcessor {
         /** chapterName 미지정 시 AI가 강의 내용 기반으로 생성한 챕터명 */
         private String chapterName;
         private List<LecturePartPayload> parts;
+        /** Gemini가 파일의 텍스트를 전혀 판독할 수 없을 때 true 반환 */
+        private Boolean unreadable;
     }
 
     @Getter

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
@@ -207,7 +207,7 @@ public class LectureMaterialAiProcessor {
             return objectMapper.readValue(normalized, LecturePartsPayload.class);
         } catch (JsonProcessingException e) {
             log.warn("AI response JSON parsing failed. response={}", aiResponse, e);
-            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, e);
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "AI가 유효한 JSON을 반환하지 않음", e);
         }
     }
 
@@ -220,11 +220,11 @@ public class LectureMaterialAiProcessor {
     private List<LecturePartDraft> parseParts(LecturePartsPayload payload) {
         if (Boolean.TRUE.equals(payload.getUnreadable())) {
             log.warn("AI reported file content is unreadable");
-            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR);
+            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "AI가 텍스트 판독 불가 판단 (이미지 레이어 PDF,이미지)");
         }
         if (payload.getParts() == null || payload.getParts().isEmpty()) {
             log.warn("AI response returned no parts");
-            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "AI가 parts 배열 미반환");
         }
 
         List<LecturePartDraft> parts = new ArrayList<>();
@@ -233,7 +233,7 @@ public class LectureMaterialAiProcessor {
             String resolvedName = StringUtils.hasText(part.getName()) ? part.getName() : part.getPartName();
             if (part.getPartNumber() == null || !StringUtils.hasText(resolvedName)) {
                 log.warn("AI response part format invalid. partNumber={}", part.getPartNumber());
-                throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
+                throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "parts 아이템에 필수 필드 누락");
             }
             parts.add(LecturePartDraft.builder()
                     .partNumber(part.getPartNumber())
@@ -442,7 +442,7 @@ public class LectureMaterialAiProcessor {
     private String normalizeJson(String aiResponse) {
         if (!StringUtils.hasText(aiResponse)) {
             log.warn("AI response is empty");
-            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "AI 응답 자체가 빈 문자열");
         }
         String trimmed = aiResponse.trim();
         // 마크다운 코드블록 응답 제거

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
@@ -42,6 +42,9 @@ public class LectureMaterialAiProcessor {
 
     /**
      * 업로드 타입별 강의 자료 AI 처리
+     *
+     * @param request AI 처리 요청
+     * @return AI 처리 결과
      */
     public LectureMaterialAiProcessResult process(LectureMaterialAiProcessRequest request) {
         validateRequest(request);
@@ -56,7 +59,11 @@ public class LectureMaterialAiProcessor {
 
     /**
      * 이미지 OCR 및 파트 분류 처리
-     * chapterName 미지정 시 AI 응답에서 생성된 챕터명 추출
+     *
+     * chapterName 미지정 시 AI 응답의 생성 챕터명 포함
+     *
+     * @param request AI 처리 요청
+     * @return 이미지 AI 처리 결과
      */
     private LectureMaterialAiProcessResult processImage(LectureMaterialAiProcessRequest request) {
         StudyMaterialAiPrompt prompt = promptBuilder.buildGeminiPrompt(request, null);
@@ -77,7 +84,11 @@ public class LectureMaterialAiProcessor {
 
     /**
      * PDF 텍스트 레이어 판별 후 AI 처리
-     * chapterName 미지정 시 AI 응답에서 생성된 챕터명 추출
+     *
+     * chapterName 미지정 시 AI 응답의 생성 챕터명 포함
+     *
+     * @param request AI 처리 요청
+     * @return PDF AI 처리 결과
      */
     private LectureMaterialAiProcessResult processPdf(LectureMaterialAiProcessRequest request) {
         StudyMaterialFile pdfFile = request.getFiles().get(0);
@@ -118,7 +129,11 @@ public class LectureMaterialAiProcessor {
 
     /**
      * 직접 입력 텍스트 기반 파트 분류 처리
-     * chapterName 미지정 시 AI 응답에서 생성된 챕터명 추출
+     *
+     * chapterName 미지정 시 AI 응답의 생성 챕터명 포함
+     *
+     * @param request AI 처리 요청
+     * @return 텍스트 AI 처리 결과
      */
     private LectureMaterialAiProcessResult processText(LectureMaterialAiProcessRequest request) {
         StudyMaterialAiPrompt prompt = promptBuilder.buildGroqPrompt(request, request.getText());
@@ -139,8 +154,11 @@ public class LectureMaterialAiProcessor {
     /**
      * chapterName 미지정 요청에서 AI가 생성한 챕터명 추출
      *
-     * 사용자가 이미 챕터명을 제공했거나 AI 응답에 챕터명이 없으면 null 반환
-     * 유효하지 않은 챕터명(31자 이상)도 null로 처리하여 폴백("새 챕터") 유지
+     * 사용자 입력 챕터명 또는 유효하지 않은 AI 응답이면 null 반환
+     *
+     * @param request AI 처리 요청
+     * @param payload AI 응답 페이로드
+     * @return AI 생성 챕터명 또는 null
      */
     private String resolveGeneratedChapterName(LectureMaterialAiProcessRequest request, LecturePartsPayload payload) {
         // 사용자가 챕터명을 직접 제공한 경우 AI 생성 불필요
@@ -150,7 +168,7 @@ public class LectureMaterialAiProcessor {
         String generatedName = payload.getChapterName();
         // 30자 초과 응답은 유효하지 않으므로 null 처리 (폴백 "새 챕터" 유지)
         if (!StringUtils.hasText(generatedName) || generatedName.trim().length() > 30) {
-            log.warn("AI 챕터명 생성 실패 또는 유효하지 않은 챕터명. 폴백 유지. generatedName={}", generatedName);
+            log.warn("AI generated chapter name is empty or invalid. generatedName={}", generatedName);
             return null;
         }
         return generatedName.trim();
@@ -158,6 +176,8 @@ public class LectureMaterialAiProcessor {
 
     /**
      * AI 처리 요청값 검증
+     *
+     * @param request AI 처리 요청
      */
     private void validateRequest(LectureMaterialAiProcessRequest request) {
         if (request == null || request.getUploadType() == null || request.getPartSplitMethod() == null) {
@@ -177,6 +197,9 @@ public class LectureMaterialAiProcessor {
      *
      * normalizeJson 후 LecturePartsPayload로 변환
      * 이후 parseParts 또는 parseGroqParts에서 파트 목록으로 추출
+     *
+     * @param aiResponse AI 원본 응답
+     * @return AI 응답 페이로드
      */
     private LecturePartsPayload parsePayload(String aiResponse) {
         try {
@@ -190,6 +213,9 @@ public class LectureMaterialAiProcessor {
 
     /**
      * Gemini 파트 분류 응답 파싱 (content 포함)
+     *
+     * @param payload AI 응답 페이로드
+     * @return 파트 초안 목록
      */
     private List<LecturePartDraft> parseParts(LecturePartsPayload payload) {
         if (Boolean.TRUE.equals(payload.getUnreadable())) {
@@ -222,96 +248,100 @@ public class LectureMaterialAiProcessor {
      * Groq 라인 범위 응답 파싱 및 원문 분리
      *
      * JSON 파싱은 parsePayload에서 완료된 상태로 진입
+     *
+     * @param payload AI 응답 페이로드
+     * @param sourceText 원문 텍스트
+     * @return 파트 초안 목록
      */
     private List<LecturePartDraft> parseGroqParts(LecturePartsPayload payload, String sourceText) {
         List<LineSpan> lineSpans = lineSpans(sourceText);
         if (payload.getParts() == null || payload.getParts().isEmpty()) {
-                log.warn("Groq 파트 범위 응답 없음, 전체 원문 미분류 처리 totalLineCount={}", lineSpans.size());
-                return List.of(unclassifiedPart(1, sourceText, lineSpans, 1, lineSpans.size()));
-            }
+            log.warn("Groq response returned no part ranges. totalLineCount={}", lineSpans.size());
+            return List.of(unclassifiedPart(1, sourceText, lineSpans, 1, lineSpans.size()));
+        }
 
-            List<LecturePartPayload> sortedParts = payload.getParts().stream()
-                    .filter(this::isValidGroqPartPayload)
-                    .sorted(Comparator.comparing(LecturePartPayload::getPartNumber))
-                    .toList();
-            if (sortedParts.size() != payload.getParts().size()) {
+        List<LecturePartPayload> sortedParts = payload.getParts().stream()
+                .filter(this::isValidGroqPartPayload)
+                .sorted(Comparator.comparing(LecturePartPayload::getPartNumber))
+                .toList();
+        if (sortedParts.size() != payload.getParts().size()) {
+            log.warn(
+                    "Some Groq part ranges are invalid. requestedParts={}, validParts={}",
+                    payload.getParts().size(),
+                    sortedParts.size()
+            );
+        }
+        if (sortedParts.isEmpty()) {
+            log.warn("Groq response returned no valid part ranges. totalLineCount={}", lineSpans.size());
+            return List.of(unclassifiedPart(1, sourceText, lineSpans, 1, lineSpans.size()));
+        }
+
+        List<LecturePartDraft> parts = new ArrayList<>();
+        int nextSourceLine = 1;
+        int nextPartNumber = 1;
+        for (LecturePartPayload part : sortedParts) {
+            int startLine = Math.max(1, part.getStartLine());
+            int endLine = Math.min(lineSpans.size(), part.getEndLine());
+            if (startLine > lineSpans.size() || endLine < 1) {
                 log.warn(
-                        "Groq 파트 범위 응답 형식 일부 무시 requestedParts={}, validParts={}",
-                        payload.getParts().size(),
-                        sortedParts.size()
-                );
-            }
-            if (sortedParts.isEmpty()) {
-                log.warn("Groq 유효 파트 범위 없음, 전체 원문 미분류 처리 totalLineCount={}", lineSpans.size());
-                return List.of(unclassifiedPart(1, sourceText, lineSpans, 1, lineSpans.size()));
-            }
-
-            List<LecturePartDraft> parts = new ArrayList<>();
-            int nextSourceLine = 1;
-            int nextPartNumber = 1;
-            for (LecturePartPayload part : sortedParts) {
-                int startLine = Math.max(1, part.getStartLine());
-                int endLine = Math.min(lineSpans.size(), part.getEndLine());
-                if (startLine > lineSpans.size() || endLine < 1) {
-                    log.warn(
-                            "Groq 파트 범위 원문 밖 위치 무시 partNumber={}, startLine={}, endLine={}, totalLineCount={}",
-                            part.getPartNumber(),
-                            part.getStartLine(),
-                            part.getEndLine(),
-                            lineSpans.size()
-                    );
-                    continue;
-                }
-                if (startLine > nextSourceLine) {
-                    log.warn(
-                            "Groq 파트 누락 범위 미분류 처리 missingStartLine={}, missingEndLine={}",
-                            nextSourceLine,
-                            startLine - 1
-                    );
-                    nextPartNumber = addUnclassifiedPart(
-                            parts,
-                            nextPartNumber,
-                            sourceText,
-                            lineSpans,
-                            nextSourceLine,
-                            startLine - 1
-                    );
-                }
-                if (startLine < nextSourceLine) {
-                    log.warn(
-                            "Groq 파트 중복 범위 보정 partNumber={}, originalStartLine={}, adjustedStartLine={}",
-                            part.getPartNumber(),
-                            startLine,
-                            nextSourceLine
-                    );
-                    startLine = nextSourceLine;
-                }
-                if (endLine < startLine) {
-                    log.warn(
-                            "Groq 파트 범위 중복으로 무시 partNumber={}, startLine={}, endLine={}",
-                            part.getPartNumber(),
-                            startLine,
-                            endLine
-                    );
-                    continue;
-                }
-
-                LineSpan start = lineSpans.get(startLine - 1);
-                LineSpan end = lineSpans.get(endLine - 1);
-                String content = sourceText.substring(start.startIndex(), end.endIndex());
-                nextPartNumber = addPart(parts, nextPartNumber, resolvePartName(part), content);
-                nextSourceLine = endLine + 1;
-            }
-
-            if (nextSourceLine <= lineSpans.size()) {
-                log.warn(
-                        "Groq 마지막 누락 범위 미분류 처리 missingStartLine={}, missingEndLine={}",
-                        nextSourceLine,
+                        "Groq part range is outside source text. partNumber={}, startLine={}, endLine={}, totalLineCount={}",
+                        part.getPartNumber(),
+                        part.getStartLine(),
+                        part.getEndLine(),
                         lineSpans.size()
                 );
-                addUnclassifiedPart(parts, nextPartNumber, sourceText, lineSpans, nextSourceLine, lineSpans.size());
+                continue;
             }
-            return parts;
+            if (startLine > nextSourceLine) {
+                log.warn(
+                        "Groq part range has missing source range. missingStartLine={}, missingEndLine={}",
+                        nextSourceLine,
+                        startLine - 1
+                );
+                nextPartNumber = addUnclassifiedPart(
+                        parts,
+                        nextPartNumber,
+                        sourceText,
+                        lineSpans,
+                        nextSourceLine,
+                        startLine - 1
+                );
+            }
+            if (startLine < nextSourceLine) {
+                log.warn(
+                        "Groq part range overlaps previous range. partNumber={}, originalStartLine={}, adjustedStartLine={}",
+                        part.getPartNumber(),
+                        startLine,
+                        nextSourceLine
+                );
+                startLine = nextSourceLine;
+            }
+            if (endLine < startLine) {
+                log.warn(
+                        "Groq part range was skipped because it overlaps previous range. partNumber={}, startLine={}, endLine={}",
+                        part.getPartNumber(),
+                        startLine,
+                        endLine
+                );
+                continue;
+            }
+
+            LineSpan start = lineSpans.get(startLine - 1);
+            LineSpan end = lineSpans.get(endLine - 1);
+            String content = sourceText.substring(start.startIndex(), end.endIndex());
+            nextPartNumber = addPart(parts, nextPartNumber, resolvePartName(part), content);
+            nextSourceLine = endLine + 1;
+        }
+
+        if (nextSourceLine <= lineSpans.size()) {
+            log.warn(
+                    "Groq part range has trailing missing source range. missingStartLine={}, missingEndLine={}",
+                    nextSourceLine,
+                    lineSpans.size()
+            );
+            addUnclassifiedPart(parts, nextPartNumber, sourceText, lineSpans, nextSourceLine, lineSpans.size());
+        }
+        return parts;
     }
 
     private boolean isValidGroqPartPayload(LecturePartPayload part) {
@@ -371,6 +401,9 @@ public class LectureMaterialAiProcessor {
 
     /**
      * 원문 라인별 문자 범위 계산
+     *
+     * @param sourceText 원문 텍스트
+     * @return 라인별 문자 범위 목록
      */
     private List<LineSpan> lineSpans(String sourceText) {
         if (!StringUtils.hasText(sourceText)) {
@@ -402,6 +435,9 @@ public class LectureMaterialAiProcessor {
 
     /**
      * AI JSON 응답 정규화
+     *
+     * @param aiResponse AI 원본 응답
+     * @return 정규화 JSON 문자열
      */
     private String normalizeJson(String aiResponse) {
         if (!StringUtils.hasText(aiResponse)) {
@@ -422,6 +458,10 @@ public class LectureMaterialAiProcessor {
 
     /**
      * 빈 문자열 기본값 처리
+     *
+     * @param value 원본 문자열
+     * @param defaultValue 기본값
+     * @return 원본 문자열 또는 기본값
      */
     private String valueOrDefault(String value, String defaultValue) {
         return StringUtils.hasText(value) ? value : defaultValue;

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
@@ -220,7 +220,7 @@ public class LectureMaterialAiProcessor {
     private List<LecturePartDraft> parseParts(LecturePartsPayload payload) {
         if (Boolean.TRUE.equals(payload.getUnreadable())) {
             log.warn("AI reported file content is unreadable");
-            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "AI가 텍스트 판독 불가 판단 (이미지 레이어 PDF,이미지)");
+            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "AI가 텍스트 판독 불가 판단");
         }
         if (payload.getParts() == null || payload.getParts().isEmpty()) {
             log.warn("AI response returned no parts");

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessor.java
@@ -257,7 +257,7 @@ public class LectureMaterialAiProcessor {
         List<LineSpan> lineSpans = lineSpans(sourceText);
         if (payload.getParts() == null || payload.getParts().isEmpty()) {
             log.warn("Groq response returned no part ranges. totalLineCount={}", lineSpans.size());
-            return List.of(unclassifiedPart(1, sourceText, lineSpans, 1, lineSpans.size()));
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "AI가 parts 배열 미반환");
         }
 
         List<LecturePartPayload> sortedParts = payload.getParts().stream()
@@ -273,7 +273,7 @@ public class LectureMaterialAiProcessor {
         }
         if (sortedParts.isEmpty()) {
             log.warn("Groq response returned no valid part ranges. totalLineCount={}", lineSpans.size());
-            return List.of(unclassifiedPart(1, sourceText, lineSpans, 1, lineSpans.size()));
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "AI가 유효한 part 범위를 반환하지 않음");
         }
 
         List<LecturePartDraft> parts = new ArrayList<>();

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiPromptBuilder.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiPromptBuilder.java
@@ -33,7 +33,15 @@ public class LectureMaterialAiPromptBuilder {
      * @param request chapterName이 null이면 챕터명 생성 지시 포함
      */
     public StudyMaterialAiPrompt buildGeminiPrompt(LectureMaterialAiProcessRequest request, String sourceText) {
-        return new StudyMaterialAiPrompt(systemMessage(needsChapterName(request)), geminiUserMessage(request, sourceText));
+        return new StudyMaterialAiPrompt(geminiSystemMessage(needsChapterName(request)), geminiUserMessage(request, sourceText));
+    }
+
+    /**
+     * Gemini 전용 시스템 메시지 - 텍스트 판독 불가 시 unreadable 응답 지시 포함
+     */
+    private String geminiSystemMessage(boolean generateChapterName) {
+        return systemMessage(generateChapterName)
+                + "파일에서 텍스트를 전혀 판독할 수 없는 경우 {\"unreadable\":true}만 반환한다.\n";
     }
 
     /**

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiPromptBuilder.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiPromptBuilder.java
@@ -22,6 +22,8 @@ public class LectureMaterialAiPromptBuilder {
      * Groq 텍스트 분류 프롬프트 생성
      *
      * @param request chapterName이 null이면 챕터명 생성 지시 포함
+     * @param sourceText 원문 텍스트
+     * @return Groq 프롬프트
      */
     public StudyMaterialAiPrompt buildGroqPrompt(LectureMaterialAiProcessRequest request, String sourceText) {
         return new StudyMaterialAiPrompt(systemMessage(needsChapterName(request)), groqUserMessage(request, sourceText));
@@ -31,13 +33,18 @@ public class LectureMaterialAiPromptBuilder {
      * Gemini OCR 및 분류 프롬프트 생성
      *
      * @param request chapterName이 null이면 챕터명 생성 지시 포함
+     * @param sourceText 추가 텍스트
+     * @return Gemini 프롬프트
      */
     public StudyMaterialAiPrompt buildGeminiPrompt(LectureMaterialAiProcessRequest request, String sourceText) {
         return new StudyMaterialAiPrompt(geminiSystemMessage(needsChapterName(request)), geminiUserMessage(request, sourceText));
     }
 
     /**
-     * Gemini 전용 시스템 메시지 - 텍스트 판독 불가 시 unreadable 응답 지시 포함
+     * Gemini 전용 시스템 메시지
+     *
+     * @param generateChapterName 챕터명 생성 여부
+     * @return Gemini 시스템 메시지
      */
     private String geminiSystemMessage(boolean generateChapterName) {
         return systemMessage(generateChapterName)
@@ -45,14 +52,20 @@ public class LectureMaterialAiPromptBuilder {
     }
 
     /**
-     * chapterName이 null이면 AI 챕터명 생성이 필요한 요청으로 판단
+     * AI 챕터명 생성 필요 여부
+     *
+     * @param request AI 처리 요청
+     * @return 챕터명 생성 필요 여부
      */
     private boolean needsChapterName(LectureMaterialAiProcessRequest request) {
         return !StringUtils.hasText(request.getChapterName());
     }
 
     /**
-     * @param generateChapterName true이면 챕터명 생성 지시 추가
+     * 공통 시스템 메시지 생성
+     *
+     * @param generateChapterName 챕터명 생성 여부
+     * @return 공통 시스템 메시지
      */
     private String systemMessage(boolean generateChapterName) {
         String base = """

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
@@ -184,7 +184,7 @@ public class LectureUploadProcessingService {
         }
         if (draft.getContent().length() > MAX_PART_CONTENT_LENGTH) {
             log.warn("Part content exceeds limit. partNumber={}, length={}", draft.getPartNumber(), draft.getContent().length());
-            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "파일 내용이 너무 많음");
+            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "파트 본문은 30,000자를 초과할 수 없습니다.");
         }
     }
 

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
@@ -184,7 +184,7 @@ public class LectureUploadProcessingService {
         }
         if (draft.getContent().length() > MAX_PART_CONTENT_LENGTH) {
             log.warn("Part content exceeds limit. partNumber={}, length={}", draft.getPartNumber(), draft.getContent().length());
-            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "파트 본문은 30,000자를 초과할 수 없습니다.");
+            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "파일 내용이 너무 많음");
         }
     }
 

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
@@ -154,7 +154,7 @@ public class LectureUploadProcessingService {
     ) {
         if (drafts == null || drafts.isEmpty()) {
             log.warn("AI response returned empty parts. lectureUploadId={}", event.lectureUploadId());
-            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "AI가 parts 배열 미반환");
         }
         // parts 저장
         return drafts.stream()
@@ -180,11 +180,11 @@ public class LectureUploadProcessingService {
                 || !StringUtils.hasText(draft.getName())
                 || !StringUtils.hasText(draft.getContent())) {
             log.warn("AI response part format invalid. partNumber={}", draft != null ? draft.getPartNumber() : null);
-            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "parts 아이템에 필수 필드 누락");
         }
         if (draft.getContent().length() > MAX_PART_CONTENT_LENGTH) {
             log.warn("Part content exceeds limit. partNumber={}, length={}", draft.getPartNumber(), draft.getContent().length());
-            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR);
+            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "파일 내용이 너무 많음");
         }
     }
 

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
@@ -244,6 +244,6 @@ public class LectureUploadProcessingService {
         if (e instanceof CustomException customException && StringUtils.hasText(customException.getMessage())) {
             return customException.getMessage();
         }
-        return "업로드에 실패하였습니다. 다시 시도해주세요";
+        return "명시된 에러 외 예외 fallback";
     }
 }

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
@@ -123,10 +123,10 @@ public class LectureUploadProcessingService {
     /**
      * chapterName 미지정 요청에서 AI 생성 챕터명으로 chapter.name 갱신
      *
-     * 사용자가 챕터명을 제공했거나 AI가 챕터명을 생성하지 못한 경우 임시명("새 챕터") 유지
+     * 사용자 입력 챕터명 또는 AI 생성 실패 시 임시명 유지
      *
-     * @param event AI 처리 요청 이벤트 (chapterName이 null이면 AI 생성 대상)
-     * @param result AI 처리 결과 (generatedChapterName이 null이면 폴백 유지)
+     * @param event AI 처리 요청 이벤트
+     * @param result AI 처리 결과
      */
     private void updateChapterNameIfGenerated(
             LectureUploadProcessingRequestedEvent event,
@@ -138,13 +138,13 @@ public class LectureUploadProcessingService {
         }
         if (!StringUtils.hasText(result.getGeneratedChapterName())) {
             // AI 챕터명 생성 실패 시 임시명("새 챕터") 유지
-            log.warn("AI 챕터명 미생성, 임시 챕터명 유지. chapterId={}", event.chapterId());
+            log.warn("AI generated chapter name is empty. chapterId={}", event.chapterId());
             return;
         }
         Chapter chapter = chapterRepository.findById(event.chapterId())
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
         chapter.updateName(result.getGeneratedChapterName());
-        log.info("AI 챕터명 업데이트 완료. chapterId={}, generatedName={}", event.chapterId(), result.getGeneratedChapterName());
+        log.info("AI generated chapter name was applied. chapterId={}, generatedName={}", event.chapterId(), result.getGeneratedChapterName());
     }
 
     private List<Part> createParts(

--- a/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
+++ b/src/main/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingService.java
@@ -84,7 +84,8 @@ public class LectureUploadProcessingService {
             saveCompleted(event, result);
         } catch (Exception e) {
             log.warn("Lecture upload processing failed. lectureUploadId={}", event.lectureUploadId(), e);
-            markFailed(event, failMessage(e));
+            ErrorCode failCode = resolveFailCode(e);
+            markFailed(event, failCode, failReason(e));
         }
     }
 
@@ -152,7 +153,8 @@ public class LectureUploadProcessingService {
             List<LecturePartDraft> drafts
     ) {
         if (drafts == null || drafts.isEmpty()) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답에 파트 정보가 없습니다.");
+            log.warn("AI response returned empty parts. lectureUploadId={}", event.lectureUploadId());
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
         }
         // parts 저장
         return drafts.stream()
@@ -177,10 +179,12 @@ public class LectureUploadProcessingService {
                 || draft.getPartNumber() < 1
                 || !StringUtils.hasText(draft.getName())
                 || !StringUtils.hasText(draft.getContent())) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "AI 응답 파트 형식이 올바르지 않습니다.");
+            log.warn("AI response part format invalid. partNumber={}", draft != null ? draft.getPartNumber() : null);
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
         }
         if (draft.getContent().length() > MAX_PART_CONTENT_LENGTH) {
-            throw new CustomException(ErrorCode.UNPROCESSABLE_ENTITY, "파트 본문은 30,000자를 초과할 수 없습니다.");
+            log.warn("Part content exceeds limit. partNumber={}, length={}", draft.getPartNumber(), draft.getContent().length());
+            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR);
         }
     }
 
@@ -198,17 +202,30 @@ public class LectureUploadProcessingService {
         return event.text();
     }
 
-    private void markFailed(LectureUploadProcessingRequestedEvent event, String failReason) {
+    private void markFailed(LectureUploadProcessingRequestedEvent event, ErrorCode failCode, String failReason) {
         new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
             LectureUpload upload = getUpload(event.lectureUploadId());
             // OCR 전체 실패/AI 실패 처리
             upload.markFailed();
-            getOrCreateJob(upload).markFailed("processing_failed", failReason);
+            getOrCreateJob(upload).markFailed(failCode.name(), failReason);
             if (event.uploadType() == StudyMaterialUploadType.IMAGE) {
                 lectureUploadFileRepository.findAllByLectureUploadIdAndDeletedAtIsNullOrderByDisplayOrderAsc(upload.getId())
                         .forEach(LectureUploadFile::markOcrFailed);
             }
         });
+    }
+
+    private ErrorCode resolveFailCode(Exception e) {
+        if (!(e instanceof CustomException customEx)) {
+            return ErrorCode.LECTURE_INFRA_ERROR;
+        }
+        ErrorCode code = customEx.getErrorCode();
+        if (code == ErrorCode.LECTURE_CONFIG_ERROR
+                || code == ErrorCode.LECTURE_AI_ERROR
+                || code == ErrorCode.LECTURE_CONTENT_ERROR) {
+            return code;
+        }
+        return ErrorCode.LECTURE_INFRA_ERROR;
     }
 
     private LectureUpload getUpload(Long lectureUploadId) {
@@ -223,7 +240,7 @@ public class LectureUploadProcessingService {
                 ));
     }
 
-    private String failMessage(Exception e) {
+    private String failReason(Exception e) {
         if (e instanceof CustomException customException && StringUtils.hasText(customException.getMessage())) {
             return customException.getMessage();
         }

--- a/src/main/java/com/f1/quiket/domain/part/service/PartAddProcessingService.java
+++ b/src/main/java/com/f1/quiket/domain/part/service/PartAddProcessingService.java
@@ -79,7 +79,7 @@ public class PartAddProcessingService {
             saveCompleted(event, result);
         } catch (Exception e) {
             log.warn("Part add processing failed. lectureUploadId={}", event.lectureUploadId(), e);
-            markFailed(event, failMessage(e));
+            markFailed(event, resolveFailCode(e), failMessage(e));
         }
     }
 
@@ -147,17 +147,31 @@ public class PartAddProcessingService {
         return normalized;
     }
 
-    private void markFailed(PartAddProcessingRequestedEvent event, String failReason) {
+    private void markFailed(PartAddProcessingRequestedEvent event, ErrorCode failCode, String failReason) {
         new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
             LectureUpload upload = getUpload(event.lectureUploadId());
             // OCR 전체 실패/추출 실패 처리
             upload.markFailed();
-            getOrCreateJob(upload).markFailed("processing_failed", failReason);
+            getOrCreateJob(upload).markFailed(failCode.name(), failReason);
             if (event.uploadType() == StudyMaterialUploadType.IMAGE) {
                 lectureUploadFileRepository.findAllByLectureUploadIdAndDeletedAtIsNullOrderByDisplayOrderAsc(upload.getId())
                         .forEach(LectureUploadFile::markOcrFailed);
             }
         });
+    }
+
+    private ErrorCode resolveFailCode(Exception e) {
+        if (!(e instanceof CustomException customEx)) {
+            return ErrorCode.LECTURE_INFRA_ERROR;
+        }
+        ErrorCode code = customEx.getErrorCode();
+        if (code == ErrorCode.LECTURE_CONTENT_ERROR || code == ErrorCode.LECTURE_AI_ERROR) {
+            return code;
+        }
+        if (code == ErrorCode.SERVICE_UNAVAILABLE || code == ErrorCode.UNPROCESSABLE_ENTITY) {
+            return ErrorCode.LECTURE_CONTENT_ERROR;
+        }
+        return ErrorCode.LECTURE_INFRA_ERROR;
     }
 
     private LectureUpload getUpload(Long lectureUploadId) {

--- a/src/main/java/com/f1/quiket/domain/part/service/PartAddProcessingService.java
+++ b/src/main/java/com/f1/quiket/domain/part/service/PartAddProcessingService.java
@@ -165,7 +165,9 @@ public class PartAddProcessingService {
             return ErrorCode.LECTURE_INFRA_ERROR;
         }
         ErrorCode code = customEx.getErrorCode();
-        if (code == ErrorCode.LECTURE_CONTENT_ERROR || code == ErrorCode.LECTURE_AI_ERROR) {
+        if (code == ErrorCode.LECTURE_CONFIG_ERROR
+                || code == ErrorCode.LECTURE_CONTENT_ERROR
+                || code == ErrorCode.LECTURE_AI_ERROR) {
             return code;
         }
         if (code == ErrorCode.SERVICE_UNAVAILABLE || code == ErrorCode.UNPROCESSABLE_ENTITY) {

--- a/src/main/java/com/f1/quiket/global/response/ErrorCode.java
+++ b/src/main/java/com/f1/quiket/global/response/ErrorCode.java
@@ -52,6 +52,12 @@ public enum ErrorCode {
     // Subject Errors
     SUBJECT_NOT_FOUND(404, "SUBJECT_NOT_FOUND", "과목을 찾을 수 없습니다."),
 
+    // Lecture Processing Errors
+    LECTURE_CONFIG_ERROR(503, "LECTURE_CONFIG_ERROR", "서비스 오류가 발생했어요. 고객센터에 문의해 주세요."),
+    LECTURE_AI_ERROR(503, "LECTURE_AI_ERROR", "처리에 실패했어요. 잠시 후 다시 시도해 주세요."),
+    LECTURE_CONTENT_ERROR(422, "LECTURE_CONTENT_ERROR", "파일을 확인해 주세요. (손상·암호화 PDF, 내용이 너무 많은 파일은 처리할 수 없어요)"),
+    LECTURE_INFRA_ERROR(503, "LECTURE_INFRA_ERROR", "일시적인 오류가 발생했어요. 잠시 후 다시 시도해 주세요."),
+
     // Quiz Errors
     QUIZ_OPTION_INVALID(400, "QUIZ_OPTION_INVALID", "퀴즈 옵션이 올바르지 않습니다."),
     QUIZ_SCOPE_INVALID(400, "QUIZ_SCOPE_INVALID", "출제 범위가 올바르지 않습니다."),

--- a/src/main/java/com/f1/quiket/infra/gemini/client/GeminiClient.java
+++ b/src/main/java/com/f1/quiket/infra/gemini/client/GeminiClient.java
@@ -64,7 +64,7 @@ public class GeminiClient {
         } catch (CustomException e) {
             throw e;
         } catch (RestClientException | JsonProcessingException e) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Gemini 서버 장애 (재시도 소진 후)", e);
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "Gemini 서버 장애 (재시도 소진 후)", e);
         }
     }
 
@@ -185,6 +185,10 @@ public class GeminiClient {
      * Gemini 응답 텍스트 파싱
      */
     private String parseResponse(String responseBody) throws JsonProcessingException {
+        if (!StringUtils.hasText(responseBody)) {
+            log.warn("Gemini response body is empty");
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "Gemini 응답 본문이 비어 있음");
+        }
         JsonNode root = objectMapper.readTree(responseBody);
         JsonNode textNode = root.path("candidates").path(0).path("content").path("parts").path(0).path("text");
         if (textNode.isMissingNode() || textNode.isNull() || !StringUtils.hasText(textNode.asText())) {

--- a/src/main/java/com/f1/quiket/infra/gemini/client/GeminiClient.java
+++ b/src/main/java/com/f1/quiket/infra/gemini/client/GeminiClient.java
@@ -73,7 +73,8 @@ public class GeminiClient {
      */
     private void validateConfigured() {
         if (!properties.isConfigured()) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Gemini 설정값이 준비되지 않았습니다.");
+            log.warn("Gemini API key is not configured");
+            throw new CustomException(ErrorCode.LECTURE_CONFIG_ERROR);
         }
     }
 
@@ -187,7 +188,8 @@ public class GeminiClient {
         JsonNode root = objectMapper.readTree(responseBody);
         JsonNode textNode = root.path("candidates").path(0).path("content").path("parts").path(0).path("text");
         if (textNode.isMissingNode() || textNode.isNull() || !StringUtils.hasText(textNode.asText())) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Gemini 응답 본문이 비어 있습니다.");
+            log.warn("Gemini response content is empty");
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
         }
         return textNode.asText();
     }

--- a/src/main/java/com/f1/quiket/infra/gemini/client/GeminiClient.java
+++ b/src/main/java/com/f1/quiket/infra/gemini/client/GeminiClient.java
@@ -74,7 +74,7 @@ public class GeminiClient {
     private void validateConfigured() {
         if (!properties.isConfigured()) {
             log.warn("Gemini API key is not configured");
-            throw new CustomException(ErrorCode.LECTURE_CONFIG_ERROR);
+            throw new CustomException(ErrorCode.LECTURE_CONFIG_ERROR, "GEMINI_API_KEY 미설정");
         }
     }
 
@@ -189,7 +189,7 @@ public class GeminiClient {
         JsonNode textNode = root.path("candidates").path(0).path("content").path("parts").path(0).path("text");
         if (textNode.isMissingNode() || textNode.isNull() || !StringUtils.hasText(textNode.asText())) {
             log.warn("Gemini response content is empty");
-            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "Gemini content 필드 없음");
         }
         return textNode.asText();
     }

--- a/src/main/java/com/f1/quiket/infra/gemini/client/GeminiClient.java
+++ b/src/main/java/com/f1/quiket/infra/gemini/client/GeminiClient.java
@@ -64,7 +64,7 @@ public class GeminiClient {
         } catch (CustomException e) {
             throw e;
         } catch (RestClientException | JsonProcessingException e) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Gemini API 호출에 실패했습니다.", e);
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Gemini 서버 장애 (재시도 소진 후)", e);
         }
     }
 
@@ -177,7 +177,7 @@ public class GeminiClient {
             Thread.sleep(backoffMillis);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Gemini API 재시도 대기가 중단되었습니다.", e);
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "재시도 중 스레드 인터럽트", e);
         }
     }
 

--- a/src/main/java/com/f1/quiket/infra/groq/client/GroqClient.java
+++ b/src/main/java/com/f1/quiket/infra/groq/client/GroqClient.java
@@ -65,7 +65,7 @@ public class GroqClient {
         } catch (CustomException e) {
             throw e;
         } catch (RestClientException | JsonProcessingException e) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Groq API 호출에 실패했습니다.", e);
+            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Groq 서버 장애·네트워크 단절", e);
         }
     }
 

--- a/src/main/java/com/f1/quiket/infra/groq/client/GroqClient.java
+++ b/src/main/java/com/f1/quiket/infra/groq/client/GroqClient.java
@@ -74,7 +74,8 @@ public class GroqClient {
      */
     private void validateConfigured() {
         if (!properties.isConfigured()) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Groq 설정값이 준비되지 않았습니다.");
+            log.warn("Groq API key is not configured");
+            throw new CustomException(ErrorCode.LECTURE_CONFIG_ERROR);
         }
     }
 
@@ -111,7 +112,8 @@ public class GroqClient {
         JsonNode root = objectMapper.readTree(responseBody);
         JsonNode contentNode = root.path("choices").path(0).path("message").path("content");
         if (contentNode.isMissingNode() || contentNode.isNull() || !StringUtils.hasText(contentNode.asText())) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Groq 응답 본문이 비어 있습니다.");
+            log.warn("Groq response content is empty");
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
         }
         return contentNode.asText();
     }

--- a/src/main/java/com/f1/quiket/infra/groq/client/GroqClient.java
+++ b/src/main/java/com/f1/quiket/infra/groq/client/GroqClient.java
@@ -75,7 +75,7 @@ public class GroqClient {
     private void validateConfigured() {
         if (!properties.isConfigured()) {
             log.warn("Groq API key is not configured");
-            throw new CustomException(ErrorCode.LECTURE_CONFIG_ERROR);
+            throw new CustomException(ErrorCode.LECTURE_CONFIG_ERROR, "GROQ_API_KEY 미설정");
         }
     }
 
@@ -113,7 +113,7 @@ public class GroqClient {
         JsonNode contentNode = root.path("choices").path(0).path("message").path("content");
         if (contentNode.isMissingNode() || contentNode.isNull() || !StringUtils.hasText(contentNode.asText())) {
             log.warn("Groq response content is empty");
-            throw new CustomException(ErrorCode.LECTURE_AI_ERROR);
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "Groq content 필드 없음");
         }
         return contentNode.asText();
     }

--- a/src/main/java/com/f1/quiket/infra/groq/client/GroqClient.java
+++ b/src/main/java/com/f1/quiket/infra/groq/client/GroqClient.java
@@ -65,7 +65,7 @@ public class GroqClient {
         } catch (CustomException e) {
             throw e;
         } catch (RestClientException | JsonProcessingException e) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "Groq 서버 장애·네트워크 단절", e);
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "Groq 서버 장애·네트워크 단절", e);
         }
     }
 
@@ -109,6 +109,10 @@ public class GroqClient {
      * Groq 응답 텍스트 파싱
      */
     private String parseResponse(String responseBody) throws JsonProcessingException {
+        if (!StringUtils.hasText(responseBody)) {
+            log.warn("Groq response body is empty");
+            throw new CustomException(ErrorCode.LECTURE_AI_ERROR, "Groq 응답 본문이 비어 있음");
+        }
         JsonNode root = objectMapper.readTree(responseBody);
         JsonNode contentNode = root.path("choices").path(0).path("message").path("content");
         if (contentNode.isMissingNode() || contentNode.isNull() || !StringUtils.hasText(contentNode.asText())) {

--- a/src/main/java/com/f1/quiket/infra/pdf/TikaStudyMaterialPdfTextExtractor.java
+++ b/src/main/java/com/f1/quiket/infra/pdf/TikaStudyMaterialPdfTextExtractor.java
@@ -40,7 +40,7 @@ public class TikaStudyMaterialPdfTextExtractor implements StudyMaterialPdfTextEx
                     .build();
         } catch (IOException | TikaException e) {
             log.warn("PDF text extraction failed", e);
-            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, e);
+            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "PDF 텍스트 추출에 실패", e);
         }
     }
 

--- a/src/main/java/com/f1/quiket/infra/pdf/TikaStudyMaterialPdfTextExtractor.java
+++ b/src/main/java/com/f1/quiket/infra/pdf/TikaStudyMaterialPdfTextExtractor.java
@@ -40,7 +40,7 @@ public class TikaStudyMaterialPdfTextExtractor implements StudyMaterialPdfTextEx
                     .build();
         } catch (IOException | TikaException e) {
             log.warn("PDF text extraction failed", e);
-            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "PDF 텍스트 추출에 실패", e);
+            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "손상·암호화 PDF", e);
         }
     }
 

--- a/src/main/java/com/f1/quiket/infra/pdf/TikaStudyMaterialPdfTextExtractor.java
+++ b/src/main/java/com/f1/quiket/infra/pdf/TikaStudyMaterialPdfTextExtractor.java
@@ -7,6 +7,7 @@ import com.f1.quiket.global.error.CustomException;
 import com.f1.quiket.global.response.ErrorCode;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.tika.Tika;
 import org.apache.tika.exception.TikaException;
 import org.springframework.stereotype.Component;
@@ -17,6 +18,7 @@ import org.springframework.util.StringUtils;
  *
  * PDF 텍스트 레이어 존재 여부 판별
  */
+@Slf4j
 @Component
 public class TikaStudyMaterialPdfTextExtractor implements StudyMaterialPdfTextExtractor {
 
@@ -37,7 +39,8 @@ public class TikaStudyMaterialPdfTextExtractor implements StudyMaterialPdfTextEx
                     .extractedText(normalized)
                     .build();
         } catch (IOException | TikaException e) {
-            throw new CustomException(ErrorCode.SERVICE_UNAVAILABLE, "PDF 텍스트 추출에 실패했습니다.", e);
+            log.warn("PDF text extraction failed", e);
+            throw new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, e);
         }
     }
 

--- a/src/test/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessorTest.java
+++ b/src/test/java/com/f1/quiket/domain/lecture/service/LectureMaterialAiProcessorTest.java
@@ -1,6 +1,7 @@
 package com.f1.quiket.domain.lecture.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -14,6 +15,8 @@ import com.f1.quiket.domain.material.dto.StudyMaterialPdfTextExtractionResult;
 import com.f1.quiket.domain.material.dto.StudyMaterialUploadType;
 import com.f1.quiket.domain.material.port.StudyMaterialAiGateway;
 import com.f1.quiket.domain.material.port.StudyMaterialPdfTextExtractor;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -180,6 +183,48 @@ class LectureMaterialAiProcessorTest {
                 .containsExactly("개념", "미분류");
         assertThat(result.getParts()).extracting("content")
                 .containsExactly("개념\n", "마지막");
+    }
+
+    @Test
+    void process_text_throws_LECTURE_AI_ERROR_when_groq_returns_no_parts() {
+        when(studyMaterialAiGateway.generateFromText(any(), any()))
+                .thenReturn("""
+                        {"parts":[]}
+                        """);
+
+        assertThatThrownBy(() -> lectureMaterialAiProcessor.process(
+                LectureMaterialAiProcessRequest.builder()
+                        .uploadType(StudyMaterialUploadType.TEXT)
+                        .partSplitMethod(PartSplitMethod.AUTO)
+                        .chapterName("1장")
+                        .text("원문 텍스트")
+                        .build()
+        ))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.LECTURE_AI_ERROR));
+    }
+
+    @Test
+    void process_text_throws_LECTURE_AI_ERROR_when_all_groq_parts_are_invalid() {
+        when(studyMaterialAiGateway.generateFromText(any(), any()))
+                .thenReturn("""
+                        {"parts":[
+                          {"partNumber":1,"name":"개념"}
+                        ]}
+                        """);
+
+        assertThatThrownBy(() -> lectureMaterialAiProcessor.process(
+                LectureMaterialAiProcessRequest.builder()
+                        .uploadType(StudyMaterialUploadType.TEXT)
+                        .partSplitMethod(PartSplitMethod.AUTO)
+                        .chapterName("1장")
+                        .text("원문 텍스트")
+                        .build()
+        ))
+                .isInstanceOf(CustomException.class)
+                .satisfies(ex -> assertThat(((CustomException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.LECTURE_AI_ERROR));
     }
 
     @Test

--- a/src/test/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingServiceTest.java
@@ -271,7 +271,7 @@ class LectureUploadProcessingServiceTest {
 
         assertThat(upload.getStatus()).isEqualTo("failed");
         assertThat(processingJob.getFailCode()).isEqualTo(ErrorCode.LECTURE_CONTENT_ERROR.name());
-        assertThat(processingJob.getFailReason()).isEqualTo("파트 본문은 30,000자를 초과할 수 없습니다.");
+        assertThat(processingJob.getFailReason()).isEqualTo("파일 내용이 너무 많음");
     }
 
     /**

--- a/src/test/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/lecture/service/LectureUploadProcessingServiceTest.java
@@ -21,6 +21,8 @@ import com.f1.quiket.domain.lecture.repository.LectureUploadRepository;
 import com.f1.quiket.domain.material.dto.StudyMaterialUploadType;
 import com.f1.quiket.domain.part.entity.Part;
 import com.f1.quiket.domain.part.repository.PartRepository;
+import com.f1.quiket.global.error.CustomException;
+import com.f1.quiket.global.response.ErrorCode;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -196,6 +198,124 @@ class LectureUploadProcessingServiceTest {
         assertThat(upload.getStatus()).isEqualTo("completed");
         // AI 챕터명 미생성 시 chapterRepository 조회 없음 (임시명 유지)
         verify(chapterRepository, never()).findById(any());
+    }
+
+    /**
+     * AI 응답 파싱 실패 시 fail_code=AI_ERROR, fail_reason=상세 원인 저장 검증
+     */
+    @Test
+    void process_marks_failed_with_AI_ERROR_when_ai_parsing_fails() {
+        LectureUpload upload = LectureUpload.create(20L, 1L, StudyMaterialUploadType.TEXT, PartSplitMethod.AUTO);
+        ReflectionTestUtils.setField(upload, "id", 30L);
+        LectureProcessingJob processingJob = LectureProcessingJob.create(upload.getId(), 1L, 30);
+        when(lectureUploadRepository.findById(30L)).thenReturn(Optional.of(upload));
+        when(lectureProcessingJobRepository.findByLectureUploadId(upload.getId())).thenReturn(Optional.of(processingJob));
+        when(lectureMaterialAiProcessor.process(any()))
+                .thenThrow(new CustomException(ErrorCode.LECTURE_AI_ERROR, "AI 응답 파싱에 실패했습니다."));
+
+        service.process(new LectureUploadProcessingRequestedEvent(
+                30L, 20L, 10L, 1L, "1장", StudyMaterialUploadType.TEXT,
+                PartSplitMethod.AUTO, "원문 텍스트", List.of(), List.of()
+        ));
+
+        assertThat(upload.getStatus()).isEqualTo("failed");
+        assertThat(processingJob.getFailCode()).isEqualTo(ErrorCode.LECTURE_AI_ERROR.name());
+        assertThat(processingJob.getFailReason()).isEqualTo("AI 응답 파싱에 실패했습니다.");
+    }
+
+    /**
+     * PDF 텍스트 추출 실패 시 fail_code=CONTENT_ERROR 저장 검증
+     */
+    @Test
+    void process_marks_failed_with_CONTENT_ERROR_when_pdf_extraction_fails() {
+        LectureUpload upload = LectureUpload.create(20L, 1L, StudyMaterialUploadType.PDF, PartSplitMethod.AUTO);
+        ReflectionTestUtils.setField(upload, "id", 30L);
+        LectureProcessingJob processingJob = LectureProcessingJob.create(upload.getId(), 1L, 30);
+        when(lectureUploadRepository.findById(30L)).thenReturn(Optional.of(upload));
+        when(lectureProcessingJobRepository.findByLectureUploadId(upload.getId())).thenReturn(Optional.of(processingJob));
+        when(lectureMaterialAiProcessor.process(any()))
+                .thenThrow(new CustomException(ErrorCode.LECTURE_CONTENT_ERROR, "PDF 텍스트 추출에 실패했습니다."));
+
+        service.process(new LectureUploadProcessingRequestedEvent(
+                30L, 20L, 10L, 1L, "1장", StudyMaterialUploadType.PDF,
+                PartSplitMethod.AUTO, null, List.of(), List.of()
+        ));
+
+        assertThat(upload.getStatus()).isEqualTo("failed");
+        assertThat(processingJob.getFailCode()).isEqualTo(ErrorCode.LECTURE_CONTENT_ERROR.name());
+    }
+
+    /**
+     * 파트 본문 30,000자 초과 시 fail_code=LECTURE_CONTENT_ERROR 저장 검증
+     */
+    @Test
+    void process_marks_failed_with_CONTENT_ERROR_when_part_content_exceeds_limit() {
+        LectureUpload upload = LectureUpload.create(20L, 1L, StudyMaterialUploadType.TEXT, PartSplitMethod.AUTO);
+        ReflectionTestUtils.setField(upload, "id", 30L);
+        LectureProcessingJob processingJob = LectureProcessingJob.create(upload.getId(), 1L, 30);
+        when(lectureUploadRepository.findById(30L)).thenReturn(Optional.of(upload));
+        when(lectureProcessingJobRepository.findByLectureUploadId(upload.getId())).thenReturn(Optional.of(processingJob));
+        String oversizedContent = "가".repeat(30001);
+        when(lectureMaterialAiProcessor.process(any()))
+                .thenReturn(LectureMaterialAiProcessResult.builder()
+                        .provider("groq")
+                        .extractedText(oversizedContent)
+                        .parts(List.of(LecturePartDraft.builder()
+                                .partNumber(1).name("개념").content(oversizedContent).build()))
+                        .build());
+
+        service.process(new LectureUploadProcessingRequestedEvent(
+                30L, 20L, 10L, 1L, "1장", StudyMaterialUploadType.TEXT,
+                PartSplitMethod.AUTO, oversizedContent, List.of(), List.of()
+        ));
+
+        assertThat(upload.getStatus()).isEqualTo("failed");
+        assertThat(processingJob.getFailCode()).isEqualTo(ErrorCode.LECTURE_CONTENT_ERROR.name());
+        assertThat(processingJob.getFailReason()).isEqualTo("파트 본문은 30,000자를 초과할 수 없습니다.");
+    }
+
+    /**
+     * Groq API Key 미설정 시 fail_code=CONFIG_ERROR 저장 검증
+     */
+    @Test
+    void process_marks_failed_with_CONFIG_ERROR_when_groq_not_configured() {
+        LectureUpload upload = LectureUpload.create(20L, 1L, StudyMaterialUploadType.TEXT, PartSplitMethod.AUTO);
+        ReflectionTestUtils.setField(upload, "id", 30L);
+        LectureProcessingJob processingJob = LectureProcessingJob.create(upload.getId(), 1L, 30);
+        when(lectureUploadRepository.findById(30L)).thenReturn(Optional.of(upload));
+        when(lectureProcessingJobRepository.findByLectureUploadId(upload.getId())).thenReturn(Optional.of(processingJob));
+        when(lectureMaterialAiProcessor.process(any()))
+                .thenThrow(new CustomException(ErrorCode.LECTURE_CONFIG_ERROR, "Groq 설정값이 준비되지 않았습니다."));
+
+        service.process(new LectureUploadProcessingRequestedEvent(
+                30L, 20L, 10L, 1L, "1장", StudyMaterialUploadType.TEXT,
+                PartSplitMethod.AUTO, "원문 텍스트", List.of(), List.of()
+        ));
+
+        assertThat(upload.getStatus()).isEqualTo("failed");
+        assertThat(processingJob.getFailCode()).isEqualTo(ErrorCode.LECTURE_CONFIG_ERROR.name());
+    }
+
+    /**
+     * 명시되지 않은 예외 발생 시 fail_code=INFRA_ERROR 저장 검증 (fallback)
+     */
+    @Test
+    void process_marks_failed_with_INFRA_ERROR_as_fallback_for_unknown_exception() {
+        LectureUpload upload = LectureUpload.create(20L, 1L, StudyMaterialUploadType.TEXT, PartSplitMethod.AUTO);
+        ReflectionTestUtils.setField(upload, "id", 30L);
+        LectureProcessingJob processingJob = LectureProcessingJob.create(upload.getId(), 1L, 30);
+        when(lectureUploadRepository.findById(30L)).thenReturn(Optional.of(upload));
+        when(lectureProcessingJobRepository.findByLectureUploadId(upload.getId())).thenReturn(Optional.of(processingJob));
+        when(lectureMaterialAiProcessor.process(any()))
+                .thenThrow(new RuntimeException("unexpected error"));
+
+        service.process(new LectureUploadProcessingRequestedEvent(
+                30L, 20L, 10L, 1L, "1장", StudyMaterialUploadType.TEXT,
+                PartSplitMethod.AUTO, "원문 텍스트", List.of(), List.of()
+        ));
+
+        assertThat(upload.getStatus()).isEqualTo("failed");
+        assertThat(processingJob.getFailCode()).isEqualTo(ErrorCode.LECTURE_INFRA_ERROR.name());
     }
 
     private PlatformTransactionManager transactionManager() {

--- a/src/test/java/com/f1/quiket/domain/lecture/service/LectureUploadStatusServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/lecture/service/LectureUploadStatusServiceTest.java
@@ -17,6 +17,7 @@ import com.f1.quiket.domain.part.entity.Part;
 import com.f1.quiket.domain.part.repository.PartRepository;
 import com.f1.quiket.domain.subject.entity.Subject;
 import com.f1.quiket.domain.subject.repository.SubjectRepository;
+import com.f1.quiket.global.response.ErrorCode;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -92,7 +93,7 @@ class LectureUploadStatusServiceTest {
         ReflectionTestUtils.setField(upload, "publicId", "upload-public-id");
         upload.markFailed();
         LectureProcessingJob processingJob = LectureProcessingJob.create(upload.getId(), 1L, 30);
-        processingJob.markFailed("processing_failed", "AI 응답 파트 형식이 올바르지 않습니다.");
+        processingJob.markFailed(ErrorCode.LECTURE_AI_ERROR.name(), "AI 응답 파트 형식이 올바르지 않습니다.");
 
         when(lectureUploadRepository.findByPublicIdAndUserIdAndDeletedAtIsNull("upload-public-id", 1L))
                 .thenReturn(Optional.of(upload));

--- a/src/test/java/com/f1/quiket/infra/gemini/client/GeminiClientTest.java
+++ b/src/test/java/com/f1/quiket/infra/gemini/client/GeminiClientTest.java
@@ -127,7 +127,7 @@ class GeminiClientTest {
         ))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.SERVICE_UNAVAILABLE);
+                .isEqualTo(ErrorCode.LECTURE_CONFIG_ERROR);
     }
 
     private GeminiProperties properties() {

--- a/src/test/java/com/f1/quiket/infra/groq/client/GroqClientTest.java
+++ b/src/test/java/com/f1/quiket/infra/groq/client/GroqClientTest.java
@@ -72,7 +72,7 @@ class GroqClientTest {
         ))
                 .isInstanceOf(CustomException.class)
                 .extracting("errorCode")
-                .isEqualTo(ErrorCode.SERVICE_UNAVAILABLE);
+                .isEqualTo(ErrorCode.LECTURE_CONFIG_ERROR);
     }
 
     private GroqProperties properties() {


### PR DESCRIPTION
## 🧩 Description

- 강의 업로드 처리 실패를 4가지 코드로 분류하는 흐름 도입
- 강의 업로드 상태 조회 응답에 `failCode` / `failMessage` / `failReason` 필드 추가
- OpenAPI 스펙에 실패 분류 스키마 및 응답 예시 추가

---

## 🛠️ Changes

- `ErrorCode`에 `LECTURE_CONFIG_ERROR` / `LECTURE_AI_ERROR` / `LECTURE_CONTENT_ERROR` / `LECTURE_INFRA_ERROR` 추가
- Groq·Gemini·Tika 인프라 클라이언트 각 예외 발생 지점에 분류 코드 적용
- `LectureUploadProcessingService`에서 예외 유형별 `failCode` 분류 로직 추가
- `LectureProcessingJob`에 `failCode` / `failReason` 저장
- `/lecture-uploads/{id}/status` 응답 DTO에 `failCode`, `failMessage`, `failReason` 추가
- `failReason` 문자열을 API 문서 기준으로 전 소스 통일
- `quiket-mvp-api.yaml`에 `LectureUploadFailCode` 스키마 및 응답 examples(processing / completed / failed) 추가

---

## 🧪 How to Test

1. 손상·암호화 PDF 업로드 후 상태 조회 → `failCode: LECTURE_CONTENT_ERROR`, `failMessage` 노출 확인
2. Groq/Gemini API 키 미설정 상태에서 업로드 → `failCode: LECTURE_CONFIG_ERROR` 확인
3. 정상 완료 케이스 → `failCode` / `failMessage` / `failReason` 모두 `null` 확인

---

## 🔗 Related Issue

Closes #164

---

## ⚠️ Notes

- `failMessage`는 클라이언트 노출용, `failReason`은 내부 디버깅용으로 구분 — 클라이언트는 `failReason`을 UI에 표시하지 않을 것
- `failCode` 값은 `LECTURE_` 접두사 포함 (ex. `LECTURE_CONTENT_ERROR`)

---

## 🧑‍💻 Assignee

- @ja2hoon