### PR TITLE
[Chore] 정식 출시 대비 MVP 네이밍·문구 정리

### DIFF
--- a/docs/db/quiket-ddl.sql
+++ b/docs/db/quiket-ddl.sql
@@ -244,7 +244,7 @@ CREATE TABLE subject_other_details (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='과목 기타 목적 상세 정보 (purpose=other)';
 
 
--- 시험 일정 (D-Day) - MVP: 과목당 1개
+-- 시험 일정 (D-Day) - 과목당 1개
 CREATE TABLE subject_exam_schedules (
     id                  BIGINT          NOT NULL AUTO_INCREMENT          COMMENT 'PK',
     public_id           CHAR(36)        NOT NULL                         COMMENT '외부 노출용 UUID v7',
@@ -258,7 +258,7 @@ CREATE TABLE subject_exam_schedules (
 
     PRIMARY KEY (id),
     UNIQUE KEY uq_subject_exam_schedules_public_id (public_id),
-    UNIQUE KEY uq_subject_exam_schedules_subject_id (subject_id),  -- MVP: 과목당 1개
+    UNIQUE KEY uq_subject_exam_schedules_subject_id (subject_id),  -- 과목당 1개
     KEY idx_subject_exam_schedules_user_id_exam_date (user_id, exam_date),
     KEY idx_subject_exam_schedules_exam_date (exam_date)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='과목별 시험 일정 (D-Day)';
@@ -268,7 +268,7 @@ CREATE TABLE subject_exam_schedules (
 CREATE TABLE certificates (
     id                  BIGINT          NOT NULL AUTO_INCREMENT          COMMENT 'PK',
     name                VARCHAR(100)    NOT NULL                         COMMENT '자격증명',
-    is_featured         TINYINT(1)      NOT NULL DEFAULT 0               COMMENT '자주 찾는 자격증 여부 (MVP: 수동 지정)',
+    is_featured         TINYINT(1)      NOT NULL DEFAULT 0               COMMENT '자주 찾는 자격증 여부 (수동 지정)',
     display_order       INT             NOT NULL DEFAULT 0               COMMENT '노출 순서',
     created_at          DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3)                          COMMENT '생성 시각',
     updated_at          DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
@@ -371,7 +371,7 @@ CREATE TABLE lecture_processing_jobs (
     timeout_at          DATETIME(3)     NULL                             COMMENT '타임아웃 기준 시각 (= started_at + 600초)',
     retry_count         TINYINT UNSIGNED NOT NULL DEFAULT 0              COMMENT '재시도 누적 횟수',
     is_retryable        TINYINT(1)      NOT NULL DEFAULT 1               COMMENT '재시도 가능 여부',
-    mq_message_id       VARCHAR(100)    NULL                             COMMENT 'RabbitMQ message-id (MVP는 NULL)',
+    mq_message_id       VARCHAR(100)    NULL                             COMMENT 'RabbitMQ message-id (MQ 미도입, 현재 NULL)',
     fail_code           VARCHAR(50)     NULL                             COMMENT '실패 코드',
     fail_reason         VARCHAR(500)    NULL                             COMMENT '실패 상세 사유',
     created_at          DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
@@ -387,7 +387,7 @@ CREATE TABLE lecture_processing_jobs (
     CONSTRAINT chk_lecture_processing_jobs_progress_pct
         CHECK (progress_pct BETWEEN 0 AND 100)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
-  COMMENT='강의 업로드 OCR/파트 분류 처리 작업 이력 (추후 도입 시 MQ 도입시 사용, MVP 구현 단계에서는 미사용)';
+  COMMENT='강의 업로드 OCR/파트 분류 처리 작업 이력 (추후 MQ 도입 시 사용, 현재 미사용)';
 
 -- ============================================================
 -- PART (파트) 관련 테이블
@@ -619,7 +619,7 @@ CREATE TABLE quiz_generation_jobs (
     is_retryable        TINYINT(1)      NOT NULL DEFAULT 1,
     fail_code           VARCHAR(50)     NULL,
     fail_reason         VARCHAR(500)    NULL,
-    mq_message_id       VARCHAR(100)    NULL    COMMENT 'RabbitMQ message-id (추후 도입 시 채움, MVP는 NULL)',
+    mq_message_id       VARCHAR(100)    NULL    COMMENT 'RabbitMQ message-id (추후 MQ 도입 시 채움, 현재 NULL)',
     created_at          DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     updated_at          DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 

--- a/docs/openapi/quiket-api.yaml
+++ b/docs/openapi/quiket-api.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.3
 info:
-  title: Quiket MVP API
+  title: Quiket API
   version: 1.0.3
   description: |
-    Quiket MVP API 명세
+    Quiket API 명세
 
     기준 문서:
     - 기존 Quiket Auth API 명세
@@ -11,7 +11,7 @@ info:
     - Quiket 기능명세 상세 v1.0
     - Quiket 서비스 DDL
 
-    MVP 범위:
+    제공 기능:
     - 자체 회원가입, 이메일 인증, 자체 로그인
     - JWT Access Token / Refresh Token 재발급, 로그아웃
     - 비밀번호 재설정
@@ -26,7 +26,7 @@ info:
     - 도토리/XP/캐릭터 성장 조회
     - 마이페이지 계정(닉네임/이메일 변경, 비밀번호 변경, 회원 탈퇴), 알림, 피드백
 
-    MVP 제외:
+    미제공 기능:
     - 퀴즈기록 별도 메뉴
     - 오답노트 별도 메뉴
     - PPTX/DOCX 업로드
@@ -82,7 +82,7 @@ tags:
   - name: Results
     description: 결과 제출, 결과 조회, 해설 조회
   - name: History
-    description: MVP 최근활동 기반 퀴즈 기록 조회
+    description: 최근활동 기반 퀴즈 기록 조회
   - name: Gamification
     description: 도토리, XP, 큐링 성장
   - name: My Page
@@ -761,7 +761,7 @@ paths:
       summary: 홈 메인 데이터 조회
       description: |
         홈 메인 화면에 필요한 사용자 요약, 캐릭터 바, D-Day, 과목 목록, 최근활동을 한 번에 조회합니다.
-        기록/오답 별도 메뉴는 MVP에서 제외되며 최근활동은 홈에서만 노출합니다.
+        기록/오답 별도 메뉴는 제공하지 않으며 최근활동은 홈에서만 노출합니다.
       operationId: getHome
       security:
         - bearerAuth: []
@@ -973,7 +973,7 @@ paths:
       tags:
         - Subjects
       summary: 시험 일정 등록/수정
-      description: MVP에서는 과목당 시험 일정 1개만 지원하며, 기존 일정이 있으면 덮어씁니다.
+      description: 과목당 시험 일정 1개만 지원하며, 기존 일정이 있으면 덮어씁니다.
       operationId: upsertSubjectExamSchedule
       security:
         - bearerAuth: []
@@ -1091,7 +1091,7 @@ paths:
       description: |
         PDF, 이미지, 텍스트 직접 입력을 하나의 업로드 API로 처리합니다.
         사용자가 선택한 파트 분류 방식에 따라 자동 분류 또는 직접 입력 파트명 기반 분류를 수행합니다.
-        원본 학습 파일은 서버 영구 저장 대상이 아니며, MVP에서는 추출된 텍스트와 파트 본문 저장을 기준으로 합니다.
+        원본 학습 파일은 서버 영구 저장 대상이 아니며, 추출된 텍스트와 파트 본문 저장을 기준으로 합니다.
       operationId: createLectureUpload
       security:
         - bearerAuth: []
@@ -1351,7 +1351,7 @@ paths:
       description: |
         선택한 과목, 출제 범위, 퀴즈 형식, 문제 수, 풀이 방식, 타이머, 난이도를 기반으로 퀴즈 생성 작업을 접수합니다.
         서버는 jobId를 즉시 반환하고 백그라운드에서 퀴즈를 생성합니다.
-        MVP 정책상 사용자당 생성 작업 1건만 순차 처리합니다.
+        사용자당 생성 작업 1건만 순차 처리합니다.
       operationId: createQuizSession
       security:
         - bearerAuth: []
@@ -1807,7 +1807,7 @@ paths:
       tags:
         - My Page
       summary: 회원 탈퇴 요청
-      description: MVP 정책상 탈퇴 시 사용자 학습 기록, 도토리, XP를 삭제 처리합니다. 세부 보존/유예 정책은 개인정보 처리방침 확정 후 조정합니다.
+      description: 탈퇴 시 사용자 학습 기록, 도토리, XP를 삭제 처리합니다. 세부 보존/유예 정책은 개인정보 처리방침 확정 후 조정합니다.
       operationId: deleteMyAccount
       security:
         - bearerAuth: []
@@ -2322,12 +2322,12 @@ components:
         accessTokenExpiresIn:
           type: integer
           format: int64
-          description: Access Token 만료 시간(초). MVP 기준 30분
+          description: Access Token 만료 시간(초). 기본 30분
           example: 1800
         refreshTokenExpiresIn:
           type: integer
           format: int64
-          description: Refresh Token 만료 시간(초). MVP 기준 30일
+          description: Refresh Token 만료 시간(초). 기본 30일
           example: 2592000
 
     AuthTokenData:
@@ -3412,7 +3412,7 @@ components:
           $ref: '#/components/schemas/PartSplitMethod'
         files:
           type: array
-          description: PDF는 1개, 이미지는 여러 장 선택 가능. 총 파일 크기 정책은 MVP 기준 50MB 이하입니다.
+          description: PDF는 1개, 이미지는 여러 장 선택 가능. 총 파일 크기는 50MB 이하입니다.
           items:
             type: string
             format: binary

--- a/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/RedisQuizGenerationQueue.java
@@ -15,7 +15,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 /**
- * Redis Stream 기반 퀴즈 생성 큐 — MVP 단일 워커 가정.
+ * Redis Stream 기반 퀴즈 생성 큐 — 단일 워커 가정.
  *
  * <h3>제약</h3>
  * <ul>


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 정식 출시 대비 저장소 전반의 MVP 네이밍·문구 정리

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- 파일명 정리
  - `docs/openapi/quiket-mvp-api.yaml` → `docs/openapi/quiket-api.yaml`
  - `docs/db/quiket-ddl-mvp.sql` → `docs/db/quiket-ddl.sql`
- OpenAPI 문구 13곳 재정리
  - title `Quiket MVP API` → `Quiket API`
  - `MVP 범위/제외` → `제공 기능/미제공 기능`
  - "MVP 정책상/MVP에서는/MVP 기준" 서술을 현행 정책 기준으로 재서술 (정책 의미 변경 없음)
- DDL 주석 6곳 MVP 표기 제거 (MQ 관련 주석은 "추후 도입/현재 미사용" 기준으로 재서술)
- `RedisQuizGenerationQueue` Javadoc "MVP 단일 워커 가정" → "단일 워커 가정"

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `grep -ri "mvp" --include='*.java' --include='*.yaml' --include='*.sql' --include='*.md' .` → 0건 확인
2. 구 파일명(`quiket-mvp-api`, `ddl-mvp`) 참조 검색 → 0건 확인
3. `./gradlew compileJava` 통과 확인 (주석만 변경)

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #172

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 문구 재정리 시 정책 의미는 그대로 유지 (예: "MVP에서는 과목당 시험 일정 1개만 지원" → "과목당 시험 일정 1개만 지원")
- 파일명 참조하는 코드/CI 없음 사전 확인 완료
- API 계약(경로/스키마) 변경 없음 — 문서·주석만 수정

---

## 🧑‍💻 Assignee

- @imclaremont
