### PR TITLE
[Refactor] Kakao 로그인 트랜잭션 내 HTTP 호출 분리

### DIFF
--- a/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/f1/quiket/domain/auth/service/KakaoOAuthService.java
@@ -19,12 +19,13 @@ import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class KakaoOAuthService {
 
     private static final String PROVIDER_KAKAO = "kakao";
@@ -38,23 +39,33 @@ public class KakaoOAuthService {
     private final PasswordEncoder passwordEncoder;
     private final AuthTokenService authTokenService;
     private final KakaoOAuthTemporaryTokenStore temporaryTokenStore;
+    private final PlatformTransactionManager transactionManager;
 
+    /**
+     * Kakao 로그인
+     *
+     * Kakao HTTP 호출(사용자 정보 조회)은 DB 커넥션 점유 방지 위해
+     * 트랜잭션 밖에서 완료 후 DB 작업만 트랜잭션으로 처리
+     */
     public KakaoOAuthLoginResult login(KakaoLoginRequest request, AuthTokenRequestContext context) {
         KakaoUserInfo kakaoUserInfo = kakaoApiClient.getUserInfo(request.getKakaoAccessToken());
-        UserAuthIdentity kakaoIdentity = userAuthIdentityRepository
-                .findByProviderAndProviderSubjectAndDeletedAtIsNull(
-                        PROVIDER_KAKAO,
-                        kakaoUserInfo.providerSubject()
-                )
-                .orElse(null);
 
-        if (kakaoIdentity != null) {
-            return loginWithExistingKakaoIdentity(kakaoIdentity, context);
-        }
+        return new TransactionTemplate(transactionManager).execute(status -> {
+            UserAuthIdentity kakaoIdentity = userAuthIdentityRepository
+                    .findByProviderAndProviderSubjectAndDeletedAtIsNull(
+                            PROVIDER_KAKAO,
+                            kakaoUserInfo.providerSubject()
+                    )
+                    .orElse(null);
 
-        return loginWithNewKakaoIdentity(kakaoUserInfo, request.getAgreedToTerms(), context);
+            if (kakaoIdentity != null) {
+                return loginWithExistingKakaoIdentity(kakaoIdentity, context);
+            }
+            return loginWithNewKakaoIdentity(kakaoUserInfo, request.getAgreedToTerms(), context);
+        });
     }
 
+    @Transactional
     public AuthTokenResponse link(KakaoAccountLinkRequest request, AuthTokenRequestContext context) {
         KakaoOAuthLinkTokenPayload payload = temporaryTokenStore.findLink(request.getLinkToken())
                 .orElseThrow(() -> new CustomException(ErrorCode.AUTH_OAUTH_LINK_TOKEN_INVALID));
@@ -104,6 +115,7 @@ public class KakaoOAuthService {
         return authTokenService.issueTokens(user, context);
     }
 
+    @Transactional
     public AuthTokenResponse completeNickname(KakaoNicknameRequest request, AuthTokenRequestContext context) {
         if (!isValidNickname(request.getNickname())) {
             throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);

--- a/src/test/java/com/f1/quiket/domain/auth/service/KakaoOAuthServiceTest.java
+++ b/src/test/java/com/f1/quiket/domain/auth/service/KakaoOAuthServiceTest.java
@@ -30,6 +30,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 class KakaoOAuthServiceTest {
 
@@ -54,8 +58,26 @@ class KakaoOAuthServiceTest {
                 userAuthIdentityRepository,
                 new BCryptPasswordEncoder(),
                 authTokenService,
-                temporaryTokenStore
+                temporaryTokenStore,
+                transactionManager()
         );
+    }
+
+    private PlatformTransactionManager transactionManager() {
+        return new PlatformTransactionManager() {
+            @Override
+            public TransactionStatus getTransaction(TransactionDefinition definition) {
+                return new SimpleTransactionStatus();
+            }
+
+            @Override
+            public void commit(TransactionStatus status) {
+            }
+
+            @Override
+            public void rollback(TransactionStatus status) {
+            }
+        };
     }
 
     @Test


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- `KakaoOAuthService`가 클래스 레벨 `@Transactional` 상태에서 카카오 HTTP 호출을 수행해, DB 커넥션을 점유한 채 카카오 API 응답을 대기하던 문제 해소
- PR #174 리뷰에서 Apple에 적용한 트랜잭션 분리 패턴을 동일하게 미러링

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- 클래스 레벨 `@Transactional` 제거
- `login()`: 카카오 사용자 정보 조회(HTTP)를 **트랜잭션 밖**에서 완료 후, DB 작업만 `TransactionTemplate`으로 처리 (트랜잭션 안에서 identity 재조회로 영속성 보장)
- `link()` / `completeNickname()`: 카카오 HTTP 호출이 없어 메서드 레벨 `@Transactional`로 전환
- `KakaoOAuthServiceTest` 생성자에 `PlatformTransactionManager` 스텁 주입

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests "com.f1.quiket.domain.auth.service.KakaoOAuthServiceTest"` — 10건 통과 확인
2. `./gradlew test` — 전체 스위트 통과 확인

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #176

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 참고 구현: `AppleOAuthService.login()` (PR #174) — Apple은 refresh token 교환 HTTP가 추가로 있어 선판단 로직이 있었으나, 카카오는 사용자 정보 조회 HTTP 1건뿐이라 더 단순함
- 동작 변화 없음: 기존에도 Redis 임시토큰/DB 작업이 한 트랜잭션이었고, HTTP만 트랜잭션 밖으로 이동한 것
- **범위 밖(후속 권장)**: `kakaoRestClient` 타임아웃 미설정 상태는 이 PR에 포함하지 않음 — 외부 클라이언트 타임아웃 정책은 별도 변경으로 다루는 것이 적절 (Apple `appleRestClient`도 동일)

---

## 🧑‍💻 Assignee

- @imclaremont
