### PR TITLE
[Chore] 서버 로그 영문 규칙 위반 정리

### DIFF
--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationEnqueueListener.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationEnqueueListener.java
@@ -37,7 +37,7 @@ public class QuizGenerationEnqueueListener {
             quizGenerationJobRepository.findById(generationJobId)
                     .ifPresent(job -> job.assignMqMessageId(messageId));
         } catch (CustomException e) {
-            log.error("퀴즈 생성 큐 발행 실패 — generation_job을 failed로 마킹. generationJobId={}", generationJobId, e);
+            log.error("Quiz generation enqueue failed. Marking generation job as failed. generationJobId={}", generationJobId, e);
             quizGenerationJobRepository.findById(generationJobId)
                     .ifPresent(this::markEnqueueFailed);
         }

--- a/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationLockStore.java
+++ b/src/main/java/com/f1/quiket/domain/quiz/service/QuizGenerationLockStore.java
@@ -45,7 +45,7 @@ public class QuizGenerationLockStore {
         try {
             stringRedisTemplate.delete(buildKey(userId));
         } catch (DataAccessException e) {
-            log.warn("퀴즈 생성 분산락 해제 실패. userId={}", userId, e);
+            log.warn("Failed to release quiz generation lock. userId={}", userId, e);
         }
     }
 

--- a/src/main/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListener.java
+++ b/src/main/java/com/f1/quiket/infra/mail/listener/EmailVerificationMailEventListener.java
@@ -64,7 +64,7 @@ public class EmailVerificationMailEventListener {
         try {
             sesMailSender.sendMail(mailRequest);
         } catch (Exception e) {
-            log.error("메일 발송 실패 — 요청 처리는 계속됩니다. mailType={}, toEmail={}", mailType, toEmail, e);
+            log.error("Mail delivery failed. Request processing will continue. mailType={}, toEmail={}", mailType, toEmail, e);
         }
     }
 }


### PR DESCRIPTION
## 🧩 Description
<!-- 작업 요약 -->

- 서버 로그 영문 작성 규칙과 어긋난 한국어 로그 문구 정리

---

## 🛠️ Changes
<!-- 주요 변경 사항 -->

- 퀴즈 생성 큐 발행 실패 로그 영문화
- 퀴즈 생성 분산락 해제 실패 로그 영문화
- 메일 발송 실패 격리 로그 영문화
- 기존 로그 파라미터와 예외 스택 유지

---

## 🧪 How to Test
<!-- 테스트 방법 -->

1. 한국어 로그 문자열 검색 결과 0건 확인
2. `./gradlew test --tests com.f1.quiket.domain.quiz.service.QuizGenerationEnqueueListenerTest --tests com.f1.quiket.infra.mail.listener.EmailVerificationMailEventListenerTest`
3. `./gradlew test`

---

## 🔗 Related Issue
<!-- 연결 이슈 번호 -->

Closes #186

---

## ⚠️ Notes
<!-- 리뷰어 참고 내용 -->

- 사용자 노출 응답 메시지와 코드 주석은 변경하지 않음
- 전체 테스트 261개 중 실패 0개, 외부 실연동 테스트 5개 제외

---

## 🧑‍💻 Assignee

- @imclaremont
