### PR TITLE
[Chore] CI 작업 브랜치 테스트 조건 보완

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
       !github.event.pull_request.draft &&
       (
         startsWith(github.head_ref, 'feat/') ||
+        startsWith(github.head_ref, 'fix/') ||
+        startsWith(github.head_ref, 'refactor/') ||
+        startsWith(github.head_ref, 'docs/') ||
+        startsWith(github.head_ref, 'chore/') ||
+        startsWith(github.head_ref, 'test/') ||
         github.head_ref == 'develop' ||
         github.head_ref == 'main'
       )


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 작업 브랜치 타입별 PR에서 CI가 누락되는 조건 보완

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `fix/*`, `refactor/*` 소스 브랜치 허용
- `docs/*`, `chore/*`, `test/*` 소스 브랜치 허용
- Draft PR 제외와 `develop`, `main` 조건 유지

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `ruby -e 'require "yaml"; YAML.parse_file(".github/workflows/ci.yml")'`
2. `git diff --check`
3. `./gradlew test`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #184

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 프로젝트 브랜치 타입 규칙 전체 반영

---

## 🧑‍💻 Assignee

- @imclaremont
