### PR TITLE
[Docs] DDL 문서 마이그레이션 정합성 정정

### DIFF
--- a/docs/db/quiket-ddl.sql
+++ b/docs/db/quiket-ddl.sql
@@ -56,8 +56,8 @@ CREATE TABLE user_auth_identities (
     KEY idx_user_auth_identities_user_id_created_at (user_id, created_at),
     KEY idx_user_auth_identities_provider_created_at (provider, created_at),
 
-    -- CONSTRAINT fk_user_auth_identities_user_id
-    --     FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT fk_user_auth_identities_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
     CONSTRAINT chk_user_auth_identities_provider
         CHECK (provider IN ('local', 'kakao', 'apple')),
     CONSTRAINT chk_user_auth_identities_is_primary
@@ -85,8 +85,8 @@ CREATE TABLE user_email_verifications (
     KEY idx_user_email_verifications_email_status (email, status),
     KEY idx_user_email_verifications_expires_at (expires_at),
 
-    -- CONSTRAINT fk_user_email_verifications_user_id
-    --     FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT fk_user_email_verifications_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
     CONSTRAINT chk_user_email_verifications_status
         CHECK (status IN ('pending', 'verified', 'expired', 'cancelled'))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='이메일 인증 요청 및 처리 이력';
@@ -96,6 +96,7 @@ CREATE TABLE user_password_reset_tokens (
     id BIGINT NOT NULL AUTO_INCREMENT COMMENT '비밀번호 재설정 토큰 ID',
     user_id BIGINT NOT NULL COMMENT '사용자 ID',
     reset_token VARCHAR(255) NOT NULL COMMENT '재설정 토큰',
+    verification_code VARCHAR(20) NULL COMMENT '사용자 입력용 인증 코드',
     status VARCHAR(20) NOT NULL DEFAULT 'pending' COMMENT '토큰 상태',
     requested_ip VARCHAR(45) NULL COMMENT '요청 IP',
     requested_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) COMMENT '요청 시각',
@@ -108,10 +109,11 @@ CREATE TABLE user_password_reset_tokens (
     PRIMARY KEY (id),
     UNIQUE KEY uq_user_password_reset_tokens_reset_token (reset_token),
     KEY idx_user_password_reset_tokens_user_id_status (user_id, status),
+    KEY idx_user_password_reset_tokens_user_id_code_status (user_id, verification_code, status),
     KEY idx_user_password_reset_tokens_expires_at (expires_at),
 
-    -- CONSTRAINT fk_user_password_reset_tokens_user_id
-    --     FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT fk_user_password_reset_tokens_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
     CONSTRAINT chk_user_password_reset_tokens_status
         CHECK (status IN ('pending', 'used', 'expired', 'cancelled'))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='비밀번호 재설정 토큰 관리';
@@ -137,7 +139,10 @@ CREATE TABLE user_refresh_tokens (
     UNIQUE KEY uq_user_refresh_tokens_token_hash (token_hash),
     KEY idx_user_refresh_tokens_user_id_expires_at (user_id, expires_at),
     KEY idx_user_refresh_tokens_user_id_revoked_at (user_id, revoked_at),
-    KEY idx_user_refresh_tokens_expires_at (expires_at)
+    KEY idx_user_refresh_tokens_expires_at (expires_at),
+
+    CONSTRAINT fk_user_refresh_tokens_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 리프레시 토큰 관리';
 
 -- ============================================================
@@ -629,10 +634,14 @@ CREATE TABLE quiz_generation_jobs (
     KEY idx_quiz_generation_jobs_user_id_status (user_id, status),
     KEY idx_quiz_generation_jobs_timeout_at (timeout_at),
 
+    CONSTRAINT fk_quiz_generation_jobs_session_id
+        FOREIGN KEY (quiz_session_id) REFERENCES quiz_sessions(id),
     CONSTRAINT chk_quiz_generation_jobs_status
         CHECK (status IN ('pending', 'in_progress', 'completed', 'failed', 'timeout')),
     CONSTRAINT chk_quiz_generation_jobs_progress_pct
-        CHECK (progress_pct BETWEEN 0 AND 100)
+        CHECK (progress_pct BETWEEN 0 AND 100),
+    CONSTRAINT chk_quiz_generation_jobs_retryable
+        CHECK (is_retryable IN (0, 1))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
   COMMENT='퀴즈 AI 생성 작업 이력';
 
@@ -683,10 +692,16 @@ CREATE TABLE quiz_play_sessions (
     KEY idx_quiz_play_sessions_parent_play_session_id (parent_play_session_id),
     KEY idx_quiz_play_sessions_subject_id_created_at (subject_id, created_at),
 
+    CONSTRAINT fk_quiz_play_sessions_quiz_session_id
+        FOREIGN KEY (quiz_session_id) REFERENCES quiz_sessions(id),
     CONSTRAINT chk_quiz_play_sessions_play_type
         CHECK (play_type IN ('first', 'retry_all', 'retry_wrong')),
     CONSTRAINT chk_quiz_play_sessions_status
-        CHECK (status IN ('in_progress', 'submitted', 'abandoned'))
+        CHECK (status IN ('in_progress', 'submitted', 'abandoned')),
+    CONSTRAINT chk_quiz_play_sessions_option_shuffled
+        CHECK (is_option_shuffled IN (0, 1)),
+    CONSTRAINT chk_quiz_play_sessions_question_shuffled
+        CHECK (is_question_shuffled IN (0, 1))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='퀴즈 풀이 세션';
 
 
@@ -860,7 +875,16 @@ CREATE TABLE user_notification_settings (
     updated_at              DATETIME(3)     NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3) COMMENT '수정 시각',
 
     PRIMARY KEY (id),
-    UNIQUE KEY uq_user_notification_settings_user_id (user_id)
+    UNIQUE KEY uq_user_notification_settings_user_id (user_id),
+
+    CONSTRAINT fk_user_notification_settings_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT chk_user_notification_settings_activity_enabled
+        CHECK (is_activity_enabled IN (0, 1)),
+    CONSTRAINT chk_user_notification_settings_review_enabled
+        CHECK (is_review_enabled IN (0, 1)),
+    CONSTRAINT chk_user_notification_settings_update_enabled
+        CHECK (is_update_enabled IN (0, 1))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci COMMENT='사용자 알림 설정';
 
 
@@ -881,6 +905,8 @@ CREATE TABLE user_feedbacks (
     KEY idx_user_feedbacks_user_id (user_id),
     KEY idx_user_feedbacks_category_created_at (category, created_at),
 
+    CONSTRAINT fk_user_feedbacks_user_id
+        FOREIGN KEY (user_id) REFERENCES users(id),
     CONSTRAINT chk_user_feedbacks_category
         CHECK (category IN ('feature', 'bug', 'inquiry', 'other')),
     CONSTRAINT chk_user_feedbacks_body_length


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- #165 드리프트 감사에서 발견된 `docs/db/quiket-ddl.sql` ↔ 마이그레이션 불일치를 정정
- DDL 문서를 현행 스키마(마이그레이션 V1~V18 = 운영 baseline 상태)와 일치시킴

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `user_password_reset_tokens`
  - `verification_code VARCHAR(20)` 컬럼 추가 (V3)
  - 인덱스 `idx_user_password_reset_tokens_user_id_code_status` 추가 (V3)
- **FK 8개 활성화**
  - 주석 처리 3개 해제: `user_auth_identities` / `user_email_verifications` / `user_password_reset_tokens`
  - 누락 5개 추가: `quiz_generation_jobs` / `quiz_play_sessions` / `user_feedbacks` / `user_notification_settings` / `user_refresh_tokens`
- **CHECK 6개 추가**
  - `chk_quiz_generation_jobs_retryable`
  - `chk_quiz_play_sessions_option_shuffled` / `chk_quiz_play_sessions_question_shuffled`
  - `chk_user_notification_settings_activity_enabled` / `_review_enabled` / `_update_enabled`

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. FK 대조: `docs/db/quiket-ddl.sql`의 활성 FK 8개 = 마이그레이션 8개 (주석 FK 0개)
2. CHECK 대조: 마이그레이션 CHECK 목록과 문서 CHECK 목록 차집합 0
3. `user_password_reset_tokens`에 `verification_code` + 코드 인덱스 존재 확인
4. 트레일링 콤마 등 문법 이상 없음 (닫는 괄호 직전 콤마 검사 통과)

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #179

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 문서 파일 변경, 코드/스키마 동작 영향 없음 (운영·마이그레이션은 이미 정상)
- `user_feedbacks.user_id`는 **현행(nullable) 유지** — 마이그레이션 V8의 NOT NULL과 불일치하나 비로그인 피드백 정책 확정이 필요한 별도 사안이라 이번 범위에서 제외 (FK만 추가)
- 로컬 MySQL 부재로 문서상 self-check(FK/CHECK 대조 + 콤마 검사)로 검증. 원하면 EC2 `quiket_ref` DB에 문서 실행으로 최종 문법 확인 가능
- 근본: 수기 관리 DDL 문서는 마이그레이션과 별개 소스라 반복 드리프트 발생 → 장기적으로 단일 소스 오브 트루스 전환 검토 필요 (별도 논의)

---

## 🧑‍💻 Assignee

- @imclaremont
