### PR TITLE
[Docs] Release Type 규칙 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,13 +197,16 @@ return ResponseEntity.status(errorCode.getStatus())
 - 커밋 메시지: `type: 한국어 핵심`
 - PR 제목: `[Type] 한국어 핵심`
 - 작업 브랜치 → `develop` Merge commit 메시지: `[Type] 한국어 핵심 (#PR번호)` (GitHub 기본 형식)
-- `develop` → `main` Squash merge 커밋 메시지: `[Release] 버전/날짜 배포`
+- 운영 배포 이슈 및 PR 제목: `[Release] v{major}.{minor}.{patch} 운영 배포`
+- `develop` → `main` Squash merge 커밋 메시지: `[Release] v{major}.{minor}.{patch} 운영 배포`
 
 ### 이슈 및 PR 제목
 
 - 형식: `[Type] 제목`
 - 예시: `[Docs] AGENTS.md 지침 추가`
-- `Type`은 `Feat`, `Fix`, `Refactor`, `Docs`, `Chore`, `Test` 중 하나 사용
+- `Type`은 `Feat`, `Fix`, `Refactor`, `Docs`, `Chore`, `Test`, `Release` 중 하나 사용
+- `Release`는 `develop` → `main` 운영 배포 이슈 및 PR에만 사용
+- 릴리즈 제목은 `[Release] v{major}.{minor}.{patch} 운영 배포` 형식 사용
 - 제목은 한국어로 핵심만 작성
 - 커밋 메시지 형식과 구분
 


### PR DESCRIPTION
## 🧩 Description

- 운영 배포 이슈와 PR을 일반 관리 작업인 `Chore`와 구분
- 릴리즈 표기 규칙을 이슈·PR·Squash 커밋에 일관되게 적용

---

## 🛠️ Changes

- 이슈 및 PR 허용 Type에 `Release` 추가
- `Release`를 `develop` → `main` 운영 배포 전용 Type으로 제한
- 릴리즈 제목과 Squash 커밋 형식을 SemVer 기준으로 통일

---

## 🧪 How to Test

1. `AGENTS.md` 릴리즈 규칙 확인
2. `git diff --check` 통과 확인
3. GitHub Actions CI 통과 확인

---

## 🔗 Related Issue

Closes #194

---

## ⚠️ Notes

- 일반 작업 브랜치와 커밋 Type은 기존 규칙 유지
- 운영 배포는 별도 릴리즈 브랜치 없이 `develop` → `main` 진행

---

## 🧑‍💻 Assignee

- @imclaremont