### PR TITLE
[Fix] 운영 JWT Secret 누락 방지 및 설정 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,24 @@ jobs:
           GHCR_IMAGE=${{ needs.build-and-push.outputs.image }}
           EOF
 
+      - name: Validate deploy env
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          JWT_SECRET_LINE="$(grep -m1 '^QUIKET_JWT_SECRET=' .deploy/.env || true)"
+          JWT_SECRET_VALUE="${JWT_SECRET_LINE#*=}"
+
+          if [ -z "${JWT_SECRET_VALUE//[[:space:]]/}" ]; then
+            echo "::error::PROD_ENV_FILE must contain QUIKET_JWT_SECRET"
+            exit 1
+          fi
+
+          if [ "${#JWT_SECRET_VALUE}" -lt 32 ]; then
+            echo "::error::QUIKET_JWT_SECRET must be at least 32 characters"
+            exit 1
+          fi
+
       - name: Copy deploy files to EC2
         uses: appleboy/scp-action@v0.1.7
         with:

--- a/src/main/java/com/f1/quiket/global/auth/JwtProperties.java
+++ b/src/main/java/com/f1/quiket/global/auth/JwtProperties.java
@@ -2,6 +2,7 @@ package com.f1.quiket.global.auth;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -19,6 +20,7 @@ public class JwtProperties {
     private String issuer;
 
     @NotBlank
+    @Size(min = 32)
     private String secret;
 
     @Positive

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -53,3 +53,7 @@ aws:
     region: ${AWS_REGION:ap-northeast-2}
     # SES 발신자 이메일 설정값
     from-email: ${AWS_SES_FROM_EMAIL:ja2hoon97@gmail.com}
+
+quiket:
+  jwt:
+    secret: ${QUIKET_JWT_SECRET:local-dev-jwt-secret-for-quiket-f1-authentication}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -67,8 +67,6 @@ azure:
     read-timeout-seconds: ${AZURE_OPENAI_READ_TIMEOUT_SECONDS:120}
 
 quiket:
-  jwt:
-    secret: ${QUIKET_JWT_SECRET}
   quiz:
     generation:
       worker:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,7 +41,7 @@ springdoc:
 quiket:
   jwt:
     issuer: quiket
-    secret: ${QUIKET_JWT_SECRET:local-dev-jwt-secret-for-quiket-f1-authentication}
+    secret: ${QUIKET_JWT_SECRET:}
     access-token-expires-in-seconds: 1800
     refresh-token-expires-in-seconds: 2592000
   quiz:

--- a/src/test/java/com/f1/quiket/global/auth/JwtPropertiesProfileTest.java
+++ b/src/test/java/com/f1/quiket/global/auth/JwtPropertiesProfileTest.java
@@ -1,0 +1,75 @@
+package com.f1.quiket.global.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.validation.autoconfigure.ValidationAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+class JwtPropertiesProfileTest {
+
+    private static final String LOCAL_SECRET = "local-dev-jwt-secret-for-quiket-f1-authentication";
+    private static final String PROD_SECRET = "prod-jwt-secret-for-binding-test";
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withInitializer(new ConfigDataApplicationContextInitializer())
+            .withConfiguration(AutoConfigurations.of(ValidationAutoConfiguration.class))
+            .withUserConfiguration(JwtPropertiesConfiguration.class);
+
+    @Test
+    void localProfile_usesDevelopmentSecretWhenEnvironmentVariableMissing() {
+        contextRunner
+                .withPropertyValues("spring.profiles.active=local")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context.getBean(JwtProperties.class).getSecret()).isEqualTo(LOCAL_SECRET);
+                });
+    }
+
+    @Test
+    void prodProfile_failsWhenJwtSecretMissing() {
+        contextRunner
+                .withPropertyValues("spring.profiles.active=prod")
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasMessageContaining("quiket.jwt");
+                });
+    }
+
+    @Test
+    void prodProfile_failsWhenJwtSecretTooShort() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.profiles.active=prod",
+                        "QUIKET_JWT_SECRET=short-secret"
+                )
+                .run(context -> {
+                    assertThat(context).hasFailed();
+                    assertThat(context.getStartupFailure())
+                            .hasMessageContaining("quiket.jwt");
+                });
+    }
+
+    @Test
+    void prodProfile_bindsJwtSecretWhenEnvironmentVariableExists() {
+        contextRunner
+                .withPropertyValues(
+                        "spring.profiles.active=prod",
+                        "QUIKET_JWT_SECRET=" + PROD_SECRET
+                )
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context.getBean(JwtProperties.class).getSecret()).isEqualTo(PROD_SECRET);
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(JwtProperties.class)
+    static class JwtPropertiesConfiguration {
+    }
+}


### PR DESCRIPTION
## 🧩 Description

- 운영 JWT Secret 누락 시 예측 가능한 값이 서명 키로 사용될 수 있는 문제 방지
- 애플리케이션 시작과 배포 단계에서 설정 오류 조기 차단

---

## 🛠️ Changes

- 공통·로컬 JWT Secret 설정 분리
- JWT Secret 필수값 및 최소 32자 검증
- 프로필별 설정 바인딩 테스트 추가
- `PROD_ENV_FILE` JWT Secret 사전 검증 추가

---

## 🧪 How to Test

1. `./gradlew test --tests com.f1.quiket.global.auth.JwtPropertiesProfileTest`
2. `./gradlew clean build`
3. 배포 환경 파일의 JWT Secret 누락·짧은 값·정상 값 검증

---

## 🔗 Related Issue

Closes #190

---

## ⚠️ Notes

- 실제 운영 JWT Secret 미포함
- 운영 배포 전 GitHub `PROD_ENV_FILE`에 `QUIKET_JWT_SECRET` 추가 필요
- 운영키 최초 설정 시 기존 Access Token 서명 무효화

---

## 🧑‍💻 Assignee

- @imclaremont