### PR TITLE
[Chore] OpenAPI와 Swagger 버전 정합성 정리

### DIFF
--- a/src/main/java/com/f1/quiket/config/SwaggerConfig.java
+++ b/src/main/java/com/f1/quiket/config/SwaggerConfig.java
@@ -32,6 +32,6 @@ public class SwaggerConfig {
         return new Info()
                 .title("F1 Quiket API")
                 .description("F1 Quiket 서비스 API 문서")
-                .version("1.0.0");
+                .version("1.1.0");
     }
 }

--- a/src/test/java/com/f1/quiket/config/SwaggerConfigTest.java
+++ b/src/test/java/com/f1/quiket/config/SwaggerConfigTest.java
@@ -1,0 +1,15 @@
+package com.f1.quiket.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class SwaggerConfigTest {
+
+    @Test
+    void openApiVersion_matchesStaticSpecVersion() {
+        SwaggerConfig swaggerConfig = new SwaggerConfig();
+
+        assertEquals("1.1.0", swaggerConfig.openAPI().getInfo().getVersion());
+    }
+}


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 정적 OpenAPI 명세와 동적 Swagger 문서의 API 버전 불일치 해소

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- `SwaggerConfig` API 버전을 `1.1.0`으로 변경
- 동적 OpenAPI 버전 검증 단위 테스트 추가

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. `./gradlew test --tests com.f1.quiket.config.SwaggerConfigTest`
2. `./gradlew test`
3. 정적 명세와 `SwaggerConfig`의 버전이 모두 `1.1.0`인지 확인

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #185

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 전체 테스트 262개 중 실패 0개, 외부 실연동 테스트 5개 제외
- 애플리케이션 빌드 버전은 변경하지 않음

---

## 🧑‍💻 Assignee

- @imclaremont
